### PR TITLE
Forgotten cleanup function in the history extension

### DIFF
--- a/jim-history.c
+++ b/jim-history.c
@@ -103,6 +103,11 @@ static int JimHistorySubCmdProc(Jim_Interp *interp, int argc, Jim_Obj *const *ar
     return Jim_CallSubCmd(interp, Jim_ParseSubCmd(interp, history_command_table, argc, argv), argc, argv);
 }
 
+static void JimHistoryDelProc(Jim_Interp *interp, void *privData)
+{
+    Jim_Free(privData);
+}
+
 int Jim_historyInit(Jim_Interp *interp)
 {
     void **history;


### PR DESCRIPTION
Not that it matters much, but maybe it's better to have it there just to be correct.
