### PR TITLE
build: use CFLAGS rather than CC to pass flags to compiler

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -25,8 +25,8 @@ LDLIBS += @LDLIBS@
 exec_prefix ?= @exec_prefix@
 prefix ?= @prefix@
 
-CC += -D_GNU_SOURCE -Wall $(OPTIM) -I.
-CXX += -D_GNU_SOURCE -Wall $(OPTIM) -I.
+CFLAGS += -D_GNU_SOURCE -Wall $(OPTIM) -I.
+CXXFLAGS += -D_GNU_SOURCE -Wall $(OPTIM) -I.
 @if srcdir != .
 CFLAGS += -I@srcdir@
 CXXFLAGS += -I@srcdir@


### PR DESCRIPTION
This fixes a failure to build with clang 3.4.
Unsure why but scan-build ignores when passed using CC.

Signed-off-by: Spencer Oliver spen@spen-soft.co.uk
