### PR TITLE
jim-win32compat.h: fix compile error about __strtod on mingw

### DIFF
--- a/jim-win32compat.h
+++ b/jim-win32compat.h
@@ -68,6 +68,7 @@ struct dirent *readdir(DIR *dir);
 
 #elif defined(__MINGW32__)
 
+#include <stdlib.h>
 #define strtod __strtod
 
 #endif


### PR DESCRIPTION
Fixes issue #20.
