### PR TITLE
Added libffi bindings

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -53,6 +53,7 @@ options {
         mk        - Interface to Metakit
         tclprefix - Support for the tcl::prefix command
         sqlite3   - Interface to sqlite3
+        ffi       - Native function interface
         win32     - Interface to win32
     }
     with-out-jim-ext: {without-ext:"default|ext1 ext2 ..."} => {
@@ -242,6 +243,7 @@ dict set extdb attrs {
     sdl       { optional }
     signal    { static }
     sqlite3   { optional }
+    ffi       { optional }
     stdlib    { tcl static }
     syslog    {}
     tclcompat { tcl static }
@@ -271,6 +273,7 @@ dict set extdb info {
              }
     signal   { check {[have-feature sigaction] && [have-feature vfork]} }
     sqlite3  { check {[cc-check-function-in-lib sqlite3_prepare_v2 sqlite3]} libdep lib_sqlite3_prepare_v2 }
+    ffi      { check {[cc-check-function-in-lib dlopen dl] && [cc-check-function-in-lib ffi_call ffi]} libdep {lib_dlopen lib_ffi_call} }
     syslog   { check {[have-feature syslog]} }
     tree     { dep oo }
     win32    { check {[have-feature windows]} }

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -28,8 +28,8 @@ proc types_example {} {
 	puts [$count_ptr value]
 
 	# strings are created using "ffi.string copy" or "ffi.string at"; the latter
-	# is also used to strings (i.e the return value of a C function that returns
-	# a char *) and dereference pointers
+	# is also used to read strings (i.e the return value of a C function that
+	# returns a char *) and dereference pointers
 	set s [ffi.string copy "this is a string"]
 	puts [$s value]
 }
@@ -56,11 +56,10 @@ proc functions_example {} {
 	# prototype: sprintf()
 	set sprintf_ptr [$::libc int sprintf pointer pointer pointer int]
 
+	# "ffi.buffer" is a quick, efficient way to allocate buffers with a given
+	# size
 	set buf [ffi.buffer 32]
-	set fmt [ffi.string copy "%s %d"]
-	set arg1 [ffi.string copy "aha"]
-	set arg2 [ffi.int 1337]
-	$sprintf_ptr [[ffi.int] address] "[$buf address] [$fmt address] [$arg1 address] [$arg2 address]"
+	$sprintf_ptr [[ffi.int] address] "[$buf address] [[ffi.string copy "%s %d"] address] [[ffi.string copy "aha"] address] [[ffi.int 1337] address]"
 
 	# print the output buffer (the first argument)
 	puts [$buf value]

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -107,7 +107,7 @@ proc constants_example {} {
 	set exit_func [ffi::pointer void [$::main dlsym exit] int]
 
 	# ::null (a global) is a NULL pointer
-	puts "the value of :null is [$::null value]"
+	puts "the value of ::null is [$::null value]"
 
 	# ::zero is 0 (int), useful for functions that accept flags
 	puts "the value of ::zero is [$::zero value]"

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -1,10 +1,7 @@
 package require ffi
 
 proc sizeof_example {} {
-	# pointers; see ffi::buffer and ffi::string later
-	puts [[ffi::pointer] size]
-
-	# standard types
+	# standard types - those that begin with "u" are unsigned
 	puts [[ffi::ulong] size]
 	puts [[ffi::long] size]
 	puts [[ffi::uint] size]
@@ -28,26 +25,31 @@ proc sizeof_example {} {
 	puts [[ffi::float] size]
 	puts [[ffi::double] size]
 
+	# pointers; see ffi::buffer and ffi::string later
+	puts [[ffi::pointer] size]
+
 	# misc. types
 	puts [[ffi::void] size]
 }
 
 proc types_example {} {
-	# variables are created using ffi::int, ffi_uint, ffi::long and so on; they
+	# variables are created using ffi::int, ffi::uint, ffi::long and so on; they
 	# can be initialized by specifying a value
 	set count [ffi::int 12345678]
 	set uninit_count [ffi::int]
 
-	# "value" returns the value of a variable as a Tcl object and "address"
-	# returns its address (like the & operator in C)
+	# the value method returns the value of a variable as a Tcl object and
+	# the method address returns its address (like the & operator in C) in
+	# hexadecimal form
 	puts "integer with contents [$count value] is at [$count address]"
 	puts "the value of the uninitialized integer is [$uninit_count value]"
 
-	# the raw contents of a variable may be accessed using "raw"
+	# the raw contents of a variable may be accessed using the raw method
 	puts "the raw, [$count size] bytes form of [$count value] is [$count raw]"
 
 	# pointers are created by calling ffi::pointer with the address of a
-	# variable
+	# variable; that's the only pointer type (i.e there's no int * equivalent,
+	# see ffi:string at and ffi::cast)
 	set count_func [ffi::pointer [$count address]]
 	puts [$count_func value]
 
@@ -175,7 +177,8 @@ proc structs_example {} {
 
 proc cast_example {} {
 	# ffi::cast can be used to create an object with with the value at a given
-	# address
+	# address: it's equivalent to the * operator in C, after casting from void *
+	# to another pointer type (e.g int *)
 	set errno_addr [$::main dlsym errno]
 	set errno [ffi::cast int $errno_addr]
 	puts "the value of errno before close() is [$errno value]"

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -78,6 +78,13 @@ proc constants_example {} {
 	# ::one is 1 (int), useful for functions that accept an int that acts as a
 	# boolean (i.e setsockopt())
 	puts [$::one value]
+
+	# make sure:
+	# 1) you don't modify these globals by mistake: don't pass them to functions
+	#    unless they don't modify them (i.e they're const parameters)
+	# 2) you use them whenever possible, instead of redefining them: this
+	#    improves efficiency (think of it - why create a new NULL pointer object
+	#    if you already have one?) and improves code clarity
 }
 
 proc pointers_example {} {

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -82,7 +82,7 @@ proc functions_example {} {
 
 	# let's do this again - this time, with a function with a more complex
 	# prototype: sprintf()
-	set sprintf_func [ffi.function int [$libc dlsym puts] pointer pointer pointer int]
+	set sprintf_func [ffi.function int [$libc dlsym sprintf] pointer pointer pointer int]
 
 	# ffi.buffer is a quick, efficient way to allocate buffers with a given size
 	set buf [ffi.buffer 32]

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -1,9 +1,35 @@
 package require ffi
 
 proc sizeof_example {} {
-	puts [[ffi.int] size]
-	puts [[ffi.long] size]
+	# pointers; see ffi.buffer and ffi.string later
 	puts [[ffi.pointer] size]
+
+	# standard types
+	puts [[ffi.ulong] size]
+	puts [[ffi.long] size]
+	puts [[ffi.uint] size]
+	puts [[ffi.int] size]
+	puts [[ffi.ushort] size]
+	puts [[ffi.short] size]
+	puts [[ffi.uchar] size]
+	puts [[ffi.char] size]
+
+	# fixed-width types ({u,}int64 may be missing on pure 32-bit architectures)
+	# puts [[ffi.uint64] size]
+	# puts [[ffi.int64] size]
+	puts [[ffi.uint32] size]
+	puts [[ffi.int32] size]
+	puts [[ffi.uint16] size]
+	puts [[ffi.int16] size]
+	puts [[ffi.uint8] size]
+	puts [[ffi.int8] size]
+
+	# floating-point types
+	puts [[ffi.float] size]
+	puts [[ffi.double] size]
+
+	# misc. types
+	puts [[ffi.void] size]
 }
 
 proc types_example {} {
@@ -24,7 +50,7 @@ proc types_example {} {
 	set count_ptr [ffi.pointer [$count address]]
 	puts [$count_ptr value]
 
-	# strings are created using "ffi.string copy" or "ffi.string at"; the latter
+	# strings are created using ffi.string copy or ffi.string at; the latter
 	# is also used to read strings (i.e the return value of a C function that
 	# returns a char *) and dereference pointers
 	set s [ffi.string copy "this is a string"]
@@ -32,9 +58,9 @@ proc types_example {} {
 }
 
 proc functions_example {} {
-	# functions are accessed through the return value of "ffi.dlopen" - the
-	# first argument is the return value type, the second is the function symbol
-	# name and the rest are argument types
+	# functions are accessed through the return value of ffi.dlopen - the first
+	# argument is the return value type, the second is the function symbol name
+	# and the rest are argument types
 	set libc [ffi.dlopen libc.so.6]
 	set puts_ptr [$libc int puts pointer]
 
@@ -54,8 +80,7 @@ proc functions_example {} {
 	# prototype: sprintf()
 	set sprintf_ptr [$libc int sprintf pointer pointer pointer int]
 
-	# "ffi.buffer" is a quick, efficient way to allocate buffers with a given
-	# size
+	# ffi.buffer is a quick, efficient way to allocate buffers with a given size
 	set buf [ffi.buffer 32]
 	$sprintf_ptr [[ffi.int] address] [$buf address] [[ffi.string copy "%s %d"] address] [[ffi.string copy "aha"] address] [[ffi.int 1337] address]
 
@@ -197,12 +222,11 @@ proc sockets_example {} {
 			throw error "failed to accept a client"
 		}
 
-		try {
-			# send something
-			$send_ptr [[ffi.int] address] [$c address] [[ffi.string copy hello] address] [[ffi.uint 5] address] [$::zero address]
-		} finally {
-			$close_ptr [[ffi.int] address] [$c address]
-		}
+		# send something
+		$send_ptr [[ffi.int] address] [$c address] [[ffi.string copy hello\n] address] [[ffi.uint 6] address] [$::zero address]
+
+		# disconnect the client
+		$close_ptr [[ffi.int] address] [$c address]
 	} on error {msg opts} {
 		puts "Error: $msg"
 	} finally {

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -33,16 +33,16 @@ proc sizeof_example {} {
 }
 
 proc types_example {} {
-	# variables are created using ffi::int, ffi::uint, ffi::long and so on; they
-	# can be initialized by specifying a value
+	# variables are created using ffi::int, ffi::uint, ffi::long and so on; if
+	# no value is specified, variables are initialized with either 0, \0 or NULL
 	set count [ffi::int 12345678]
-	set uninit_count [ffi::int]
+	set zero_count [ffi::int]
 
 	# the value method returns the value of a variable as a Tcl object and
 	# the method address returns its address (like the & operator in C) in
 	# hexadecimal form
 	puts "integer with contents [$count value] is at [$count address]"
-	puts "the value of the uninitialized integer is [$uninit_count value]"
+	puts "the value of the integer created with no value is [$zero_count value]"
 
 	# the raw contents of a variable may be accessed using the raw method
 	puts "the raw, [$count size] bytes form of [$count value] is [$count raw]"
@@ -104,7 +104,7 @@ proc constants_example {} {
 	# ::main is the the main executable handle (see dlopen(3)) - on some
 	# platforms, the loader resolves symbols recursively, so there's no need to
 	# load obtain a libc handle
-	set exit_func [ffi::pointer void [$::main dlsym exit] int]
+	puts "exit() is at [$::main dlsym exit]"
 
 	# ::null (a global) is a NULL pointer
 	puts "the value of ::null is [$::null value]"

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -65,7 +65,7 @@ proc functions_example {} {
 
 proc constants_example {} {
 	# ::main is the the main executable handle (see dlopen(3)) - on some
-	# platforms, the loader resolves symbols recursively, so ther's no need to
+	# platforms, the loader resolves symbols recursively, so there's no need to
 	# load obtain a libc handle
 	set exit_ptr [$::main void exit int]
 

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -3,25 +3,97 @@ package require ffi
 # load the C libary
 set libc [ffi.dlopen libc.so.6]
 
-# locate sprintf() and define its prototype
-set sprintf [$libc int sprintf string string string int]
+proc sizeof_example {} {
+	puts [[ffi.int] size]
+	puts [[ffi.long] size]
+	puts [[ffi.pointer] size]
+}
 
-# create objects for the arguments of sprintf() - they should match the
-# prototype
-set buf [ffi.buffer 32]
-set fmt [ffi.string "%s %d"]
-set arg1 [ffi.string "aha"]
-set arg2 [ffi.int 1337]
+proc types_example {} {
+	set count [ffi.int 12345678]
+	puts "integer with contents [$count value] is at [$count address]"
 
-# create an object for the return value; if no value is specified it's an
-# uninitialized variable
-set ret [ffi.int]
+	# the raw contents of a variable may be accessed using "raw"
+	puts "the raw, [$count size] bytes form of [$count value] is [$count raw]"
 
-# call sprintf() - variables must be passed as pointers
-$sprintf [$ret address] "[$buf address] [$fmt address] [$arg1 address] [$arg2 address]"
+	# pointers are created by calling ffi.pointer with the address of a variable
+	set count_ptr [ffi.pointer [$count address]]
+	puts [$count_ptr value]
 
-# print the output buffer (the first argument)
-puts [$buf value]
+	# strings are created using "ffi.string copy" or "ffi.string at"
+	set s [ffi.string copy "this is a string"]
+	puts [$s value]
+}
 
-# print the return value of sprintf()
-puts [$ret value]
+proc simple_example {} {
+	# locate sprintf() and define its prototype
+	set sprintf_ptr [$::libc int sprintf string string string int]
+
+	# create objects for the arguments of sprintf() - they should match the
+	# prototype
+	set buf [ffi.buffer 32]
+	set fmt [ffi.string copy "%s %d"]
+	set arg1 [ffi.string copy "aha"]
+	set arg2 [ffi.int 1337]
+
+	# create an object for the return value; if no value is specified it's an
+	# uninitialized variable
+	set ret [ffi.int]
+
+	# call sprintf() - variables must be passed as pointers
+	$sprintf_ptr [$ret address] "[$buf address] [$fmt address] [$arg1 address] [$arg2 address]"
+
+	# print the output buffer (the first argument)
+	puts [$buf value]
+
+	# print the return value of sprintf()
+	puts [$ret value]
+}
+
+
+proc pointers_example {} {
+	# call time() to get the current time
+	set time_ptr [$::libc void time pointer]
+	set now [ffi.int]
+	$time_ptr [[ffi.void] address] [[ffi.pointer [$now address]] address]
+
+	# call gmtime(), which returns a struct tm pointer
+	set gmtime_ptr [$::libc pointer gmtime pointer]
+	set now_ptr [ffi.pointer [$now address]]
+	set now_broken [ffi.pointer]
+	$gmtime_ptr [$now_broken address] [$now_ptr address]
+
+	# call asctime() and pass the struct tm pointer
+	set asctime_ptr [$::libc pointer asctime pointer]
+	set now_broken_ptr [ffi.pointer [$now_broken value]]
+	set out [ffi.pointer]
+	$asctime_ptr [$out address] [$now_broken_ptr address]
+
+	# asctime() returns a string - print it
+	puts [ffi.string at [$out value] 24]
+}
+
+proc structs_example {} {
+	# locate asctime()
+	set asctime_ptr [$::libc pointer asctime pointer]
+
+	# create a struct tm and initialize it with January 30th 1992, 2:10 AM
+	set now_broken [ffi.struct "[[ffi.int 0] raw][[ffi.int 10] raw][[ffi.int 2] raw][[ffi.int 30] raw][[ffi.int 0] raw][[ffi.int 92] raw][[ffi.int 0] raw][[ffi.int 30] raw][[ffi.int 0] raw][[ffi.long 0] raw][[ffi.pointer 0] raw]" int int int int int int int int int long pointer]
+
+	# for demonstration purposes, read tm_year (the 6th member of struct tm),
+	# using "member" and the zero-based member index
+	set tm_year 5
+	puts [[$now_broken member $tm_year] value]
+
+	# call asctime()
+	set now_broken_ptr [ffi.pointer [$now_broken address]]
+	set out [ffi.pointer]
+	$asctime_ptr [$out address] [$now_broken_ptr address]
+	puts [ffi.string at [$out value] 24]
+}
+
+sizeof_example
+types_example
+simple_example
+pointers_example
+structs_example

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -51,7 +51,7 @@ proc types_example {} {
 	# variable; that's the only pointer type (i.e there's no int * equivalent,
 	# see ffi:string at and ffi::cast)
 	set count_func [ffi::pointer [$count address]]
-	puts [$count_func value]
+	puts "the pointer points to [$count_func value]"
 
 	# strings are created using ffi::string copy or ffi::string at; the latter
 	# is also used to read strings (i.e the return value of a C function that
@@ -63,6 +63,10 @@ proc types_example {} {
 proc functions_example {} {
 	# shared libraries are loaded using ffi::dlopen
 	set libc [ffi::dlopen libc.so.6]
+
+	# the handle method returns the handle (i.e return value of dlopen()) of a
+	# shared library
+	puts "the handle of libc.so.6 is [$libc handle]"
 
 	# functions are accessed through the dlsym method of a library and
 	# ffi::function; the first argument is the return value type, the second is
@@ -149,12 +153,15 @@ proc structs_example {} {
 	# create a struct tm and initialize it with January 30th 1992, 2:10 AM;
 	# structs are initialized using their raw value
 	set now_broken [ffi::struct "[$::zero raw][[ffi::int 10] raw][[ffi::int 2] raw][[ffi::int 30] raw][$::zero raw][[ffi::int 92] raw][$::zero raw][[ffi::int 30] raw][$::zero raw][[ffi::long 0] raw][$::null raw]" int int int int int int int int int long pointer]
+
+	# the size method returns the size of a struct (like sizeof())
 	set struct_tm_size [$now_broken size]
+	puts "the size of struct tm is $struct_tm_size bytes"
 
 	# for demonstration purposes, read tm_year (the 6th member of struct tm),
 	# using "member" and the zero-based member index
 	set tm_year 5
-	puts [[$now_broken member $tm_year] value]
+	puts "tm_year of the struct_tm at [$now_broken address] is [[$now_broken member $tm_year] value]"
 
 	# call asctime()
 	set now_broken_func [ffi::pointer [$now_broken address]]
@@ -168,11 +175,12 @@ proc structs_example {} {
 	$asctime_func [$out address] [$now_broken_func address]
 	puts [ffi::string at [$out value] 24]
 
-	# ... and again: this time with a zeroed struct tm
+	# ... and again: this time with a zeroed struct tm and without passing the
+	# string length to ffi::string at (so it guesses it using strlen())
 	set now_broken [ffi::struct "[string repeat \x00 [expr $struct_tm_size - 1]]]" int int int int int int int int int long pointer]
 	set now_broken_func [ffi::pointer [$now_broken address]]
 	$asctime_func [$out address] [$now_broken_func address]
-	puts [ffi::string at [$out value] 24]
+	puts [ffi::string at [$out value]]
 }
 
 proc cast_example {} {

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -47,8 +47,8 @@ proc types_example {} {
 	puts "the raw, [$count size] bytes form of [$count value] is [$count raw]"
 
 	# pointers are created by calling ffi.pointer with the address of a variable
-	set count_ptr [ffi.pointer [$count address]]
-	puts [$count_ptr value]
+	set count_func [ffi.pointer [$count address]]
+	puts [$count_func value]
 
 	# strings are created using ffi.string copy or ffi.string at; the latter
 	# is also used to read strings (i.e the return value of a C function that
@@ -58,31 +58,35 @@ proc types_example {} {
 }
 
 proc functions_example {} {
-	# functions are accessed through the return value of ffi.dlopen - the first
-	# argument is the return value type, the second is the function symbol name
-	# and the rest are argument types
+	# shared libraries are loaded using ffi.dlopen
 	set libc [ffi.dlopen libc.so.6]
-	set puts_ptr [$libc int puts pointer]
+
+	# functions are accessed through the dlsym method of a library and
+	# ffi.function; the first argument is the return value type, the second is
+	# the function address and the rest are argument types
+	set puts_addr [$libc dlsym puts]
+	puts "puts() is at $puts_addr"
+	set puts_func [ffi.function int $puts_addr pointer]
 
 	# functions are called by using the function object as the command; the
 	# return value object and the parameters must be passed using their
 	# addresses
 	set ret [ffi.int]
 	set msg [ffi.string copy "print this please"]
-	$puts_ptr [$ret address] [$msg address]
+	$puts_func [$ret address] [$msg address]
 	puts "the return value of puts() is [$ret value]"
 
 	# (it's also possible to create temporary variables in case you don't want
 	# to read the variable values)
-	$puts_ptr [[ffi.int] address] [$msg address]
+	$puts_func [[ffi.int] address] [$msg address]
 
 	# let's do this again - this time, with a function with a more complex
 	# prototype: sprintf()
-	set sprintf_ptr [$libc int sprintf pointer pointer pointer int]
+	set sprintf_func [ffi.function int [$libc dlsym puts] pointer pointer pointer int]
 
 	# ffi.buffer is a quick, efficient way to allocate buffers with a given size
 	set buf [ffi.buffer 32]
-	$sprintf_ptr [[ffi.int] address] [$buf address] [[ffi.string copy "%s %d"] address] [[ffi.string copy "aha"] address] [[ffi.int 1337] address]
+	$sprintf_func [[ffi.int] address] [$buf address] [[ffi.string copy "%s %d"] address] [[ffi.string copy "aha"] address] [[ffi.int 1337] address]
 
 	# print the output buffer (the first argument)
 	puts [$buf value]
@@ -92,7 +96,7 @@ proc constants_example {} {
 	# ::main is the the main executable handle (see dlopen(3)) - on some
 	# platforms, the loader resolves symbols recursively, so there's no need to
 	# load obtain a libc handle
-	set exit_ptr [$::main void exit int]
+	set exit_func [ffi.pointer void [$::main dlsym exit] int]
 
 	# ::null (a global) is a NULL pointer
 	puts [$::null value]
@@ -114,21 +118,21 @@ proc constants_example {} {
 
 proc pointers_example {} {
 	# call time() to get the current time
-	set time_ptr [$::main void time pointer]
+	set time_func [ffi.function void [$::main dlsym time] pointer]
 	set now [ffi.int]
-	$time_ptr [[ffi.void] address] [[ffi.pointer [$now address]] address]
+	$time_func [[ffi.void] address] [[ffi.pointer [$now address]] address]
 
 	# call gmtime(), which returns a struct tm pointer
-	set gmtime_ptr [$::main pointer gmtime pointer]
-	set now_ptr [ffi.pointer [$now address]]
+	set gmtime_func [ffi.function pointer [$::main dlsym gmtime] pointer]
+	set now_func [ffi.pointer [$now address]]
 	set now_broken [ffi.pointer]
-	$gmtime_ptr [$now_broken address] [$now_ptr address]
+	$gmtime_func [$now_broken address] [$now_func address]
 
 	# call asctime() and pass the struct tm pointer
-	set asctime_ptr [$::main pointer asctime pointer]
-	set now_broken_ptr [ffi.pointer [$now_broken value]]
+	set asctime_func [ffi.function pointer [$::main dlsym asctime] pointer]
+	set now_broken_func [ffi.pointer [$now_broken value]]
 	set out [ffi.pointer]
-	$asctime_ptr [$out address] [$now_broken_ptr address]
+	$asctime_func [$out address] [$now_broken_func address]
 
 	# asctime() returns a string - print it
 	puts [ffi.string at [$out value] 24]
@@ -136,7 +140,7 @@ proc pointers_example {} {
 
 proc structs_example {} {
 	# locate asctime()
-	set asctime_ptr [$::main pointer asctime pointer]
+	set asctime_func [ffi.function pointer [$::main dlsym asctime] pointer]
 
 	# create a struct tm and initialize it with January 30th 1992, 2:10 AM;
 	# structs are initialized using their raw value
@@ -149,21 +153,21 @@ proc structs_example {} {
 	puts [[$now_broken member $tm_year] value]
 
 	# call asctime()
-	set now_broken_ptr [ffi.pointer [$now_broken address]]
+	set now_broken_func [ffi.pointer [$now_broken address]]
 	set out [ffi.pointer]
-	$asctime_ptr [$out address] [$now_broken_ptr address]
+	$asctime_func [$out address] [$now_broken_func address]
 	puts [ffi.string at [$out value] 24]
 
 	# now, let's do this again: this time, with an uninitialized struct
 	set now_broken [ffi.struct "" int int int int int int int int int long pointer]
-	set now_broken_ptr [ffi.pointer [$now_broken address]]
-	$asctime_ptr [$out address] [$now_broken_ptr address]
+	set now_broken_func [ffi.pointer [$now_broken address]]
+	$asctime_func [$out address] [$now_broken_func address]
 	puts [ffi.string at [$out value] 24]
 
 	# ... and again: this time with a zeroed struct tm
 	set now_broken [ffi.struct "[string repeat \x00 [expr $struct_tm_size - 1]]]" int int int int int int int int int long pointer]
-	set now_broken_ptr [ffi.pointer [$now_broken address]]
-	$asctime_ptr [$out address] [$now_broken_ptr address]
+	set now_broken_func [ffi.pointer [$now_broken address]]
+	$asctime_func [$out address] [$now_broken_func address]
 	puts [ffi.string at [$out value] 24]
 }
 
@@ -176,39 +180,39 @@ proc sockets_example {} {
 	set SOCK_STREAM 1
 	set INADDR_LOOPBACK 0x7F000001
 
-	set socket_ptr [$::main int socket int int int]
-	set htons_ptr [$::main uint16 htons uint16]
-	set htonl_ptr [$::main uint32 htonl uint32]
-	set bind_ptr [$::main int bind int pointer uint32]
-	set listen_ptr [$::main int listen int int]
-	set accept_ptr [$::main int accept int pointer pointer]
-	set send_ptr [$::main int send int pointer uint int]
-	set close_ptr [$::main int close int]
+	set socket_func [ffi.function int [$::main dlsym socket] int int int]
+	set htons_func [ffi.function uint16 [$::main dlsym htons] uint16]
+	set htonl_func [ffi.function uint32 [$::main dlsym htonl] uint32]
+	set bind_func [ffi.function int [$::main dlsym bind] int pointer uint32]
+	set listen_func [ffi.function int [$::main dlsym listen] int int]
+	set accept_func [ffi.function int [$::main dlsym accept] int pointer pointer]
+	set send_func [ffi.function int [$::main dlsym send] int pointer uint int]
+	set close_func [ffi.function int [$::main dlsym close] int]
 
 	set ret [ffi.int]
 
 	# format a struct sockaddr_in structure (127.0.0.1:9000)
 	set port [ffi.uint16]
-	$htons_ptr [$port address] [[ffi.uint16 9000] address]
+	$htons_func [$port address] [[ffi.uint16 9000] address]
 	set addr [ffi.uint32]
-	$htonl_ptr [$addr address] [[ffi.uint32 $INADDR_LOOPBACK] address]
+	$htonl_func [$addr address] [[ffi.uint32 $INADDR_LOOPBACK] address]
 	set listen_addr [ffi.struct "[[ffi.ushort $AF_INET] raw][$port raw][$addr raw][[ffi.uint64] raw]" ushort uint16 uint32 uint64]
 
 	# create a socket
 	set s [ffi.int]
-	$socket_ptr [$s address] [[ffi.int $AF_INET] address] [[ffi.int $SOCK_STREAM] address] [$::zero address]
+	$socket_func [$s address] [[ffi.int $AF_INET] address] [[ffi.int $SOCK_STREAM] address] [$::zero address]
 	if {[$s value] < 0} {
 		return
 	}
 
 	try {
 		# start listening
-		$bind_ptr [$ret address] [$s address] [[ffi.pointer [$listen_addr address]] address] [[ffi.int [$listen_addr size]] address]
+		$bind_func [$ret address] [$s address] [[ffi.pointer [$listen_addr address]] address] [[ffi.int [$listen_addr size]] address]
 		if {[$ret value] < 0} {
 			throw error "failed to bind the socket"
 		}
 
-		$listen_ptr [$ret address] [$s address] [[ffi.int 5] address]
+		$listen_func [$ret address] [$s address] [[ffi.int 5] address]
 		if {[$ret value] < 0} {
 			throw error "failed to listen"
 		}
@@ -217,22 +221,22 @@ proc sockets_example {} {
 		set client_addr [ffi.struct "[[ffi.ushort] raw][[ffi.uint16] raw][[ffi.uint32] raw][[ffi.uint64] raw]" ushort uint16 uint32 uint64]
 		set c [ffi.int]
 		puts "waiting for a client on port 9000"
-		$accept_ptr [$c address] [$s address] [[ffi.pointer [$client_addr address]] address] [[ffi.pointer [[ffi.int [$client_addr size]] address]] address]
+		$accept_func [$c address] [$s address] [[ffi.pointer [$client_addr address]] address] [[ffi.pointer [[ffi.int [$client_addr size]] address]] address]
 		if {[$c value] < 0} {
 			throw error "failed to accept a client"
 		}
 
 		# send something
-		$send_ptr [[ffi.int] address] [$c address] [[ffi.string copy hello\n] address] [[ffi.uint 6] address] [$::zero address]
+		$send_func [[ffi.int] address] [$c address] [[ffi.string copy hello\n] address] [[ffi.uint 6] address] [$::zero address]
 
 		# disconnect the client
-		$close_ptr [[ffi.int] address] [$c address]
+		$close_func [[ffi.int] address] [$c address]
 	} on error {msg opts} {
 		puts "Error: $msg"
 	} finally {
 		# pay attention: correct error handling is crucial when working with
 		# file descriptors directly
-		$close_ptr [[ffi.int] address] [$s address]
+		$close_func [[ffi.int] address] [$s address]
 	}
 }
 

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -1,42 +1,42 @@
 package require ffi
 
 proc sizeof_example {} {
-	# pointers; see ffi.buffer and ffi.string later
-	puts [[ffi.pointer] size]
+	# pointers; see ffi::buffer and ffi::string later
+	puts [[ffi::pointer] size]
 
 	# standard types
-	puts [[ffi.ulong] size]
-	puts [[ffi.long] size]
-	puts [[ffi.uint] size]
-	puts [[ffi.int] size]
-	puts [[ffi.ushort] size]
-	puts [[ffi.short] size]
-	puts [[ffi.uchar] size]
-	puts [[ffi.char] size]
+	puts [[ffi::ulong] size]
+	puts [[ffi::long] size]
+	puts [[ffi::uint] size]
+	puts [[ffi::int] size]
+	puts [[ffi::ushort] size]
+	puts [[ffi::short] size]
+	puts [[ffi::uchar] size]
+	puts [[ffi::char] size]
 
 	# fixed-width types ({u,}int64 may be missing on pure 32-bit architectures)
-	# puts [[ffi.uint64] size]
-	# puts [[ffi.int64] size]
-	puts [[ffi.uint32] size]
-	puts [[ffi.int32] size]
-	puts [[ffi.uint16] size]
-	puts [[ffi.int16] size]
-	puts [[ffi.uint8] size]
-	puts [[ffi.int8] size]
+	# puts [[ffi::uint64] size]
+	# puts [[ffi::int64] size]
+	puts [[ffi::uint32] size]
+	puts [[ffi::int32] size]
+	puts [[ffi::uint16] size]
+	puts [[ffi::int16] size]
+	puts [[ffi::uint8] size]
+	puts [[ffi::int8] size]
 
 	# floating-point types
-	puts [[ffi.float] size]
-	puts [[ffi.double] size]
+	puts [[ffi::float] size]
+	puts [[ffi::double] size]
 
 	# misc. types
-	puts [[ffi.void] size]
+	puts [[ffi::void] size]
 }
 
 proc types_example {} {
-	# variables are created using ffi.int, ffi_uint, ffi.long and so on; they
+	# variables are created using ffi::int, ffi_uint, ffi::long and so on; they
 	# can be initialized by specifying a value
-	set count [ffi.int 12345678]
-	set uninit_count [ffi.int]
+	set count [ffi::int 12345678]
+	set uninit_count [ffi::int]
 
 	# "value" returns the value of a variable as a Tcl object and "address"
 	# returns its address (like the & operator in C)
@@ -46,47 +46,49 @@ proc types_example {} {
 	# the raw contents of a variable may be accessed using "raw"
 	puts "the raw, [$count size] bytes form of [$count value] is [$count raw]"
 
-	# pointers are created by calling ffi.pointer with the address of a variable
-	set count_func [ffi.pointer [$count address]]
+	# pointers are created by calling ffi::pointer with the address of a
+	# variable
+	set count_func [ffi::pointer [$count address]]
 	puts [$count_func value]
 
-	# strings are created using ffi.string copy or ffi.string at; the latter
+	# strings are created using ffi::string copy or ffi::string at; the latter
 	# is also used to read strings (i.e the return value of a C function that
 	# returns a char *) and dereference pointers
-	set s [ffi.string copy "this is a string"]
+	set s [ffi::string copy "this is a string"]
 	puts [$s value]
 }
 
 proc functions_example {} {
-	# shared libraries are loaded using ffi.dlopen
-	set libc [ffi.dlopen libc.so.6]
+	# shared libraries are loaded using ffi::dlopen
+	set libc [ffi::dlopen libc.so.6]
 
 	# functions are accessed through the dlsym method of a library and
-	# ffi.function; the first argument is the return value type, the second is
+	# ffi::function; the first argument is the return value type, the second is
 	# the function address and the rest are argument types
 	set puts_addr [$libc dlsym puts]
 	puts "puts() is at $puts_addr"
-	set puts_func [ffi.function int $puts_addr pointer]
+	set puts_func [ffi::function int $puts_addr pointer]
 
 	# functions are called by using the function object as the command; the
 	# return value object and the parameters must be passed using their
 	# addresses
-	set ret [ffi.int]
-	set msg [ffi.string copy "print this please"]
+	set ret [ffi::int]
+	set msg [ffi::string copy "print this please"]
 	$puts_func [$ret address] [$msg address]
 	puts "the return value of puts() is [$ret value]"
 
 	# (it's also possible to create temporary variables in case you don't want
 	# to read the variable values)
-	$puts_func [[ffi.int] address] [$msg address]
+	$puts_func [[ffi::int] address] [$msg address]
 
 	# let's do this again - this time, with a function with a more complex
 	# prototype: sprintf()
-	set sprintf_func [ffi.function int [$libc dlsym sprintf] pointer pointer pointer int]
+	set sprintf_func [ffi::function int [$libc dlsym sprintf] pointer pointer pointer int]
 
-	# ffi.buffer is a quick, efficient way to allocate buffers with a given size
-	set buf [ffi.buffer 32]
-	$sprintf_func [[ffi.int] address] [$buf address] [[ffi.string copy "%s %d"] address] [[ffi.string copy "aha"] address] [[ffi.int 1337] address]
+	# ffi::buffer is a quick, efficient way to allocate buffers with a given
+	# size
+	set buf [ffi::buffer 32]
+	$sprintf_func [[ffi::int] address] [$buf address] [[ffi::string copy "%s %d"] address] [[ffi::string copy "aha"] address] [[ffi::int 1337] address]
 
 	# print the output buffer (the first argument)
 	puts [$buf value]
@@ -96,17 +98,17 @@ proc constants_example {} {
 	# ::main is the the main executable handle (see dlopen(3)) - on some
 	# platforms, the loader resolves symbols recursively, so there's no need to
 	# load obtain a libc handle
-	set exit_func [ffi.pointer void [$::main dlsym exit] int]
+	set exit_func [ffi::pointer void [$::main dlsym exit] int]
 
 	# ::null (a global) is a NULL pointer
-	puts [$::null value]
+	puts "the value of :null is [$::null value]"
 
 	# ::zero is 0 (int), useful for functions that accept flags
-	puts [$::zero value]
+	puts "the value of ::zero is [$::zero value]"
 
 	# ::one is 1 (int), useful for functions that accept an int that acts as a
 	# boolean (i.e setsockopt())
-	puts [$::one value]
+	puts "the value of ::one is [$::one value]"
 
 	# make sure:
 	# 1) you don't modify these globals by mistake: don't pass them to functions
@@ -118,33 +120,33 @@ proc constants_example {} {
 
 proc pointers_example {} {
 	# call time() to get the current time
-	set time_func [ffi.function void [$::main dlsym time] pointer]
-	set now [ffi.int]
-	$time_func [[ffi.void] address] [[ffi.pointer [$now address]] address]
+	set time_func [ffi::function void [$::main dlsym time] pointer]
+	set now [ffi::int]
+	$time_func [[ffi::void] address] [[ffi::pointer [$now address]] address]
 
 	# call gmtime(), which returns a struct tm pointer
-	set gmtime_func [ffi.function pointer [$::main dlsym gmtime] pointer]
-	set now_func [ffi.pointer [$now address]]
-	set now_broken [ffi.pointer]
+	set gmtime_func [ffi::function pointer [$::main dlsym gmtime] pointer]
+	set now_func [ffi::pointer [$now address]]
+	set now_broken [ffi::pointer]
 	$gmtime_func [$now_broken address] [$now_func address]
 
 	# call asctime() and pass the struct tm pointer
-	set asctime_func [ffi.function pointer [$::main dlsym asctime] pointer]
-	set now_broken_func [ffi.pointer [$now_broken value]]
-	set out [ffi.pointer]
+	set asctime_func [ffi::function pointer [$::main dlsym asctime] pointer]
+	set now_broken_func [ffi::pointer [$now_broken value]]
+	set out [ffi::pointer]
 	$asctime_func [$out address] [$now_broken_func address]
 
 	# asctime() returns a string - print it
-	puts [ffi.string at [$out value] 24]
+	puts [ffi::string at [$out value] 24]
 }
 
 proc structs_example {} {
 	# locate asctime()
-	set asctime_func [ffi.function pointer [$::main dlsym asctime] pointer]
+	set asctime_func [ffi::function pointer [$::main dlsym asctime] pointer]
 
 	# create a struct tm and initialize it with January 30th 1992, 2:10 AM;
 	# structs are initialized using their raw value
-	set now_broken [ffi.struct "[$::zero raw][[ffi.int 10] raw][[ffi.int 2] raw][[ffi.int 30] raw][$::zero raw][[ffi.int 92] raw][$::zero raw][[ffi.int 30] raw][$::zero raw][[ffi.long 0] raw][$::null raw]" int int int int int int int int int long pointer]
+	set now_broken [ffi::struct "[$::zero raw][[ffi::int 10] raw][[ffi::int 2] raw][[ffi::int 30] raw][$::zero raw][[ffi::int 92] raw][$::zero raw][[ffi::int 30] raw][$::zero raw][[ffi::long 0] raw][$::null raw]" int int int int int int int int int long pointer]
 	set struct_tm_size [$now_broken size]
 
 	# for demonstration purposes, read tm_year (the 6th member of struct tm),
@@ -153,22 +155,22 @@ proc structs_example {} {
 	puts [[$now_broken member $tm_year] value]
 
 	# call asctime()
-	set now_broken_func [ffi.pointer [$now_broken address]]
-	set out [ffi.pointer]
+	set now_broken_func [ffi::pointer [$now_broken address]]
+	set out [ffi::pointer]
 	$asctime_func [$out address] [$now_broken_func address]
-	puts [ffi.string at [$out value] 24]
+	puts [ffi::string at [$out value] 24]
 
 	# now, let's do this again: this time, with an uninitialized struct
-	set now_broken [ffi.struct "" int int int int int int int int int long pointer]
-	set now_broken_func [ffi.pointer [$now_broken address]]
+	set now_broken [ffi::struct "" int int int int int int int int int long pointer]
+	set now_broken_func [ffi::pointer [$now_broken address]]
 	$asctime_func [$out address] [$now_broken_func address]
-	puts [ffi.string at [$out value] 24]
+	puts [ffi::string at [$out value] 24]
 
 	# ... and again: this time with a zeroed struct tm
-	set now_broken [ffi.struct "[string repeat \x00 [expr $struct_tm_size - 1]]]" int int int int int int int int int long pointer]
-	set now_broken_func [ffi.pointer [$now_broken address]]
+	set now_broken [ffi::struct "[string repeat \x00 [expr $struct_tm_size - 1]]]" int int int int int int int int int long pointer]
+	set now_broken_func [ffi::pointer [$now_broken address]]
 	$asctime_func [$out address] [$now_broken_func address]
-	puts [ffi.string at [$out value] 24]
+	puts [ffi::string at [$out value] 24]
 }
 
 proc sockets_example {} {
@@ -180,63 +182,63 @@ proc sockets_example {} {
 	set SOCK_STREAM 1
 	set INADDR_LOOPBACK 0x7F000001
 
-	set socket_func [ffi.function int [$::main dlsym socket] int int int]
-	set htons_func [ffi.function uint16 [$::main dlsym htons] uint16]
-	set htonl_func [ffi.function uint32 [$::main dlsym htonl] uint32]
-	set bind_func [ffi.function int [$::main dlsym bind] int pointer uint32]
-	set listen_func [ffi.function int [$::main dlsym listen] int int]
-	set accept_func [ffi.function int [$::main dlsym accept] int pointer pointer]
-	set send_func [ffi.function int [$::main dlsym send] int pointer uint int]
-	set close_func [ffi.function int [$::main dlsym close] int]
+	set socket_func [ffi::function int [$::main dlsym socket] int int int]
+	set htons_func [ffi::function uint16 [$::main dlsym htons] uint16]
+	set htonl_func [ffi::function uint32 [$::main dlsym htonl] uint32]
+	set bind_func [ffi::function int [$::main dlsym bind] int pointer uint32]
+	set listen_func [ffi::function int [$::main dlsym listen] int int]
+	set accept_func [ffi::function int [$::main dlsym accept] int pointer pointer]
+	set send_func [ffi::function int [$::main dlsym send] int pointer uint int]
+	set close_func [ffi::function int [$::main dlsym close] int]
 
-	set ret [ffi.int]
+	set ret [ffi::int]
 
 	# format a struct sockaddr_in structure (127.0.0.1:9000)
-	set port [ffi.uint16]
-	$htons_func [$port address] [[ffi.uint16 9000] address]
-	set addr [ffi.uint32]
-	$htonl_func [$addr address] [[ffi.uint32 $INADDR_LOOPBACK] address]
-	set listen_addr [ffi.struct "[[ffi.ushort $AF_INET] raw][$port raw][$addr raw][[ffi.uint64] raw]" ushort uint16 uint32 uint64]
+	set port [ffi::uint16]
+	$htons_func [$port address] [[ffi::uint16 9000] address]
+	set addr [ffi::uint32]
+	$htonl_func [$addr address] [[ffi::uint32 $INADDR_LOOPBACK] address]
+	set listen_addr [ffi::struct "[[ffi::ushort $AF_INET] raw][$port raw][$addr raw][[ffi::uint64] raw]" ushort uint16 uint32 uint64]
 
 	# create a socket
-	set s [ffi.int]
-	$socket_func [$s address] [[ffi.int $AF_INET] address] [[ffi.int $SOCK_STREAM] address] [$::zero address]
+	set s [ffi::int]
+	$socket_func [$s address] [[ffi::int $AF_INET] address] [[ffi::int $SOCK_STREAM] address] [$::zero address]
 	if {[$s value] < 0} {
 		return
 	}
 
 	try {
 		# start listening
-		$bind_func [$ret address] [$s address] [[ffi.pointer [$listen_addr address]] address] [[ffi.int [$listen_addr size]] address]
+		$bind_func [$ret address] [$s address] [[ffi::pointer [$listen_addr address]] address] [[ffi::int [$listen_addr size]] address]
 		if {[$ret value] < 0} {
 			throw error "failed to bind the socket"
 		}
 
-		$listen_func [$ret address] [$s address] [[ffi.int 5] address]
+		$listen_func [$ret address] [$s address] [[ffi::int 5] address]
 		if {[$ret value] < 0} {
 			throw error "failed to listen"
 		}
 
 		# accept a client
-		set client_addr [ffi.struct "[[ffi.ushort] raw][[ffi.uint16] raw][[ffi.uint32] raw][[ffi.uint64] raw]" ushort uint16 uint32 uint64]
-		set c [ffi.int]
+		set client_addr [ffi::struct "[[ffi::ushort] raw][[ffi::uint16] raw][[ffi::uint32] raw][[ffi::uint64] raw]" ushort uint16 uint32 uint64]
+		set c [ffi::int]
 		puts "waiting for a client on port 9000"
-		$accept_func [$c address] [$s address] [[ffi.pointer [$client_addr address]] address] [[ffi.pointer [[ffi.int [$client_addr size]] address]] address]
+		$accept_func [$c address] [$s address] [[ffi::pointer [$client_addr address]] address] [[ffi::pointer [[ffi::int [$client_addr size]] address]] address]
 		if {[$c value] < 0} {
 			throw error "failed to accept a client"
 		}
 
 		# send something
-		$send_func [[ffi.int] address] [$c address] [[ffi.string copy hello\n] address] [[ffi.uint 6] address] [$::zero address]
+		$send_func [[ffi::int] address] [$c address] [[ffi::string copy hello\n] address] [[ffi::uint 6] address] [$::zero address]
 
 		# disconnect the client
-		$close_func [[ffi.int] address] [$c address]
+		$close_func [[ffi::int] address] [$c address]
 	} on error {msg opts} {
 		puts "Error: $msg"
 	} finally {
 		# pay attention: correct error handling is crucial when working with
 		# file descriptors directly
-		$close_func [[ffi.int] address] [$s address]
+		$close_func [[ffi::int] address] [$s address]
 	}
 }
 

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -64,7 +64,7 @@ proc functions_example {} {
 }
 
 proc constants_example {} {
-	# $::main is the the main executable handle (see dlopen(3)) - on some
+	# ::main is the the main executable handle (see dlopen(3)) - on some
 	# platforms, the loader resolves symbols recursively, so ther's no need to
 	# load obtain a libc handle
 	set exit_ptr [$::main void exit int]

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -92,7 +92,7 @@ proc functions_example {} {
 	set sprintf_func [ffi::function int [$libc dlsym sprintf] pointer pointer pointer int]
 
 	# ffi::buffer is a quick, efficient way to allocate buffers with a given
-	# size
+	# size and filled with null bytes
 	set buf [ffi::buffer 32]
 	$sprintf_func [[ffi::int] address] [$buf address] [[ffi::string copy "%s %d"] address] [[ffi::string copy "aha"] address] [[ffi::int 1337] address]
 

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -18,7 +18,7 @@ set arg2 [ffi.int 1337]
 set ret [ffi.int]
 
 # call sprintf() - variables must be passed as pointers
-$sprintf [$ret pointer] "[$buf pointer] [$fmt pointer] [$arg1 pointer] [$arg2 pointer]"
+$sprintf [$ret address] "[$buf address] [$fmt address] [$arg1 address] [$arg2 address]"
 
 # print the output buffer (the first argument)
 puts [$buf value]

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -209,6 +209,29 @@ proc cast_example {} {
 	puts "the error in errno after close() is: [ffi::string at [$str value]] ([$errno value])"
 }
 
+proc safety_example {} {
+	# ffi::string, ffi::function and ffi::cast throw an error upon attempt to
+	# dereference a NULL pointer, but all other memory and pointer operations
+	# are unsafe and may lead to crashes, as in C
+	try {
+		ffi::string at [$::null value]
+	} on error {msg opts} {
+		puts "Caught an exception: $msg"
+	}
+
+	try {
+		ffi::function void [$::null value]
+	} on error {msg opts} {
+		puts "Caught an exception: $msg"
+	}
+
+	try {
+		ffi::cast int [$::null value]
+	} on error {msg opts} {
+		puts "Caught an exception: $msg"
+	}
+}
+
 proc sockets_example {} {
 	# this is a fairly complex, non-trivial example; it may not work on
 	# architectures other than x86, because of the size and alignment of struct
@@ -285,4 +308,5 @@ constants_example
 pointers_example
 structs_example
 cast_example
+safety_example
 sockets_example

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -115,7 +115,7 @@ proc structs_example {} {
 	puts [ffi.string at [$out value] 24]
 
 	# ... and again: this time with a zeroed struct tm
-	set now_broken [ffi.struct "[string repeat \x01 [expr $struct_tm_size - 1]]]" int int int int int int int int int long pointer]
+	set now_broken [ffi.struct "[string repeat \x00 [expr $struct_tm_size - 1]]]" int int int int int int int int int long pointer]
 	set now_broken_ptr [ffi.pointer [$now_broken address]]
 	$asctime_ptr [$out address] [$now_broken_ptr address]
 	puts [ffi.string at [$out value] 24]

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -1,0 +1,27 @@
+package require ffi
+
+# load the C libary
+set libc [ffi.dlopen libc.so.6]
+
+# locate sprintf() and define its prototype
+set sprintf [$libc int sprintf string string string int]
+
+# create objects for the arguments of sprintf() - they should match the
+# prototype
+set buf [ffi.buffer 32]
+set fmt [ffi.string "%s %d"]
+set arg1 [ffi.string "aha"]
+set arg2 [ffi.int 1337]
+
+# create an object for the return value; if no value is specified it's an
+# uninitialized variable
+set ret [ffi.int]
+
+# call sprintf() - variables must be passed as pointers
+$sprintf [$ret pointer] "[$buf pointer] [$fmt pointer] [$arg1 pointer] [$arg2 pointer]"
+
+# print the output buffer (the first argument)
+puts [$buf value]
+
+# print the return value of sprintf()
+puts [$ret value]

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -154,6 +154,10 @@ proc structs_example {} {
 	# structs are initialized using their raw value
 	set now_broken [ffi::struct "[$::zero raw][[ffi::int 10] raw][[ffi::int 2] raw][[ffi::int 30] raw][$::zero raw][[ffi::int 92] raw][$::zero raw][[ffi::int 30] raw][$::zero raw][[ffi::long 0] raw][$::null raw]" int int int int int int int int int long pointer]
 
+	# it is also possible to pass an empty string instead of an initializer - in
+	# this case, the struct is filled with zero bytes
+	set now_zero [ffi::struct "" int int int int int int int int int long pointer]
+
 	# the size method returns the size of a struct (like sizeof())
 	set struct_tm_size [$now_broken size]
 	puts "the size of struct tm is $struct_tm_size bytes"
@@ -181,6 +185,16 @@ proc structs_example {} {
 	set now_broken_func [ffi::pointer [$now_broken address]]
 	$asctime_func [$out address] [$now_broken_func address]
 	puts [ffi::string at [$out value]]
+}
+
+proc arrays_example {} {
+	# arrays are created almost like structs, using an initializer (or an empty
+	# string), the type of all elements and the array length
+	set numbers [ffi::array [[ffi::long 0x10] raw][[ffi::long 0x20] raw] long 2]
+
+	puts "the array length is [$numbers length]"
+	puts "the array size is [$numbers size] bytes"
+	puts "the first element in the array is [[$numbers member 0] value]"
 }
 
 proc cast_example {} {
@@ -307,6 +321,7 @@ functions_example
 constants_example
 pointers_example
 structs_example
+arrays_example
 cast_example
 safety_example
 sockets_example

--- a/examples/ffi.tcl
+++ b/examples/ffi.tcl
@@ -10,8 +10,15 @@ proc sizeof_example {} {
 }
 
 proc types_example {} {
+	# variables are created using ffi.int, ffi_uint, ffi.long and so on; they
+	# can be initialized by specifying a value
 	set count [ffi.int 12345678]
+	set uninit_count [ffi.int]
+
+	# "value" returns the value of a variable as a Tcl object and "address"
+	# returns its address (like the & operator in C)
 	puts "integer with contents [$count value] is at [$count address]"
+	puts "the value of the uninitialized integer is [$uninit_count value]"
 
 	# the raw contents of a variable may be accessed using "raw"
 	puts "the raw, [$count size] bytes form of [$count value] is [$count raw]"
@@ -20,36 +27,44 @@ proc types_example {} {
 	set count_ptr [ffi.pointer [$count address]]
 	puts [$count_ptr value]
 
-	# strings are created using "ffi.string copy" or "ffi.string at"
+	# strings are created using "ffi.string copy" or "ffi.string at"; the latter
+	# is also used to strings (i.e the return value of a C function that returns
+	# a char *) and dereference pointers
 	set s [ffi.string copy "this is a string"]
 	puts [$s value]
 }
 
-proc simple_example {} {
-	# locate sprintf() and define its prototype
-	set sprintf_ptr [$::libc int sprintf string string string int]
+proc functions_example {} {
+	# functions are accessed through the return value of "ffi.dlopen" - the
+	# first argument is the return value type, the second is the function symbol
+	# name and the rest are argument types
+	set puts_ptr [$::libc int puts pointer]
 
-	# create objects for the arguments of sprintf() - they should match the
-	# prototype
+	# functions are called by using the function object as the command; the
+	# return value object and the parameters must be passed using their
+	# addresses
+	set ret [ffi.int]
+	set msg [ffi.string copy "print this please"]
+	$puts_ptr [$ret address] [$msg address]
+	puts "the return value of puts() is [$ret value]"
+
+	# (it's also possible to create temporary variables in case you don't want
+	# to read the variable values)
+	$puts_ptr [[ffi.int] address] [$msg address]
+
+	# let's do this again - this time, with a function with a more complex
+	# prototype: sprintf()
+	set sprintf_ptr [$::libc int sprintf pointer pointer pointer int]
+
 	set buf [ffi.buffer 32]
 	set fmt [ffi.string copy "%s %d"]
 	set arg1 [ffi.string copy "aha"]
 	set arg2 [ffi.int 1337]
-
-	# create an object for the return value; if no value is specified it's an
-	# uninitialized variable
-	set ret [ffi.int]
-
-	# call sprintf() - variables must be passed as pointers
-	$sprintf_ptr [$ret address] "[$buf address] [$fmt address] [$arg1 address] [$arg2 address]"
+	$sprintf_ptr [[ffi.int] address] "[$buf address] [$fmt address] [$arg1 address] [$arg2 address]"
 
 	# print the output buffer (the first argument)
 	puts [$buf value]
-
-	# print the return value of sprintf()
-	puts [$ret value]
 }
-
 
 proc pointers_example {} {
 	# call time() to get the current time
@@ -77,8 +92,10 @@ proc structs_example {} {
 	# locate asctime()
 	set asctime_ptr [$::libc pointer asctime pointer]
 
-	# create a struct tm and initialize it with January 30th 1992, 2:10 AM
+	# create a struct tm and initialize it with January 30th 1992, 2:10 AM;
+	# structs are initialized using their raw value
 	set now_broken [ffi.struct "[[ffi.int 0] raw][[ffi.int 10] raw][[ffi.int 2] raw][[ffi.int 30] raw][[ffi.int 0] raw][[ffi.int 92] raw][[ffi.int 0] raw][[ffi.int 30] raw][[ffi.int 0] raw][[ffi.long 0] raw][[ffi.pointer 0] raw]" int int int int int int int int int long pointer]
+	set struct_tm_size [$now_broken size]
 
 	# for demonstration purposes, read tm_year (the 6th member of struct tm),
 	# using "member" and the zero-based member index
@@ -90,10 +107,22 @@ proc structs_example {} {
 	set out [ffi.pointer]
 	$asctime_ptr [$out address] [$now_broken_ptr address]
 	puts [ffi.string at [$out value] 24]
+
+	# now, let's do this again: this time, with an uninitialized struct
+	set now_broken [ffi.struct "" int int int int int int int int int long pointer]
+	set now_broken_ptr [ffi.pointer [$now_broken address]]
+	$asctime_ptr [$out address] [$now_broken_ptr address]
+	puts [ffi.string at [$out value] 24]
+
+	# ... and again: this time with a zeroed struct tm
+	set now_broken [ffi.struct "[string repeat \x01 [expr $struct_tm_size - 1]]]" int int int int int int int int int long pointer]
+	set now_broken_ptr [ffi.pointer [$now_broken address]]
+	$asctime_ptr [$out address] [$now_broken_ptr address]
+	puts [ffi.string at [$out value] 24]
 }
 
 sizeof_example
 types_example
-simple_example
+functions_example
 pointers_example
 structs_example

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -334,11 +334,7 @@ static void Jim_NewChar(Jim_Interp *interp, const char val)
 
 static void Jim_UcharToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
-    char buf[2];
-
-    buf[0] = (char) var->val.uc;
-    buf[1] = '\0';
-    Jim_SetResultString(interp, buf, -1);
+    Jim_SetResultInt(interp, (jim_wide) var->val.uc);
 }
 
 static void Jim_NewUchar(Jim_Interp *interp, const jim_wide val)

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -156,7 +156,7 @@ static struct ffi_var *Jim_NewIntBase(Jim_Interp *interp, const char *name)
 
     sprintf(buf, "ffi.%s%ld", name, Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimVarDelProc);
-    Jim_SetResultString(interp, buf, -1);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 
     return var;
 }
@@ -548,7 +548,7 @@ static void Jim_NewPointer(Jim_Interp *interp, void *p)
     var = Jim_Alloc(sizeof(*var));
 
     Jim_NewPointerBase(interp, var, p, buf, JimVarDelProc);
-    Jim_SetResultString(interp, buf, -1);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 }
 
 /* buffer methods */
@@ -576,7 +576,7 @@ static void Jim_NewBuffer(Jim_Interp *interp, void *p)
 
     sprintf(buf, "ffi.buffer%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimBufferDelProc);
-    Jim_SetResultString(interp, buf, -1);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 
     var->val.vp = p;
     var->type = &ffi_type_pointer;
@@ -904,7 +904,7 @@ static int JimVoidCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     sprintf(buf, "ffi.void%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimVarDelProc);
-    Jim_SetResultString(interp, buf, -1);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 
     return JIM_OK;
 }
@@ -1054,6 +1054,7 @@ static int JimStructCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     }
 
     raw = Jim_GetString(argv[1], &len);
+
     s = Jim_Alloc(sizeof(*s));
     s->nmemb = argc - 1;
     s->type.elements = Jim_Alloc(sizeof(ffi_type *) * (1 + s->nmemb));
@@ -1094,7 +1095,7 @@ static int JimStructCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     sprintf(buf, "ffi.struct%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimStructHandlerCommand, s, JimStructDelProc);
-    Jim_SetResultString(interp, buf, -1);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 
     return JIM_OK;
 }
@@ -1232,7 +1233,7 @@ static int JimLibraryHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const
 
     sprintf(buf, "ffi.function%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimFunctionHandlerCommand, f, JimFunctionDelProc);
-    Jim_SetResultString(interp, buf, -1);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 
     return JIM_OK;
 }
@@ -1255,7 +1256,7 @@ static int JimDlopenCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     sprintf(buf, "ffi.library%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimLibraryHandlerCommand, h, JimLibraryDelProc);
-    Jim_SetResultString(interp, buf, -1);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 
     return JIM_OK;
 }
@@ -1272,9 +1273,8 @@ int Jim_ffiInit(Jim_Interp *interp)
     void *self;
 
     self = dlopen(NULL, RTLD_LAZY);
-    if (self == NULL) {
+    if (self == NULL)
         return JIM_ERR;
-    }
 
     if (Jim_PackageProvide(interp, "ffi", "1.0", JIM_ERRMSG)) {
         return JIM_ERR;

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -45,11 +45,11 @@
 
 #if INT64_MAX <= JIM_WIDE_MAX
 #define TYPE_NAMES "char", "uchar", "short", "ushort", "int", "uint", "long", \
-                   "ulong", "pointer", "double", "float", "int8", "uint8", \
+                   "ulong", "pointer", "double", "float", "int8", "uint8",    \
                    "int16", "uint16", "int32", "uint32", "int64", "uint64"
 #else
 #define TYPE_NAMES "char", "uchar", "short", "ushort", "int", "uint", "long", \
-                   "ulong", "pointer", "double", "float", "int8", "uint8", \
+                   "ulong", "pointer", "double", "float", "int8", "uint8",    \
                    "int16", "uint16", "int32", "uint32"
 #endif
 
@@ -230,9 +230,7 @@ static int JimVariableHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *cons
     return Jim_CallSubCmd(interp, Jim_ParseSubCmd(interp, variable_command_table, argc, argv), argc, argv);
 }
 
-/* common int methods */
-
-static struct ffi_var *Jim_NewIntBase(Jim_Interp *interp, const char *name)
+static struct ffi_var *Jim_NewVariableBase(Jim_Interp *interp, const char *name)
 {
     char buf[32];
     struct ffi_var *var;
@@ -246,6 +244,22 @@ static struct ffi_var *Jim_NewIntBase(Jim_Interp *interp, const char *name)
     return var;
 }
 
+/* common int methods */
+
+#define JIM_NEWINT(func_name, tcl_name, val_memb, c_type, ffi_type, to_str_func) \
+static void func_name(Jim_Interp *interp, const jim_wide val) \
+{                                                             \
+    struct ffi_var *var;                                      \
+                                                              \
+    var = Jim_NewVariableBase(interp, tcl_name);              \
+                                                              \
+    var->val.val_memb = (c_type)val;                          \
+    var->type = &(ffi_type);                                  \
+    var->to_str = to_str_func;                                \
+    var->addr = &var->val.val_memb;                           \
+    var->size = sizeof(var->val.val_memb);                    \
+}
+
 /* {u,}int8 methods */
 
 static void Jim_Int8ToStr(Jim_Interp *interp, const struct ffi_var *var)
@@ -253,36 +267,14 @@ static void Jim_Int8ToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultInt(interp, (jim_wide)var->val.i8);
 }
 
-static void Jim_NewInt8(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "int8");
-
-    var->val.i8 = (int8_t)val;
-    var->type = &ffi_type_sint8;
-    var->to_str = Jim_Int8ToStr;
-    var->addr = &var->val.i8;
-    var->size = sizeof(var->val.i8);
-}
+JIM_NEWINT(Jim_NewInt8, "int8", i8, int8_t, ffi_type_sint8, Jim_Int8ToStr)
 
 static void Jim_Uint8ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ui8);
 }
 
-static void Jim_NewUint8(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "uint8");
-
-    var->val.ui8 = (uint8_t)val;
-    var->type = &ffi_type_uint8;
-    var->to_str = Jim_Uint8ToStr;
-    var->addr = &var->val.ui8;
-    var->size = sizeof(var->val.ui8);
-}
+JIM_NEWINT(Jim_NewUint8, "uint8", ui8, uint8_t, ffi_type_uint8, Jim_Uint8ToStr)
 
 /* {u,}int16 methods */
 
@@ -291,36 +283,14 @@ static void Jim_Int16ToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultInt(interp, (jim_wide)var->val.i16);
 }
 
-static void Jim_NewInt16(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "int16");
-
-    var->val.i16 = (int16_t)val;
-    var->type = &ffi_type_sint16;
-    var->to_str = Jim_Int16ToStr;
-    var->addr = &var->val.i16;
-    var->size = sizeof(var->val.i16);
-}
+JIM_NEWINT(Jim_NewInt16, "int16", i16, int16_t, ffi_type_sint16, Jim_Int16ToStr)
 
 static void Jim_Uint16ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ui16);
 }
 
-static void Jim_NewUint16(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "uint16");
-
-    var->val.ui16 = (uint16_t)val;
-    var->type = &ffi_type_uint16;
-    var->to_str = Jim_Uint16ToStr;
-    var->addr = &var->val.ui16;
-    var->size = sizeof(var->val.ui16);
-}
+JIM_NEWINT(Jim_NewUint16, "uint16", ui16, uint16_t, ffi_type_uint16, Jim_Uint16ToStr)
 
 /* {u,}int32 methods */
 
@@ -329,36 +299,14 @@ static void Jim_Int32ToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultInt(interp, (jim_wide)var->val.i32);
 }
 
-static void Jim_NewInt32(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "int32");
-
-    var->val.i32 = (int32_t)val;
-    var->type = &ffi_type_sint32;
-    var->to_str = Jim_Int32ToStr;
-    var->addr = &var->val.i32;
-    var->size = sizeof(var->val.i32);
-}
+JIM_NEWINT(Jim_NewInt32, "int32", i32, int32_t, ffi_type_sint32, Jim_Int32ToStr)
 
 static void Jim_Uint32ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ui32);
 }
 
-static void Jim_NewUint32(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "uint32");
-
-    var->val.ui32 = (uint32_t)val;
-    var->type = &ffi_type_uint32;
-    var->to_str = Jim_Uint32ToStr;
-    var->addr = &var->val.ui32;
-    var->size = sizeof(var->val.ui32);
-}
+JIM_NEWINT(Jim_NewUint32, "uint32", ui32, uint32_t, ffi_type_uint32, Jim_Uint32ToStr)
 
 /* {u,}int64 methods */
 
@@ -369,36 +317,14 @@ static void Jim_Int64ToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultInt(interp, (jim_wide)var->val.i64);
 }
 
-static void Jim_NewInt64(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "int64");
-
-    var->val.i64 = (int64_t)val;
-    var->type = &ffi_type_sint64;
-    var->to_str = Jim_Int64ToStr;
-    var->addr = &var->val.i64;
-    var->size = sizeof(var->val.i64);
-}
+JIM_NEWINT(Jim_NewInt64, "int64", i64, int64_t, ffi_type_sint64, Jim_Int64ToStr)
 
 static void Jim_Uint64ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ui64);
 }
 
-static void Jim_NewUint64(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "uint64");
-
-    var->val.ui64 = (uint64_t)val;
-    var->type = &ffi_type_uint64;
-    var->to_str = Jim_Uint64ToStr;
-    var->addr = &var->val.ui64;
-    var->size = sizeof(var->val.ui64);
-}
+JIM_NEWINT(Jim_NewUint64, "uint64", ui64, uint64_t, ffi_type_uint64, Jim_Uint64ToStr)
 
 #endif
 
@@ -414,18 +340,7 @@ static void Jim_CharToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultString(interp, buf, 1);
 }
 
-static void Jim_NewChar(Jim_Interp *interp, const char val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "char");
-
-    var->val.c = val;
-    var->type = &ffi_type_schar;
-    var->to_str = Jim_CharToStr;
-    var->addr = &var->val.c;
-    var->size = sizeof(var->val.c);
-}
+JIM_NEWINT(Jim_NewChar, "char", c, char, ffi_type_schar, Jim_CharToStr)
 
 static void Jim_UcharToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
@@ -433,18 +348,7 @@ static void Jim_UcharToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultInt(interp, (jim_wide)var->val.uc);
 }
 
-static void Jim_NewUchar(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "uchar");
-
-    var->val.uc = (unsigned char)val;
-    var->type = &ffi_type_uchar;
-    var->to_str = Jim_UcharToStr;
-    var->addr = &var->val.uc;
-    var->size = sizeof(var->val.uc);
-}
+JIM_NEWINT(Jim_NewUchar, "uchar", uc, unsigned char, ffi_type_uchar, Jim_UcharToStr)
 
 /* short methods */
 
@@ -453,36 +357,14 @@ static void Jim_ShortToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultInt(interp, (jim_wide)var->val.s);
 }
 
-static void Jim_NewShort(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "short");
-
-    var->val.s = (short)val;
-    var->type = &ffi_type_sshort;
-    var->to_str = Jim_ShortToStr;
-    var->addr = &var->val.s;
-    var->size = sizeof(var->val.s);
-}
+JIM_NEWINT(Jim_NewShort, "short", s, short, ffi_type_sshort, Jim_ShortToStr)
 
 static void Jim_UshortToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.us);
 }
 
-static void Jim_NewUshort(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "ushort");
-
-    var->val.us = (unsigned short)val;
-    var->type = &ffi_type_ushort;
-    var->to_str = Jim_UshortToStr;
-    var->addr = &var->val.us;
-    var->size = sizeof(var->val.us);
-}
+JIM_NEWINT(Jim_NewUshort, "ushort", us, unsigned short, ffi_type_ushort, Jim_UshortToStr)
 
 /* int methods */
 
@@ -490,6 +372,8 @@ static void Jim_IntToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.i);
 }
+
+JIM_NEWINT(Jim_NewInt, "int", i, int, ffi_type_sint, Jim_IntToStr)
 
 /* needed for statically-allocated int objects - we use it for global
  * constants */
@@ -508,36 +392,12 @@ static void Jim_NewIntNoAlloc(Jim_Interp *interp,
     var->size = sizeof(var->val.i);
 }
 
-static void Jim_NewInt(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "int");
-
-    var->val.i = (int)val;
-    var->type = &ffi_type_sint;
-    var->to_str = Jim_IntToStr;
-    var->addr = &var->val.i;
-    var->size = sizeof(var->val.i);
-}
-
 static void Jim_UintToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ui);
 }
 
-static void Jim_NewUint(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "uint");
-
-    var->val.ui = (unsigned int)val;
-    var->type = &ffi_type_uint;
-    var->to_str = Jim_UintToStr;
-    var->addr = &var->val.ui;
-    var->size = sizeof(var->val.ui);
-}
+JIM_NEWINT(Jim_NewUint, "uint", ui, unsigned int, ffi_type_uint, Jim_UintToStr)
 
 /* long methods */
 
@@ -546,36 +406,14 @@ static void Jim_LongToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultInt(interp, (jim_wide)var->val.l);
 }
 
-static void Jim_NewLong(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "long");
-
-    var->val.l = (long)val;
-    var->type = &ffi_type_slong;
-    var->to_str = Jim_LongToStr;
-    var->addr = &var->val.l;
-    var->size = sizeof(var->val.l);
-}
+JIM_NEWINT(Jim_NewLong, "long", l, long, ffi_type_slong, Jim_LongToStr)
 
 static void Jim_UlongToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ul);
 }
 
-static void Jim_NewUlong(Jim_Interp *interp, const jim_wide val)
-{
-    struct ffi_var *var;
-
-    var = Jim_NewIntBase(interp, "ulong");
-
-    var->val.ul = (unsigned long)val;
-    var->type = &ffi_type_ulong;
-    var->to_str = Jim_UlongToStr;
-    var->addr = &var->val.ul;
-    var->size = sizeof(var->val.ul);
-}
+JIM_NEWINT(Jim_NewUlong, "ulong", ul, unsigned long, ffi_type_ulong, Jim_UlongToStr)
 
 /* float methods */
 
@@ -591,7 +429,7 @@ static void Jim_NewFloat(Jim_Interp *interp, const float val)
 {
     struct ffi_var *var;
 
-    var = Jim_NewIntBase(interp, "float");
+    var = Jim_NewVariableBase(interp, "float");
 
     var->val.f = val;
     var->type = &ffi_type_float;
@@ -614,7 +452,7 @@ static void Jim_NewDouble(Jim_Interp *interp, const double val)
 {
     struct ffi_var *var;
 
-    var = Jim_NewIntBase(interp, "double");
+    var = Jim_NewVariableBase(interp, "double");
 
     var->val.d = (double)val;
     var->type = &ffi_type_double;
@@ -740,57 +578,30 @@ static int JimIntBaseCmd(Jim_Interp *interp,
     return JIM_OK;
 }
 
-static int JimUintBaseCmd(Jim_Interp *interp,
-                          int argc,
-                          Jim_Obj *const *argv,
-                          const jim_wide max,
-                          void (*new_obj)(Jim_Interp *, const jim_wide))
-{
-    return JimIntBaseCmd(interp, argc, argv, 0, max, new_obj);
+#define JIMINTCMD(func_name, min, max, new_func) \
+static int func_name(Jim_Interp *interp, int argc, Jim_Obj *const *argv) \
+{                                                                        \
+    return JimIntBaseCmd(interp, argc, argv, min, max, new_func);        \
 }
 
-static int JimInt8Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimIntBaseCmd(interp, argc, argv, INT8_MIN, INT8_MAX, Jim_NewInt8);
+#define JIMUINTCMD(func_name, max, new_func) \
+static int func_name(Jim_Interp *interp, int argc, Jim_Obj *const *argv) \
+{                                                                        \
+    return JimIntBaseCmd(interp, argc, argv, 0, max, new_func);          \
 }
 
-static int JimUint8Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimUintBaseCmd(interp, argc, argv, UINT8_MAX, Jim_NewUint8);
-}
+JIMINTCMD(JimInt8Cmd, INT8_MIN, INT8_MAX, Jim_NewInt8)
+JIMUINTCMD(JimUint8Cmd, UINT8_MAX, Jim_NewUint8);
 
-static int JimInt16Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimIntBaseCmd(interp, argc, argv, INT16_MIN, INT16_MAX, Jim_NewInt16);
-}
+JIMINTCMD(JimInt16Cmd, INT16_MIN, INT16_MAX, Jim_NewInt16)
+JIMUINTCMD(JimUint16Cmd, UINT16_MAX, Jim_NewUint16);
 
-static int JimUint16Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimUintBaseCmd(interp, argc, argv, UINT16_MAX, Jim_NewUint16);
-}
-
-static int JimInt32Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimIntBaseCmd(interp, argc, argv, INT32_MIN, INT32_MAX, Jim_NewInt32);
-}
-
-static int JimUint32Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimUintBaseCmd(interp, argc, argv, UINT32_MAX, Jim_NewUint32);
-}
+JIMINTCMD(JimInt32Cmd, INT32_MIN, INT32_MAX, Jim_NewInt32)
+JIMUINTCMD(JimUint32Cmd, UINT32_MAX, Jim_NewUint32);
 
 #if INT64_MAX <= JIM_WIDE_MAX
-
-static int JimInt64Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimIntBaseCmd(interp, argc, argv, INT64_MIN, INT64_MAX, Jim_NewInt64);
-}
-
-static int JimUint64Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimUintBaseCmd(interp, argc, argv, UINT64_MAX, Jim_NewUint64);
-}
-
+JIMINTCMD(JimInt64Cmd, INT64_MIN, INT64_MAX, Jim_NewInt64)
+JIMUINTCMD(JimUint64Cmd, UINT64_MAX, Jim_NewUint64);
 #endif
 
 static int JimCharCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -822,40 +633,16 @@ static int JimCharCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     return JIM_OK;
 }
 
-static int JimUcharCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimUintBaseCmd(interp, argc, argv, UCHAR_MAX, Jim_NewUchar);
-}
+JIMUINTCMD(JimUcharCmd, UCHAR_MAX, Jim_NewUchar);
 
-static int JimShortCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimIntBaseCmd(interp, argc, argv, SHRT_MIN, SHRT_MAX, Jim_NewShort);
-}
+JIMINTCMD(JimShortCmd, SHRT_MIN, SHRT_MAX, Jim_NewShort)
+JIMUINTCMD(JimUshortCmd, USHRT_MAX, Jim_NewUshort)
 
-static int JimUshortCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimUintBaseCmd(interp, argc, argv, USHRT_MAX, Jim_NewUshort);
-}
+JIMINTCMD(JimIntCmd, INT_MIN, INT_MAX, Jim_NewInt)
+JIMUINTCMD(JimUintCmd, UINT_MAX, Jim_NewUint)
 
-static int JimIntCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimIntBaseCmd(interp, argc, argv, INT_MIN, INT_MAX, Jim_NewInt);
-}
-
-static int JimUintCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimUintBaseCmd(interp, argc, argv, UINT_MAX, Jim_NewUint);
-}
-
-static int JimLongCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimIntBaseCmd(interp, argc, argv, LONG_MIN, LONG_MAX, Jim_NewLong);
-}
-
-static int JimUlongCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return JimUintBaseCmd(interp, argc, argv, ULONG_MAX, Jim_NewUlong);
-}
+JIMINTCMD(JimLongCmd, LONG_MIN, LONG_MAX, Jim_NewLong)
+JIMUINTCMD(JimUlongCmd, ULONG_MAX, Jim_NewUlong)
 
 /* float commands */
 

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -125,18 +125,6 @@ static struct ffi_var zero_var;
 static struct ffi_var one_var;
 static Jim_Obj *main_obj;
 
-/* common functions */
-
-static int JimAddress(Jim_Interp *interp, const void *p)
-{
-    char buf[32];
-
-    sprintf(buf, "%p", p);
-    Jim_SetResultString(interp, buf, -1);
-
-    return JIM_OK;
-}
-
 /* variable methods */
 
 static void JimVariableDelProc(Jim_Interp *interp, void *privData)
@@ -158,9 +146,13 @@ static int JimVariableValue(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
 static int JimVariableAddress(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
+    char buf[32];
     struct ffi_var *var = Jim_CmdPrivData(interp);
 
-    return JimAddress(interp, var->addr);
+    sprintf(buf, "%p", var->addr);
+    Jim_SetResultString(interp, buf, -1);
+
+    return JIM_OK;
 }
 
 static int JimVariableSize(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -230,7 +222,7 @@ static int JimVariableHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *cons
     return Jim_CallSubCmd(interp, Jim_ParseSubCmd(interp, variable_command_table, argc, argv), argc, argv);
 }
 
-static struct ffi_var *Jim_NewVariableBase(Jim_Interp *interp, const char *name)
+static struct ffi_var *JimNewVariableBase(Jim_Interp *interp, const char *name)
 {
     char buf[32];
     struct ffi_var *var;
@@ -246,12 +238,12 @@ static struct ffi_var *Jim_NewVariableBase(Jim_Interp *interp, const char *name)
 
 /* common int methods */
 
-#define JIM_NEWINT(func_name, tcl_name, val_memb, c_type, ffi_type, to_str_func) \
+#define JIMNEWINT(func_name, tcl_name, val_memb, c_type, ffi_type, to_str_func) \
 static void func_name(Jim_Interp *interp, const jim_wide val) \
 {                                                             \
     struct ffi_var *var;                                      \
                                                               \
-    var = Jim_NewVariableBase(interp, tcl_name);              \
+    var = JimNewVariableBase(interp, tcl_name);               \
                                                               \
     var->val.val_memb = (c_type)val;                          \
     var->type = &(ffi_type);                                  \
@@ -262,75 +254,75 @@ static void func_name(Jim_Interp *interp, const jim_wide val) \
 
 /* {u,}int8 methods */
 
-static void Jim_Int8ToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimInt8ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.i8);
 }
 
-JIM_NEWINT(Jim_NewInt8, "int8", i8, int8_t, ffi_type_sint8, Jim_Int8ToStr)
+JIMNEWINT(JimNewInt8, "int8", i8, int8_t, ffi_type_sint8, JimInt8ToStr)
 
-static void Jim_Uint8ToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimUint8ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ui8);
 }
 
-JIM_NEWINT(Jim_NewUint8, "uint8", ui8, uint8_t, ffi_type_uint8, Jim_Uint8ToStr)
+JIMNEWINT(JimNewUint8, "uint8", ui8, uint8_t, ffi_type_uint8, JimUint8ToStr)
 
 /* {u,}int16 methods */
 
-static void Jim_Int16ToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimInt16ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.i16);
 }
 
-JIM_NEWINT(Jim_NewInt16, "int16", i16, int16_t, ffi_type_sint16, Jim_Int16ToStr)
+JIMNEWINT(JimNewInt16, "int16", i16, int16_t, ffi_type_sint16, JimInt16ToStr)
 
-static void Jim_Uint16ToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimUint16ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ui16);
 }
 
-JIM_NEWINT(Jim_NewUint16, "uint16", ui16, uint16_t, ffi_type_uint16, Jim_Uint16ToStr)
+JIMNEWINT(JimNewUint16, "uint16", ui16, uint16_t, ffi_type_uint16, JimUint16ToStr)
 
 /* {u,}int32 methods */
 
-static void Jim_Int32ToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimInt32ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.i32);
 }
 
-JIM_NEWINT(Jim_NewInt32, "int32", i32, int32_t, ffi_type_sint32, Jim_Int32ToStr)
+JIMNEWINT(JimNewInt32, "int32", i32, int32_t, ffi_type_sint32, JimInt32ToStr)
 
-static void Jim_Uint32ToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimUint32ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ui32);
 }
 
-JIM_NEWINT(Jim_NewUint32, "uint32", ui32, uint32_t, ffi_type_uint32, Jim_Uint32ToStr)
+JIMNEWINT(JimNewUint32, "uint32", ui32, uint32_t, ffi_type_uint32, JimUint32ToStr)
 
 /* {u,}int64 methods */
 
 #if INT64_MAX <= JIM_WIDE_MAX
 
-static void Jim_Int64ToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimInt64ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.i64);
 }
 
-JIM_NEWINT(Jim_NewInt64, "int64", i64, int64_t, ffi_type_sint64, Jim_Int64ToStr)
+JIMNEWINT(JimNewInt64, "int64", i64, int64_t, ffi_type_sint64, JimInt64ToStr)
 
-static void Jim_Uint64ToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimUint64ToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ui64);
 }
 
-JIM_NEWINT(Jim_NewUint64, "uint64", ui64, uint64_t, ffi_type_uint64, Jim_Uint64ToStr)
+JIMNEWINT(JimNewUint64, "uint64", ui64, uint64_t, ffi_type_uint64, JimUint64ToStr)
 
 #endif
 
 /* char methods */
 
-static void Jim_CharToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimCharToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     char buf[2];
 
@@ -340,44 +332,44 @@ static void Jim_CharToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultString(interp, buf, 1);
 }
 
-JIM_NEWINT(Jim_NewChar, "char", c, char, ffi_type_schar, Jim_CharToStr)
+JIMNEWINT(JimNewChar, "char", c, char, ffi_type_schar, JimCharToStr)
 
-static void Jim_UcharToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimUcharToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     /* uchar objects are represented as Tcl integers */
     Jim_SetResultInt(interp, (jim_wide)var->val.uc);
 }
 
-JIM_NEWINT(Jim_NewUchar, "uchar", uc, unsigned char, ffi_type_uchar, Jim_UcharToStr)
+JIMNEWINT(JimNewUchar, "uchar", uc, unsigned char, ffi_type_uchar, JimUcharToStr)
 
 /* short methods */
 
-static void Jim_ShortToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimShortToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.s);
 }
 
-JIM_NEWINT(Jim_NewShort, "short", s, short, ffi_type_sshort, Jim_ShortToStr)
+JIMNEWINT(JimNewShort, "short", s, short, ffi_type_sshort, JimShortToStr)
 
-static void Jim_UshortToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimUshortToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.us);
 }
 
-JIM_NEWINT(Jim_NewUshort, "ushort", us, unsigned short, ffi_type_ushort, Jim_UshortToStr)
+JIMNEWINT(JimNewUshort, "ushort", us, unsigned short, ffi_type_ushort, JimUshortToStr)
 
 /* int methods */
 
-static void Jim_IntToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimIntToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.i);
 }
 
-JIM_NEWINT(Jim_NewInt, "int", i, int, ffi_type_sint, Jim_IntToStr)
+JIMNEWINT(JimNewInt, "int", i, int, ffi_type_sint, JimIntToStr)
 
 /* needed for statically-allocated int objects - we use it for global
  * constants */
-static void Jim_NewIntNoAlloc(Jim_Interp *interp,
+static void JimNewIntNoAlloc(Jim_Interp *interp,
                               struct ffi_var *var,
                               const jim_wide val,
                               char *buf)
@@ -387,37 +379,37 @@ static void Jim_NewIntNoAlloc(Jim_Interp *interp,
 
     var->val.i = (int)val;
     var->type = &ffi_type_sint;
-    var->to_str = Jim_IntToStr;
+    var->to_str = JimIntToStr;
     var->addr = &var->val.i;
     var->size = sizeof(var->val.i);
 }
 
-static void Jim_UintToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimUintToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ui);
 }
 
-JIM_NEWINT(Jim_NewUint, "uint", ui, unsigned int, ffi_type_uint, Jim_UintToStr)
+JIMNEWINT(JimNewUint, "uint", ui, unsigned int, ffi_type_uint, JimUintToStr)
 
 /* long methods */
 
-static void Jim_LongToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimLongToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.l);
 }
 
-JIM_NEWINT(Jim_NewLong, "long", l, long, ffi_type_slong, Jim_LongToStr)
+JIMNEWINT(JimNewLong, "long", l, long, ffi_type_slong, JimLongToStr)
 
-static void Jim_UlongToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimUlongToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResultInt(interp, (jim_wide)var->val.ul);
 }
 
-JIM_NEWINT(Jim_NewUlong, "ulong", ul, unsigned long, ffi_type_ulong, Jim_UlongToStr)
+JIMNEWINT(JimNewUlong, "ulong", ul, unsigned long, ffi_type_ulong, JimUlongToStr)
 
 /* float methods */
 
-static void Jim_FloatToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimFloatToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     char buf[JIM_DOUBLE_SPACE + 1];
 
@@ -425,22 +417,22 @@ static void Jim_FloatToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultString(interp, buf, -1);
 }
 
-static void Jim_NewFloat(Jim_Interp *interp, const float val)
+static void JimNewFloat(Jim_Interp *interp, const float val)
 {
     struct ffi_var *var;
 
-    var = Jim_NewVariableBase(interp, "float");
+    var = JimNewVariableBase(interp, "float");
 
     var->val.f = val;
     var->type = &ffi_type_float;
-    var->to_str = Jim_FloatToStr;
+    var->to_str = JimFloatToStr;
     var->addr = &var->val.f;
     var->size = sizeof(var->val.f);
 }
 
 /* double methods */
 
-static void Jim_DoubleToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimDoubleToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     char buf[JIM_DOUBLE_SPACE + 1];
 
@@ -448,22 +440,22 @@ static void Jim_DoubleToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultString(interp, buf, -1);
 }
 
-static void Jim_NewDouble(Jim_Interp *interp, const double val)
+static void JimNewDouble(Jim_Interp *interp, const double val)
 {
     struct ffi_var *var;
 
-    var = Jim_NewVariableBase(interp, "double");
+    var = JimNewVariableBase(interp, "double");
 
     var->val.d = (double)val;
     var->type = &ffi_type_double;
-    var->to_str = Jim_DoubleToStr;
+    var->to_str = JimDoubleToStr;
     var->addr = &var->val.d;
     var->size = sizeof(var->val.d);
 }
 
 /* pointer methods */
 
-static void Jim_PointerToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimPointerToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     char buf[32];
 
@@ -475,34 +467,38 @@ static void Jim_PointerToStr(Jim_Interp *interp, const struct ffi_var *var)
         sprintf(buf, "%p", var->val.vp);
         Jim_SetResultString(interp, buf, -1);
     }
+
+    return JIM_OK;
 }
 
-/* like Jim_NewIntNoAlloc, this one is used for constants */
-static void Jim_NewPointerNoAlloc(Jim_Interp *interp,
-                                  struct ffi_var *var,
-                                  void *p,
-                                  char *buf,
-                                  void (*del)(Jim_Interp *, void *))
+/* like JimNewIntNoAlloc, this one is used for constants */
+static void JimNewPointerNoAlloc(Jim_Interp *interp,
+                                 struct ffi_var *var,
+                                 void *p,
+                                 char *buf,
+                                 void (*del)(Jim_Interp *, void *))
 {
     sprintf(buf, "ffi.pointer%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimVariableHandlerCommand, var, del);
 
     var->val.vp = p;
     var->type = &ffi_type_pointer;
-    var->to_str = Jim_PointerToStr;
+    var->to_str = JimPointerToStr;
     var->addr = &var->val.vp;
     var->size = sizeof(var->val.vp);
 }
 
-static void Jim_NewPointer(Jim_Interp *interp, void *p)
+static void JimNewPointer(Jim_Interp *interp, void *p)
 {
-    char buf[32];
     struct ffi_var *var;
 
-    var = Jim_Alloc(sizeof(*var));
+    var = JimNewVariableBase(interp, "pointer");
 
-    Jim_NewPointerNoAlloc(interp, var, p, buf, JimVariableDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+    var->val.vp = p;
+    var->type = &ffi_type_pointer;
+    var->to_str = JimPointerToStr;
+    var->addr = &var->val.vp;
+    var->size = sizeof(var->val.vp);
 }
 
 /* buffer methods */
@@ -517,13 +513,13 @@ static void JimBufferDelProc(Jim_Interp *interp, void *privData)
     JimVariableDelProc(interp, privData);
 }
 
-static void Jim_BufferToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimBufferToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     /* dangerous - we assume the string is null-terminated */
     Jim_SetResultString(interp, var->val.vp, -1);
 }
 
-static void Jim_NewBuffer(Jim_Interp *interp, void *p, const size_t size)
+static void JimNewBuffer(Jim_Interp *interp, void *p, const size_t size)
 {
     char buf[32];
     struct ffi_var *var;
@@ -536,7 +532,7 @@ static void Jim_NewBuffer(Jim_Interp *interp, void *p, const size_t size)
 
     var->val.vp = p;
     var->type = &ffi_type_pointer;
-    var->to_str = Jim_BufferToStr;
+    var->to_str = JimBufferToStr;
     var->addr = &var->val.vp;
     /* the size of a buffer object is not determined by the value (i.e pointer)
      * size */
@@ -590,18 +586,18 @@ static int func_name(Jim_Interp *interp, int argc, Jim_Obj *const *argv) \
     return JimIntBaseCmd(interp, argc, argv, 0, max, new_func);          \
 }
 
-JIMINTCMD(JimInt8Cmd, INT8_MIN, INT8_MAX, Jim_NewInt8)
-JIMUINTCMD(JimUint8Cmd, UINT8_MAX, Jim_NewUint8);
+JIMINTCMD(JimInt8Cmd, INT8_MIN, INT8_MAX, JimNewInt8)
+JIMUINTCMD(JimUint8Cmd, UINT8_MAX, JimNewUint8);
 
-JIMINTCMD(JimInt16Cmd, INT16_MIN, INT16_MAX, Jim_NewInt16)
-JIMUINTCMD(JimUint16Cmd, UINT16_MAX, Jim_NewUint16);
+JIMINTCMD(JimInt16Cmd, INT16_MIN, INT16_MAX, JimNewInt16)
+JIMUINTCMD(JimUint16Cmd, UINT16_MAX, JimNewUint16);
 
-JIMINTCMD(JimInt32Cmd, INT32_MIN, INT32_MAX, Jim_NewInt32)
-JIMUINTCMD(JimUint32Cmd, UINT32_MAX, Jim_NewUint32);
+JIMINTCMD(JimInt32Cmd, INT32_MIN, INT32_MAX, JimNewInt32)
+JIMUINTCMD(JimUint32Cmd, UINT32_MAX, JimNewUint32);
 
 #if INT64_MAX <= JIM_WIDE_MAX
-JIMINTCMD(JimInt64Cmd, INT64_MIN, INT64_MAX, Jim_NewInt64)
-JIMUINTCMD(JimUint64Cmd, UINT64_MAX, Jim_NewUint64);
+JIMINTCMD(JimInt64Cmd, INT64_MIN, INT64_MAX, JimNewInt64)
+JIMUINTCMD(JimUint64Cmd, UINT64_MAX, JimNewUint64);
 #endif
 
 static int JimCharCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -629,20 +625,20 @@ static int JimCharCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    Jim_NewChar(interp, c);
+    JimNewChar(interp, c);
     return JIM_OK;
 }
 
-JIMUINTCMD(JimUcharCmd, UCHAR_MAX, Jim_NewUchar);
+JIMUINTCMD(JimUcharCmd, UCHAR_MAX, JimNewUchar);
 
-JIMINTCMD(JimShortCmd, SHRT_MIN, SHRT_MAX, Jim_NewShort)
-JIMUINTCMD(JimUshortCmd, USHRT_MAX, Jim_NewUshort)
+JIMINTCMD(JimShortCmd, SHRT_MIN, SHRT_MAX, JimNewShort)
+JIMUINTCMD(JimUshortCmd, USHRT_MAX, JimNewUshort)
 
-JIMINTCMD(JimIntCmd, INT_MIN, INT_MAX, Jim_NewInt)
-JIMUINTCMD(JimUintCmd, UINT_MAX, Jim_NewUint)
+JIMINTCMD(JimIntCmd, INT_MIN, INT_MAX, JimNewInt)
+JIMUINTCMD(JimUintCmd, UINT_MAX, JimNewUint)
 
-JIMINTCMD(JimLongCmd, LONG_MIN, LONG_MAX, Jim_NewLong)
-JIMUINTCMD(JimUlongCmd, ULONG_MAX, Jim_NewUlong)
+JIMINTCMD(JimLongCmd, LONG_MIN, LONG_MAX, JimNewLong)
+JIMUINTCMD(JimUlongCmd, ULONG_MAX, JimNewUlong)
 
 /* float commands */
 
@@ -678,7 +674,7 @@ static int JimFloatCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    Jim_NewFloat(interp, (float)val);
+    JimNewFloat(interp, (float)val);
     return JIM_OK;
 }
 
@@ -690,7 +686,7 @@ static int JimDoubleCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    Jim_NewDouble(interp, val);
+    JimNewDouble(interp, val);
     return JIM_OK;
 }
 
@@ -715,7 +711,7 @@ static int JimPointerCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
             return JIM_ERR;
     }
 
-    Jim_NewPointer(interp, (void *)(intptr_t)val);
+    JimNewPointer(interp, (void *)(intptr_t)val);
 
     return JIM_OK;
 }
@@ -769,7 +765,7 @@ static int JimStringCopy(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     /* in "copy" mode, copy the string into a new buffer object */
     s = (char *)Jim_GetString(argv[0], &len);
-    Jim_NewBuffer(interp, (void *)Jim_StrDupLen(s, len), (size_t) len);
+    JimNewBuffer(interp, (void *)Jim_StrDupLen(s, len), (size_t) len);
 
     return JIM_OK;
 }
@@ -816,13 +812,13 @@ static int JimBufferCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    Jim_NewBuffer(interp, Jim_Alloc((int)len), (size_t)len);
+    JimNewBuffer(interp, Jim_Alloc((int)len), (size_t)len);
     return JIM_OK;
 }
 
 /* misc. commands */
 
-static void Jim_VoidToStr(Jim_Interp *interp, const struct ffi_var *var)
+static void JimVoidToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     /* void objects are represented as empty strings */
     Jim_SetResult(interp, Jim_NewEmptyStringObj(interp));
@@ -830,7 +826,6 @@ static void Jim_VoidToStr(Jim_Interp *interp, const struct ffi_var *var)
 
 static int JimVoidCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    char buf[32];
     struct ffi_var *var;
 
     if (argc != 1) {
@@ -838,15 +833,12 @@ static int JimVoidCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    var = Jim_Alloc(sizeof(*var));
+    var = JimNewVariableBase(interp, "void");
+
     var->type = &ffi_type_void;
-    var->to_str = Jim_VoidToStr;
+    var->to_str = JimVoidToStr;
     var->addr = NULL;
     var->size = 0;
-
-    sprintf(buf, "ffi.void%ld", Jim_GetId(interp));
-    Jim_CreateCommand(interp, buf, JimVariableHandlerCommand, var, JimVariableDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 
     return JIM_OK;
 }
@@ -864,34 +856,34 @@ static void JimStructDelProc(Jim_Interp *interp, void *privData)
     Jim_Free(s);
 }
 
-static void Jim_RawValueToObj(Jim_Interp *interp, void *p, const ffi_type *type)
+static void JimRawValueToObj(Jim_Interp *interp, void *p, const ffi_type *type)
 {
     if (type == &ffi_type_pointer) {
-        Jim_NewPointer(interp, *((void **) p));
+        JimNewPointer(interp, *((void **) p));
     /* ffi_type_sint, ffi_type_slong, etc' are #defines of the fixed-width
      * integer types */
 #if INT64_MAX <= JIM_WIDE_MAX
     } else if (type == &ffi_type_uint64) {
-        Jim_NewUint64(interp, (jim_wide)(*((uint64_t *)p)));
+        JimNewUint64(interp, (jim_wide)(*((uint64_t *)p)));
     } else if (type == &ffi_type_sint64) {
-        Jim_NewInt64(interp, (jim_wide)(*((int64_t *)p)));
+        JimNewInt64(interp, (jim_wide)(*((int64_t *)p)));
 #endif
     } else if (type == &ffi_type_uint32) {
-        Jim_NewUint32(interp, (jim_wide)(*((uint32_t *)p)));
+        JimNewUint32(interp, (jim_wide)(*((uint32_t *)p)));
     } else if (type == &ffi_type_sint32) {
-        Jim_NewInt32(interp, (jim_wide)(*((int32_t *)p)));
+        JimNewInt32(interp, (jim_wide)(*((int32_t *)p)));
     } else if (type == &ffi_type_uint16) {
-        Jim_NewUint16(interp, (jim_wide)(*((uint16_t *)p)));
+        JimNewUint16(interp, (jim_wide)(*((uint16_t *)p)));
     } else if (type == &ffi_type_sint16) {
-        Jim_NewInt16(interp, (jim_wide)(*((int16_t *)p)));
+        JimNewInt16(interp, (jim_wide)(*((int16_t *)p)));
     } else if (type == &ffi_type_uint8) {
-        Jim_NewUint8(interp, (jim_wide)(*((uint8_t *)p)));
+        JimNewUint8(interp, (jim_wide)(*((uint8_t *)p)));
     } else if (type == &ffi_type_sint8) {
-        Jim_NewInt8(interp, (jim_wide)(*((int8_t *)p)));
+        JimNewInt8(interp, (jim_wide)(*((int8_t *)p)));
     } else if (type == &ffi_type_float) {
-        Jim_NewFloat(interp, (*((float *)p)));
+        JimNewFloat(interp, (*((float *)p)));
     } else { /* raw values cannot be of type void */
-        Jim_NewDouble(interp, (*((double *)p)));
+        JimNewDouble(interp, (*((double *)p)));
     }
 }
 
@@ -911,7 +903,7 @@ static int JimStructMember(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     }
 
     /* create a Tcl representation of the member value */
-    Jim_RawValueToObj(interp,
+    JimRawValueToObj(interp,
                       s->buf + s->offs[memb],
                       s->type.elements[memb]);
 
@@ -920,9 +912,13 @@ static int JimStructMember(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
 static int JimStructAddress(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
+    char buf[32];
     struct ffi_struct *s = Jim_CmdPrivData(interp);
 
-    return JimAddress(interp, s->buf);
+    sprintf(buf, "%p", s->buf);
+    Jim_SetResultString(interp, buf, -1);
+
+    return JIM_OK;
 }
 
 static int JimStructSize(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -1067,7 +1063,7 @@ static int JimFunctionHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *cons
     args = Jim_Alloc(sizeof(void *) * nargs);
 
     s = Jim_String(argv[1]);
-    /* see the comment Jim_PointerToStr() - NULL is a special case */
+    /* see the comment JimPointerToStr() - NULL is a special case */
     if (sscanf(s, "%p", &ret) != 1) {
         Jim_SetResultFormatted(interp, "bad pointer: %s", s);
         return JIM_ERR;
@@ -1280,7 +1276,7 @@ static int JimCastCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    Jim_RawValueToObj(interp, p, type_structs[i]);
+    JimRawValueToObj(interp, p, type_structs[i]);
 
     return JIM_OK;
 }
@@ -1342,17 +1338,17 @@ int Jim_ffiInit(Jim_Interp *interp)
         return JIM_ERR;
     }
 
-    Jim_NewPointerNoAlloc(interp, &null_var, NULL, buf, NULL);
+    JimNewPointerNoAlloc(interp, &null_var, NULL, buf, NULL);
     if (Jim_SetVariable(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, "null", -1)), Jim_NewStringObj(interp, buf, -1)) != JIM_OK) {
         return JIM_ERR;
     }
 
-    Jim_NewIntNoAlloc(interp, &zero_var, 0, buf);
+    JimNewIntNoAlloc(interp, &zero_var, 0, buf);
     if (Jim_SetVariable(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, "zero", -1)), Jim_NewStringObj(interp, buf, -1)) != JIM_OK) {
         return JIM_ERR;
     }
 
-    Jim_NewIntNoAlloc(interp, &one_var, 1, buf);
+    JimNewIntNoAlloc(interp, &one_var, 1, buf);
     if (Jim_SetVariable(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, "one", -1)), Jim_NewStringObj(interp, buf, -1)) != JIM_OK) {
         return JIM_ERR;
     }

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -35,6 +35,7 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <dlfcn.h>
+#include <string.h>
 
 #include <ffi.h>
 
@@ -57,6 +58,13 @@ struct ffi_var {
     void *addr;
 };
 
+struct ffi_struct {
+    ffi_type type;
+    int size;
+    int nmemb;
+    unsigned char *buf;
+};
+
 struct ffi_func {
     ffi_cif cif;
     ffi_type *rtype;
@@ -64,7 +72,7 @@ struct ffi_func {
     void *p;
 };
 
-static int JimVarHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv);
+/* variable methods */
 
 static void JimVarDelProc(Jim_Interp *interp, void *privData)
 {
@@ -74,38 +82,15 @@ static void JimVarDelProc(Jim_Interp *interp, void *privData)
     Jim_Free(var);
 }
 
-static void Jim_PointerToStr(Jim_Interp *interp, const struct ffi_var *var)
-{
-    char buf[32];
-
-    sprintf(buf, "%p", var->val.vp);
-    Jim_SetResultString(interp, buf, -1);
-}
-
-static void Jim_NewPointer(Jim_Interp *interp, void *p)
-{
-    char buf[32];
-    struct ffi_var *var;
-
-    var = Jim_Alloc(sizeof(struct ffi_var));
-
-    sprintf(buf, "ffi.pointer%ld", Jim_GetId(interp));
-    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimVarDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
-
-    var->val.vp = p;
-    var->type = &ffi_type_pointer;
-    var->to_str = Jim_PointerToStr;
-    var->addr = &var->val.vp;
-}
-
 static int JimVarHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     char buf[32];
-    static const char * const options[] = { "value", "address", NULL };
+    static const char * const options[] = {
+        "value", "address", "size", "raw", NULL
+    };
     struct ffi_var *var = Jim_CmdPrivData(interp);
     int option;
-    enum { OPT_VALUE, OPT_ADDRESS };
+    enum { OPT_VALUE, OPT_ADDRESS, OPT_SIZE, OPT_RAW };
 
     if (argc != 2) {
         Jim_WrongNumArgs(interp, 1, argv, "method ?args ...?");
@@ -125,32 +110,232 @@ static int JimVarHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
         sprintf(buf, "%p", var->addr);
         Jim_SetResultString(interp, buf, -1);
         return JIM_OK;
+
+    case OPT_SIZE:
+        if (var->type->size > INT_MAX) {
+            Jim_SetResultFormatted(interp, "bad variable size for: %#s", argv[1]);
+            return JIM_ERR;
+        }
+        Jim_SetResultInt(interp, (int) var->type->size);
+        return JIM_OK;
+
+    case OPT_RAW:
+        if (var->type->size > INT_MAX) {
+            Jim_SetResultFormatted(interp, "bad variable size for: %#s", argv[1]);
+            return JIM_ERR;
+        }
+        Jim_SetResultString(interp, (char *) var->addr, (int) var->type->size);
+        return JIM_OK;
     }
 
     return JIM_ERR;
 }
 
+/* common int methods */
+
+static struct ffi_var *Jim_NewIntBase(Jim_Interp *interp, const char *name)
+{
+    char buf[32];
+    struct ffi_var *var;
+
+    var = Jim_Alloc(sizeof(*var));
+
+    sprintf(buf, "ffi.%s%ld", name, Jim_GetId(interp));
+    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimVarDelProc);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+
+    return var;
+}
+
+/* short methods */
+
+static void Jim_ShortToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.s);
+}
+
+static void Jim_NewShort(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "short");
+
+    var->val.s = (short) val;
+    var->type = &ffi_type_sshort;
+    var->to_str = Jim_ShortToStr;
+    var->addr = &var->val.s;
+}
+
+static void Jim_UshortToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.us);
+}
+
+static void Jim_NewUshort(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "ushort");
+
+    var->val.us = (unsigned short) val;
+    var->type = &ffi_type_ushort;
+    var->to_str = Jim_UshortToStr;
+    var->addr = &var->val.us;
+}
+
+/* int methods */
+
+static void Jim_IntToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.i);
+}
+
+static void Jim_NewInt(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "int");
+
+    var->val.i = (int) val;
+    var->type = &ffi_type_sint;
+    var->to_str = Jim_IntToStr;
+    var->addr = &var->val.i;
+}
+
+static void Jim_UintToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.ui);
+}
+
+static void Jim_NewUint(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "uint");
+
+    var->val.ui = (unsigned int) val;
+    var->type = &ffi_type_uint;
+    var->to_str = Jim_UintToStr;
+    var->addr = &var->val.ui;
+}
+
+/* long methods */
+
+static void Jim_LongToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.l);
+}
+
+static void Jim_NewLong(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "long");
+
+    var->val.l = (long) val;
+    var->type = &ffi_type_slong;
+    var->to_str = Jim_LongToStr;
+    var->addr = &var->val.l;
+}
+
+static void Jim_UlongToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.ul);
+}
+
+static void Jim_NewUlong(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "ulong");
+
+    var->val.ul = (unsigned long) val;
+    var->type = &ffi_type_ulong;
+    var->to_str = Jim_UlongToStr;
+    var->addr = &var->val.ul;
+}
+
+/* pointer methods */
+
+static void Jim_PointerToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    char buf[32];
+
+    sprintf(buf, "%p", var->val.vp);
+    Jim_SetResultString(interp, buf, -1);
+}
+
+static void Jim_NewPointer(Jim_Interp *interp, void *p)
+{
+    char buf[32];
+    struct ffi_var *var;
+
+    var = Jim_Alloc(sizeof(*var));
+
+    sprintf(buf, "ffi.pointer%ld", Jim_GetId(interp));
+    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimVarDelProc);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+
+    var->val.vp = p;
+    var->type = &ffi_type_pointer;
+    var->to_str = Jim_PointerToStr;
+    var->addr = &var->val.vp;
+}
+
+/* buffer methods */
+
+static void JimBufferDelProc(Jim_Interp *interp, void *privData)
+{
+    struct ffi_var *var = privData;
+
+    JIM_NOTUSED(interp);
+    Jim_Free(var->val.vp);
+    JimVarDelProc(interp, privData);
+}
+
+static void Jim_BufferToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultString(interp, var->val.vp, -1);
+}
+
+static void Jim_NewBuffer(Jim_Interp *interp, void *p)
+{
+    char buf[32];
+    struct ffi_var *var;
+
+    var = Jim_Alloc(sizeof(*var));
+
+    sprintf(buf, "ffi.buffer%ld", Jim_GetId(interp));
+    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimBufferDelProc);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+
+    var->val.vp = p;
+    var->type = &ffi_type_pointer;
+    var->to_str = Jim_BufferToStr;
+    var->addr = &var->val.vp;
+}
+
+/* int commands */
+
 static int JimIntBaseCmd(Jim_Interp *interp,
                          int argc,
                          Jim_Obj *const *argv,
-                         const char *name,
                          const long min,
                          const long max,
-                         struct ffi_var **var,
-                         jim_wide *val)
+                         void (*new_obj)(Jim_Interp *, const jim_wide))
 {
-    char buf[32];
+    jim_wide val;
 
     switch (argc) {
     case 1:
         break;
 
     case 2:
-        if (Jim_GetWide(interp, argv[1], val) != JIM_OK) {
+        if (Jim_GetWide(interp, argv[1], &val) != JIM_OK) {
             return JIM_ERR;
         }
-        if ((*val < min) || (*val > max)) {
-            Jim_SetResultFormatted(interp, "bad %s value: %#s", name, argv[1]);
+        if ((val < min) || (val > max)) {
+            Jim_SetResultFormatted(interp, "bad integer value: %#s", argv[1]);
             return JIM_ERR;
         }
         break;
@@ -160,157 +345,50 @@ static int JimIntBaseCmd(Jim_Interp *interp,
         return JIM_ERR;
     }
 
-    *var = Jim_Alloc(sizeof(struct ffi_var));
-
-    sprintf(buf, "ffi.%s%ld", name, Jim_GetId(interp));
-    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, *var, JimVarDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
-
+    new_obj(interp, val);
     return JIM_OK;
 }
 
 static int JimUintBaseCmd(Jim_Interp *interp,
                           int argc,
                           Jim_Obj *const *argv,
-                          const char *name,
                           const long max,
-                          struct ffi_var **var,
-                          jim_wide *val)
+                          void (*new_obj)(Jim_Interp *, const jim_wide))
 {
-    return JimIntBaseCmd(interp, argc, argv, name, 0, max, var, val);
-}
-
-static void Jim_ShortToStr(Jim_Interp *interp, const struct ffi_var *var)
-{
-    Jim_SetResultInt(interp, (jim_wide) var->val.s);
+    return JimIntBaseCmd(interp, argc, argv, 0, max, new_obj);
 }
 
 static int JimShortCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    jim_wide val;
-    struct ffi_var *var;
-
-    if (JimIntBaseCmd(interp, argc, argv, "short", SHRT_MIN, SHRT_MAX, &var, &val) != JIM_OK) {
-        return JIM_ERR;
-    }
-
-    var->val.s = (short) val;
-    var->type = &ffi_type_sshort;
-    var->to_str = Jim_ShortToStr;
-    var->addr = &var->val.s;
-
-    return JIM_OK;
-}
-
-static void Jim_UshortToStr(Jim_Interp *interp, const struct ffi_var *var)
-{
-    Jim_SetResultInt(interp, (jim_wide) var->val.us);
+    return JimIntBaseCmd(interp, argc, argv, SHRT_MIN, SHRT_MAX, Jim_NewShort);
 }
 
 static int JimUshortCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    jim_wide val;
-    struct ffi_var *var;
-
-    if (JimUintBaseCmd(interp, argc, argv, "ushort", USHRT_MAX, &var, &val) != JIM_OK) {
-        return JIM_ERR;
-    }
-
-    var->val.us = (unsigned short) val;
-    var->type = &ffi_type_ushort;
-    var->to_str = Jim_UshortToStr;
-    var->addr = &var->val.us;
-
-    return JIM_OK;
-}
-
-static void Jim_IntToStr(Jim_Interp *interp, const struct ffi_var *var)
-{
-    Jim_SetResultInt(interp, (jim_wide) var->val.i);
+    return JimUintBaseCmd(interp, argc, argv, USHRT_MAX, Jim_NewUshort);
 }
 
 static int JimIntCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    jim_wide val;
-    struct ffi_var *var;
-
-    if (JimIntBaseCmd(interp, argc, argv, "int", INT_MIN, INT_MAX, &var, &val) != JIM_OK) {
-        return JIM_ERR;
-    }
-
-    var->val.i = (int) val;
-    var->type = &ffi_type_sint;
-    var->to_str = Jim_IntToStr;
-    var->addr = &var->val.i;
-
-    return JIM_OK;
-}
-
-static void Jim_UintToStr(Jim_Interp *interp, const struct ffi_var *var)
-{
-    Jim_SetResultInt(interp, (jim_wide) var->val.ui);
+    return JimIntBaseCmd(interp, argc, argv, INT_MIN, INT_MAX, Jim_NewInt);
 }
 
 static int JimUintCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    jim_wide val;
-    struct ffi_var *var;
-
-    if (JimUintBaseCmd(interp, argc, argv, "uint", UINT_MAX, &var, &val) != JIM_OK) {
-        return JIM_ERR;
-    }
-
-    var->val.ui = (unsigned int) val;
-    var->type = &ffi_type_uint;
-    var->to_str = Jim_UintToStr;
-    var->addr = &var->val.ui;
-
-    return JIM_OK;
-}
-
-static void Jim_LongToStr(Jim_Interp *interp, const struct ffi_var *var)
-{
-    Jim_SetResultInt(interp, (jim_wide) var->val.l);
+    return JimUintBaseCmd(interp, argc, argv, UINT_MAX, Jim_NewUint);
 }
 
 static int JimLongCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    jim_wide val;
-    struct ffi_var *var;
-
-    if (JimIntBaseCmd(interp, argc, argv, "long", LONG_MIN, LONG_MAX, &var, &val) != JIM_OK) {
-        return JIM_ERR;
-    }
-
-    var->val.l = (long) val;
-    var->type = &ffi_type_slong;
-    var->to_str = Jim_LongToStr;
-    var->addr = &var->val.l;
-
-    return JIM_OK;
-}
-
-static void Jim_UlongToStr(Jim_Interp *interp, const struct ffi_var *var)
-{
-    Jim_SetResultInt(interp, (jim_wide) var->val.ul);
+    return JimIntBaseCmd(interp, argc, argv, LONG_MIN, LONG_MAX, Jim_NewLong);
 }
 
 static int JimUlongCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    jim_wide val;
-    struct ffi_var *var;
-
-    if (JimUintBaseCmd(interp, argc, argv, "ulong", ULONG_MAX, &var, &val) != JIM_OK) {
-        return JIM_ERR;
-    }
-
-    var->val.ul = (unsigned long) val;
-    var->type = &ffi_type_ulong;
-    var->to_str = Jim_UlongToStr;
-    var->addr = &var->val.ul;
-
-    return JIM_OK;
+    return JimUintBaseCmd(interp, argc, argv, ULONG_MAX, Jim_NewUlong);
 }
+
+/* pointer commands */
 
 static int JimPointerCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
@@ -338,34 +416,63 @@ static int JimPointerCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
 static int JimStringCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "str");
+    static const char * const options[] = { "at", "copy", NULL };
+    const char *s;
+    jim_wide addr;
+    long size;
+    int option, len;
+    enum { OPT_AT, OPT_COPY };
+
+    if (argc < 2) {
+        Jim_WrongNumArgs(interp, 1, argv, "at|copy str|addr");
         return JIM_ERR;
     }
 
-    Jim_NewPointer(interp, (void *) Jim_String(argv[1]));
+    if (Jim_GetEnum(interp, argv[1], options, &option, "ffi string method", JIM_ERRMSG) != JIM_OK) {
+        return JIM_ERR;
+    }
+
+    if (option == OPT_COPY) {
+        if (argc != 3) {
+            Jim_WrongNumArgs(interp, 1, argv, "copy str");
+            return JIM_ERR;
+        }
+
+        s = Jim_GetString(argv[2], &len);
+        Jim_NewBuffer(interp, (void *) Jim_StrDupLen(s, len));
+    } else {
+        if ((argc != 3) && (argc != 4)) {
+            Jim_WrongNumArgs(interp, 1, argv, "at addr ?size?");
+            return JIM_ERR;
+        }
+
+        if (Jim_GetWide(interp, argv[2], &addr) != JIM_OK) {
+            Jim_SetResultFormatted(interp, "bad address: %#s", argv[2]);
+            return JIM_ERR;
+        }
+
+        if (argc == 3) {
+            Jim_SetResultString(interp, (char *) (uintptr_t) addr, -1);
+        } else {
+            if (Jim_GetLong(interp, argv[3], &size) != JIM_OK) {
+                Jim_SetResultFormatted(interp, "invalid size: %#s", argv[3]);
+                return JIM_ERR;
+            }
+
+            if ((size < 0) || (size > INT_MAX)) {
+                Jim_SetResultFormatted(interp, "bad size: %#s", argv[3]);
+                return JIM_ERR;
+            }
+
+            Jim_SetResultString(interp, (char *) (uintptr_t) addr, (int) size);
+        }
+    }
 
     return JIM_OK;
 }
 
-static void Jim_BufferToStr(Jim_Interp *interp, const struct ffi_var *var)
-{
-    Jim_SetResultString(interp, var->val.vp, -1);
-}
-
-static void JimBufferDelProc(Jim_Interp *interp, void *privData)
-{
-    struct ffi_var *var = privData;
-
-    JIM_NOTUSED(interp);
-    Jim_Free(var->val.vp);
-    JimVarDelProc(interp, privData);
-}
-
 static int JimBufferCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    char buf[32];
-    struct ffi_var *var;
     long len;
 
     if (argc != 2) {
@@ -383,19 +490,11 @@ static int JimBufferCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    var = Jim_Alloc(sizeof(struct ffi_var));
-    var->val.vp = Jim_Alloc((int) len);
-    var->type = &ffi_type_pointer;
-    var->to_str = Jim_BufferToStr;
-    var->addr = &var->val.vp;
-
-    sprintf(buf, "ffi.buffer%ld", Jim_GetId(interp));
-    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimBufferDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
-
+    Jim_NewBuffer(interp, Jim_Alloc((int) len));
     return JIM_OK;
 }
 
+/* misc. commands */
 static void Jim_VoidToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResult(interp, Jim_NewEmptyStringObj(interp));
@@ -411,22 +510,179 @@ static int JimVoidCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    var = Jim_Alloc(sizeof(struct ffi_var));
+    var = Jim_Alloc(sizeof(*var));
     var->type = &ffi_type_void;
     var->to_str = Jim_VoidToStr;
     var->addr = NULL;
 
     sprintf(buf, "ffi.void%ld", Jim_GetId(interp));
-    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimBufferDelProc);
+    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimVarDelProc);
     Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 
     return JIM_OK;
 }
 
-static void JimLibraryDelProc(Jim_Interp *interp, void *privData)
+/* struct commands */
+
+static void JimStructDelProc(Jim_Interp *interp, void *privData)
 {
+    struct ffi_struct *s = privData;
+
     JIM_NOTUSED(interp);
-    dlclose(privData);
+    Jim_Free(s->buf);
+    Jim_Free(s->type.elements);
+    Jim_Free(s);
+}
+
+static int JimStructHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    char buf[32];
+    static const char * const options[] = { "member", "address", "size", NULL };
+    struct ffi_struct *s = Jim_CmdPrivData(interp);
+    size_t off;
+    long memb;
+    void *p;
+    int option, i;
+    enum { OPT_MEMBER, OPT_ADDRESS, OPT_SIZE };
+
+    if (argc < 2) {
+        Jim_WrongNumArgs(interp, 1, argv, "method ?args ...?");
+        return JIM_ERR;
+    }
+
+    if (Jim_GetEnum(interp, argv[1], options, &option, "ffi struct method", JIM_ERRMSG) != JIM_OK) {
+        return JIM_ERR;
+    }
+
+    switch (option) {
+    case OPT_MEMBER:
+        if (argc != 3) {
+            Jim_WrongNumArgs(interp, 1, argv, "index");
+            return JIM_ERR;
+        }
+
+        if (Jim_GetLong(interp, argv[2], &memb) != JIM_OK) {
+            Jim_SetResultFormatted(interp, "invalid member index: %#s", argv[2]);
+            return JIM_ERR;
+        }
+        if ((memb < 0) || ((int) memb >= s->nmemb)) {
+            Jim_SetResultFormatted(interp, "bad member index: %#s", argv[2]);
+            return JIM_ERR;
+        }
+
+        off = 0;
+        for (i = 0; i < (int) memb; ++i) {
+            off += s->type.elements[i]->size;
+        }
+
+        p = s->buf + off;
+
+        if (s->type.elements[memb] == &ffi_type_sshort) {
+            Jim_NewShort(interp, (jim_wide) (*((short *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_ushort) {
+            Jim_NewUshort(interp, (jim_wide) (*((unsigned short *) p)));
+        } if (s->type.elements[memb] == &ffi_type_sint) {
+            Jim_NewInt(interp, (jim_wide) (*((int *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_uint) {
+            Jim_NewUint(interp, (jim_wide) (*((unsigned int *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_slong) {
+            Jim_NewLong(interp, (jim_wide) (*((long *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_ulong) {
+            Jim_NewUlong(interp, (jim_wide) (*((unsigned long *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_pointer) {
+            Jim_NewPointer(interp, p);
+        }
+
+        return JIM_OK;
+
+    case OPT_ADDRESS:
+        sprintf(buf, "%p", s->buf);
+        Jim_SetResultString(interp, buf, -1);
+        return JIM_OK;
+
+    case OPT_SIZE:
+        Jim_SetResultInt(interp, s->size);
+        return JIM_OK;
+    }
+
+    return JIM_ERR;
+}
+
+static int JimStructCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    static const char * const type_names[] = {
+        "short", "ushort", "int", "uint", "long", "ulong", "pointer",  NULL
+    };
+    ffi_type *types[] = {
+        &ffi_type_sshort, &ffi_type_ushort, &ffi_type_sint, &ffi_type_uint,
+        &ffi_type_slong, &ffi_type_ulong, &ffi_type_pointer
+    };
+    char buf[32];
+    struct ffi_struct *s;
+    const char *raw;
+    int i, j, len;
+
+    if (argc < 3) {
+        Jim_WrongNumArgs(interp, 1, argv, "raw member ?member ...?");
+        return JIM_ERR;
+    }
+
+    raw = Jim_GetString(argv[1], &len);
+
+    s = Jim_Alloc(sizeof(*s));
+    s->nmemb = argc - 1;
+    s->type.elements = Jim_Alloc(sizeof(ffi_type *) * (1 + s->nmemb));
+    s->size = 0;
+
+    for (i = 2; i < argc; ++i) {
+        if (Jim_GetEnum(interp, argv[i], type_names, &j, "ffi type", JIM_ERRMSG) != JIM_OK) {
+            Jim_Free(s->type.elements);
+            Jim_Free(s);
+            return JIM_ERR;
+        }
+        s->type.elements[i - 2] = types[j];
+
+        if (s->size >= (INT_MAX - types[j]->size)) {
+            Jim_SetResultString(interp, "bad struct size", -1);
+            Jim_Free(s->type.elements);
+            Jim_Free(s);
+            return JIM_ERR;
+        }
+        s->size += types[j]->size;
+    }
+
+    if ((0 != len) && (size_t) len != s->size) {
+        Jim_SetResultFormatted(interp, "bad struct initializer: %#s", argv[1]);
+        Jim_Free(s->type.elements);
+        Jim_Free(s);
+        return JIM_ERR;
+    }
+
+    s->buf = Jim_Alloc(s->size);
+    if (0 != len) {
+        memcpy(s->buf, raw, (size_t) len);
+    }
+    s->type.size = 0;
+    s->type.alignment = 0;
+    s->type.type = FFI_TYPE_STRUCT;
+    s->type.elements[s->nmemb] = NULL;
+
+    sprintf(buf, "ffi.struct%ld", Jim_GetId(interp));
+    Jim_CreateCommand(interp, buf, JimStructHandlerCommand, s, JimStructDelProc);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+
+    return JIM_OK;
+}
+
+/* function commands */
+
+static void JimFunctionDelProc(Jim_Interp *interp, void *privData)
+{
+    struct ffi_func *f = privData;
+
+    JIM_NOTUSED(interp);
+    Jim_Free(f->atypes);
+    Jim_Free(f);
 }
 
 static int JimFunctionHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -466,13 +722,12 @@ static int JimFunctionHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *cons
     return JIM_OK;
 }
 
-static void JimFunctionDelProc(Jim_Interp *interp, void *privData)
-{
-    struct ffi_func *f = privData;
+/* library commands */
 
+static void JimLibraryDelProc(Jim_Interp *interp, void *privData)
+{
     JIM_NOTUSED(interp);
-    Jim_Free(f->atypes);
-    Jim_Free(f);
+    dlclose(privData);
 }
 
 static int JimLibraryHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -582,11 +837,12 @@ int Jim_ffiInit(Jim_Interp *interp)
     Jim_CreateCommand(interp, "ffi.ulong", JimUlongCmd, 0, 0);
 
     Jim_CreateCommand(interp, "ffi.pointer", JimPointerCmd, 0, 0);
-
     Jim_CreateCommand(interp, "ffi.string", JimStringCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.buffer", JimBufferCmd, 0, 0);
 
+    Jim_CreateCommand(interp, "ffi.buffer", JimBufferCmd, 0, 0);
     Jim_CreateCommand(interp, "ffi.void", JimVoidCmd, 0, 0);
+
+    Jim_CreateCommand(interp, "ffi.struct", JimStructCmd, 0, 0);
 
     Jim_CreateCommand(interp, "ffi.dlopen", JimDlopenCmd, 0, 0);
 

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -1,7 +1,7 @@
 /*
  * Jim - libffi bindings
  *
- * Copyright 2015 Dima Krasner <dima@dimakrasner.com>
+ * Copyright 2015, 2016 Dima Krasner <dima@dimakrasner.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -317,7 +317,7 @@ static void Jim_CharToStr(Jim_Interp *interp, const struct ffi_var *var)
 
     buf[0] = var->val.c;
     buf[1] = '\0';
-    Jim_SetResultString(interp, buf, -1);
+    Jim_SetResultString(interp, buf, 1);
 }
 
 static void Jim_NewChar(Jim_Interp *interp, const char val)

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -1403,40 +1403,40 @@ int Jim_ffiInit(Jim_Interp *interp)
         return JIM_ERR;
     }
 
-    Jim_CreateCommand(interp, "ffi.pointer", JimPointerCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::pointer", JimPointerCmd, 0, 0);
 
-    Jim_CreateCommand(interp, "ffi.ulong", JimUlongCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.long", JimLongCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.uint", JimUintCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.int", JimIntCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.ushort", JimUshortCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.short", JimShortCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.uchar", JimUcharCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.char", JimCharCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::ulong", JimUlongCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::long", JimLongCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::uint", JimUintCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::int", JimIntCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::ushort", JimUshortCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::short", JimShortCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::uchar", JimUcharCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::char", JimCharCmd, 0, 0);
 
 #if INT64_MAX <= JIM_WIDE_MAX
-    Jim_CreateCommand(interp, "ffi.uint64", JimUint64Cmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.int64", JimInt64Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::uint64", JimUint64Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::int64", JimInt64Cmd, 0, 0);
 #endif
-    Jim_CreateCommand(interp, "ffi.uint32", JimUint32Cmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.int32", JimInt32Cmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.uint16", JimUint16Cmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.int16", JimInt16Cmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.uint8", JimUint8Cmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.int8", JimInt8Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::uint32", JimUint32Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::int32", JimInt32Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::uint16", JimUint16Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::int16", JimInt16Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::uint8", JimUint8Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::int8", JimInt8Cmd, 0, 0);
 
-    Jim_CreateCommand(interp, "ffi.float", JimFloatCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.double", JimDoubleCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::float", JimFloatCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::double", JimDoubleCmd, 0, 0);
 
-    Jim_CreateCommand(interp, "ffi.string", JimStringCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.buffer", JimBufferCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::string", JimStringCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::buffer", JimBufferCmd, 0, 0);
 
-    Jim_CreateCommand(interp, "ffi.void", JimVoidCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::void", JimVoidCmd, 0, 0);
 
-    Jim_CreateCommand(interp, "ffi.struct", JimStructCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::struct", JimStructCmd, 0, 0);
 
-    Jim_CreateCommand(interp, "ffi.function", JimFunctionCmd, 0, 0);
-    Jim_CreateCommand(interp, "ffi.dlopen", JimDlopenCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::function", JimFunctionCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi::dlopen", JimDlopenCmd, 0, 0);
 
     Jim_CreateCommand(interp, "ffi.handle0", JimLibraryHandlerCommand, self, JimLibraryDelProc);
     main_obj = Jim_NewStringObj(interp, "ffi.handle0", -1);
@@ -1454,7 +1454,7 @@ int Jim_ffiInit(Jim_Interp *interp)
         return JIM_ERR;
     }
 
-    Jim_NewIntNoAlloc(interp, &one_var, 0, buf);
+    Jim_NewIntNoAlloc(interp, &one_var, 1, buf);
     if (Jim_SetVariable(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, "one", -1)), Jim_NewStringObj(interp, buf, -1)) != JIM_OK) {
         return JIM_ERR;
     }

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -181,7 +181,7 @@ static int JimVariableRaw(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     struct ffi_var *var = Jim_CmdPrivData(interp);
 
-    if (var->type->size > INT_MAX) {
+    if (var->size > INT_MAX) {
         Jim_SetResultFormatted(interp, "bad variable size for: %#s", argv[0]);
         return JIM_ERR;
     }
@@ -211,6 +211,7 @@ static const jim_subcmd_type variable_command_table[] = {
         JimVariableSize,
         0,
         0,
+        JIM_MODFLAG_FULLARGV
         /* Description: Returns the size of a variable */
     },
     {   "raw",
@@ -218,6 +219,7 @@ static const jim_subcmd_type variable_command_table[] = {
         JimVariableRaw,
         0,
         0,
+        JIM_MODFLAG_FULLARGV
         /* Description: Returns the raw value of a variable */
     }
 };

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -542,8 +542,12 @@ static void Jim_PointerToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     char buf[32];
 
-    sprintf(buf, "%p", var->val.vp);
-    Jim_SetResultString(interp, buf, -1);
+    if (var->val.vp == NULL) {
+        Jim_SetResultString(interp, "0x0", -1);
+    } else {
+        sprintf(buf, "%p", var->val.vp);
+        Jim_SetResultString(interp, buf, -1);
+    }
 }
 
 static void Jim_NewPointerBase(Jim_Interp *interp,

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -1,0 +1,594 @@
+/*
+ * Jim - libffi bindings
+ *
+ * Copyright 2015 Dima Krasner <dima@dimakrasner.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE JIM TCL PROJECT ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * JIM TCL PROJECT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * official policies, either expressed or implied, of the Jim Tcl Project.
+ */
+
+#include <inttypes.h>
+#include <limits.h>
+#include <dlfcn.h>
+
+#include <ffi.h>
+
+#include <jim.h>
+
+struct ffi_var {
+    union {
+        void *vp;
+        unsigned long ul;
+        long l;
+        unsigned int ui;
+        int i;
+        unsigned short us;
+        short s;
+        unsigned char uc;
+        char c;
+    } val;
+    ffi_type *type;
+    void (*to_str)(Jim_Interp *, const struct ffi_var *);
+    void *addr;
+};
+
+struct ffi_func {
+    ffi_cif cif;
+    ffi_type *rtype;
+    ffi_type **atypes;
+    void *p;
+};
+
+static int JimVarHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv);
+
+static void JimVarDelProc(Jim_Interp *interp, void *privData)
+{
+    struct ffi_var *var = privData;
+
+    JIM_NOTUSED(interp);
+    Jim_Free(var);
+}
+
+static void Jim_PointerToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    char buf[32];
+
+    sprintf(buf, "%p", var->val.vp);
+    Jim_SetResultString(interp, buf, -1);
+}
+
+static void Jim_NewPointer(Jim_Interp *interp, void *p)
+{
+    char buf[32];
+    struct ffi_var *var;
+
+    var = Jim_Alloc(sizeof(struct ffi_var));
+
+    sprintf(buf, "ffi.pointer%ld", Jim_GetId(interp));
+    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimVarDelProc);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+
+    var->val.vp = p;
+    var->type = &ffi_type_pointer;
+    var->to_str = Jim_PointerToStr;
+    var->addr = &var->val.vp;
+}
+
+static int JimVarHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    char buf[32];
+    static const char * const options[] = { "value", "pointer", NULL };
+    struct ffi_var *var = Jim_CmdPrivData(interp);
+    int option;
+    enum { OPT_VALUE, OPT_POINTER };
+
+    if (argc != 2) {
+        Jim_WrongNumArgs(interp, 1, argv, "method ?args ...?");
+        return JIM_ERR;
+    }
+
+    if (Jim_GetEnum(interp, argv[1], options, &option, "ffi variable method", JIM_ERRMSG) != JIM_OK) {
+        return JIM_ERR;
+    }
+
+    switch (option) {
+    case OPT_VALUE:
+        var->to_str(interp, var);
+        return JIM_OK;
+
+    case OPT_POINTER:
+        sprintf(buf, "%p", var->addr);
+        Jim_SetResultString(interp, buf, -1);
+        return JIM_OK;
+    }
+
+    return JIM_ERR;
+}
+
+static int JimIntBaseCmd(Jim_Interp *interp,
+                         int argc,
+                         Jim_Obj *const *argv,
+                         const char *name,
+                         const long min,
+                         const long max,
+                         struct ffi_var **var,
+                         jim_wide *val)
+{
+    char buf[32];
+
+    switch (argc) {
+    case 1:
+        break;
+
+    case 2:
+        if (Jim_GetWide(interp, argv[1], val) != JIM_OK) {
+            return JIM_ERR;
+        }
+        if ((*val < min) || (*val > max)) {
+            Jim_SetResultFormatted(interp, "bad %s value: %#s", name, argv[1]);
+            return JIM_ERR;
+        }
+        break;
+
+    default:
+        Jim_WrongNumArgs(interp, 1, argv, "val");
+        return JIM_ERR;
+    }
+
+    *var = Jim_Alloc(sizeof(struct ffi_var));
+
+    sprintf(buf, "ffi.%s%ld", name, Jim_GetId(interp));
+    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, *var, JimVarDelProc);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+
+    return JIM_OK;
+}
+
+static int JimUintBaseCmd(Jim_Interp *interp,
+                          int argc,
+                          Jim_Obj *const *argv,
+                          const char *name,
+                          const long max,
+                          struct ffi_var **var,
+                          jim_wide *val)
+{
+    return JimIntBaseCmd(interp, argc, argv, name, 0, max, var, val);
+}
+
+static void Jim_ShortToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.s);
+}
+
+static int JimShortCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    jim_wide val;
+    struct ffi_var *var;
+
+    if (JimIntBaseCmd(interp, argc, argv, "short", SHRT_MIN, SHRT_MAX, &var, &val) != JIM_OK) {
+        return JIM_ERR;
+    }
+
+    var->val.s = (short) val;
+    var->type = &ffi_type_sshort;
+    var->to_str = Jim_ShortToStr;
+    var->addr = &var->val.s;
+
+    return JIM_OK;
+}
+
+static void Jim_UshortToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.us);
+}
+
+static int JimUshortCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    jim_wide val;
+    struct ffi_var *var;
+
+    if (JimUintBaseCmd(interp, argc, argv, "ushort", USHRT_MAX, &var, &val) != JIM_OK) {
+        return JIM_ERR;
+    }
+
+    var->val.us = (unsigned short) val;
+    var->type = &ffi_type_ushort;
+    var->to_str = Jim_UshortToStr;
+    var->addr = &var->val.us;
+
+    return JIM_OK;
+}
+
+static void Jim_IntToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.i);
+}
+
+static int JimIntCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    jim_wide val;
+    struct ffi_var *var;
+
+    if (JimIntBaseCmd(interp, argc, argv, "int", INT_MIN, INT_MAX, &var, &val) != JIM_OK) {
+        return JIM_ERR;
+    }
+
+    var->val.i = (int) val;
+    var->type = &ffi_type_sint;
+    var->to_str = Jim_IntToStr;
+    var->addr = &var->val.i;
+
+    return JIM_OK;
+}
+
+static void Jim_UintToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.ui);
+}
+
+static int JimUintCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    jim_wide val;
+    struct ffi_var *var;
+
+    if (JimUintBaseCmd(interp, argc, argv, "uint", UINT_MAX, &var, &val) != JIM_OK) {
+        return JIM_ERR;
+    }
+
+    var->val.ui = (unsigned int) val;
+    var->type = &ffi_type_uint;
+    var->to_str = Jim_UintToStr;
+    var->addr = &var->val.ui;
+
+    return JIM_OK;
+}
+
+static void Jim_LongToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.l);
+}
+
+static int JimLongCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    jim_wide val;
+    struct ffi_var *var;
+
+    if (JimIntBaseCmd(interp, argc, argv, "long", LONG_MIN, LONG_MAX, &var, &val) != JIM_OK) {
+        return JIM_ERR;
+    }
+
+    var->val.l = (long) val;
+    var->type = &ffi_type_slong;
+    var->to_str = Jim_LongToStr;
+    var->addr = &var->val.l;
+
+    return JIM_OK;
+}
+
+static void Jim_UlongToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.ul);
+}
+
+static int JimUlongCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    jim_wide val;
+    struct ffi_var *var;
+
+    if (JimUintBaseCmd(interp, argc, argv, "ulong", ULONG_MAX, &var, &val) != JIM_OK) {
+        return JIM_ERR;
+    }
+
+    var->val.ul = (unsigned long) val;
+    var->type = &ffi_type_ulong;
+    var->to_str = Jim_UlongToStr;
+    var->addr = &var->val.ul;
+
+    return JIM_OK;
+}
+
+static int JimPointerCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    jim_wide val;
+
+    switch (argc) {
+        case 1:
+            break;
+
+        case 2:
+            if (Jim_GetWide(interp, argv[1], &val) != JIM_OK) {
+                return JIM_ERR;
+            }
+            break;
+
+        case 3:
+            Jim_WrongNumArgs(interp, 1, argv, "address");
+            return JIM_ERR;
+    }
+
+    Jim_NewPointer(interp, (void *) (intptr_t) val);
+
+    return JIM_OK;
+}
+
+static int JimStringCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    if (argc != 2) {
+        Jim_WrongNumArgs(interp, 1, argv, "str");
+        return JIM_ERR;
+    }
+
+    Jim_NewPointer(interp, (void *) Jim_String(argv[1]));
+
+    return JIM_OK;
+}
+
+static void Jim_BufferToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultString(interp, var->val.vp, -1);
+}
+
+static void JimBufferDelProc(Jim_Interp *interp, void *privData)
+{
+    struct ffi_var *var = privData;
+
+    JIM_NOTUSED(interp);
+    Jim_Free(var->val.vp);
+    JimVarDelProc(interp, privData);
+}
+
+static int JimBufferCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    char buf[32];
+    struct ffi_var *var;
+    long len;
+
+    if (argc != 2) {
+        Jim_WrongNumArgs(interp, 1, argv, "len");
+        return JIM_ERR;
+    }
+
+    if (Jim_GetLong(interp, argv[1], &len) != JIM_OK) {
+        Jim_SetResultFormatted(interp, "invalid length: %#s", argv[1]);
+        return JIM_ERR;
+    }
+
+    if ((len <= 0) || (len > INT_MAX)) {
+        Jim_SetResultFormatted(interp, "bad length: %#s", argv[1]);
+        return JIM_ERR;
+    }
+
+    var = Jim_Alloc(sizeof(struct ffi_var));
+    var->val.vp = Jim_Alloc((int) len);
+    var->type = &ffi_type_pointer;
+    var->to_str = Jim_BufferToStr;
+    var->addr = &var->val.vp;
+
+    sprintf(buf, "ffi.buffer%ld", Jim_GetId(interp));
+    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimBufferDelProc);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+
+    return JIM_OK;
+}
+
+static void Jim_VoidToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResult(interp, Jim_NewEmptyStringObj(interp));
+}
+
+static int JimVoidCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    char buf[32];
+    struct ffi_var *var;
+
+    if (argc != 1) {
+        Jim_WrongNumArgs(interp, 1, argv, "");
+        return JIM_ERR;
+    }
+
+    var = Jim_Alloc(sizeof(struct ffi_var));
+    var->type = &ffi_type_void;
+    var->to_str = Jim_VoidToStr;
+    var->addr = NULL;
+
+    sprintf(buf, "ffi.void%ld", Jim_GetId(interp));
+    Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimBufferDelProc);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+
+    return JIM_OK;
+}
+
+static void JimLibraryDelProc(Jim_Interp *interp, void *privData)
+{
+    JIM_NOTUSED(interp);
+    dlclose(privData);
+}
+
+static int JimFunctionHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    struct ffi_func *f = Jim_CmdPrivData(interp);
+    void **args, *ret;
+    int nargs, i;
+    const char *s;
+
+    if (argc != 3) {
+        Jim_WrongNumArgs(interp, 1, argv, "ret ?args ...?");
+        return JIM_ERR;
+    }
+
+    nargs = Jim_ListLength(interp, argv[2]);
+    args = Jim_Alloc(sizeof(void *) * nargs);
+
+    s = Jim_String(argv[1]);
+    if (sscanf(s, "%p", &ret) != 1) {
+        Jim_SetResultFormatted(interp, "bad pointer: %s", s);
+        return JIM_ERR;
+    }
+
+    for (i = 0; i < nargs; ++i) {
+        s = Jim_String(Jim_ListGetIndex(interp, argv[2], i));
+        if (sscanf(s, "%p", &args[i]) != 1) {
+            Jim_Free(args);
+            Jim_SetResultFormatted(interp, "bad pointer: %s", s);
+            return JIM_ERR;
+        }
+    }
+
+    ffi_call(&f->cif, f->p, ret, args);
+
+    Jim_Free(args);
+
+    return JIM_OK;
+}
+
+static void JimFunctionDelProc(Jim_Interp *interp, void *privData)
+{
+    struct ffi_func *f = privData;
+
+    JIM_NOTUSED(interp);
+    Jim_Free(f->atypes);
+    Jim_Free(f);
+}
+
+static int JimLibraryHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    char buf[32];
+    static const char * const type_names[] = {
+        "short", "ushort", "int", "uint", "long", "ulong", "pointer", "string",
+        "void",
+        NULL
+    };
+    ffi_type *types[] = {
+        &ffi_type_sshort, &ffi_type_ushort, &ffi_type_sint, &ffi_type_uint,
+        &ffi_type_slong, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer,
+        &ffi_type_void
+    };
+    struct ffi_func *f;
+    void *h = Jim_CmdPrivData(interp);
+    const char *sym;
+    int i, j, nargs;
+
+    if (argc < 3) {
+        Jim_WrongNumArgs(interp, 1, argv, "rtype name ?argtypes ...?");
+        return JIM_ERR;
+    }
+
+    if (Jim_GetEnum(interp, argv[1], type_names, &i, "ffi type", JIM_ERRMSG) != JIM_OK) {
+        return JIM_ERR;
+    }
+
+    f = Jim_Alloc(sizeof(*f));
+
+    sym = Jim_String(argv[2]);
+    f->p = dlsym(h, sym);
+    if (f->p == NULL) {
+        Jim_SetResultFormatted(interp, "failed to resolve %s", sym);
+        Jim_Free(f);
+        return JIM_ERR;
+    }
+
+    f->rtype = types[i];
+    nargs = argc - 3;
+
+    f->atypes = Jim_Alloc(sizeof(char *) * nargs);
+    for (i = 3; i < argc; ++i) {
+        if (Jim_GetEnum(interp, argv[i], type_names, &j, "ffi type", JIM_ERRMSG) != JIM_OK) {
+            Jim_Free(f->atypes);
+            Jim_Free(f);
+            return JIM_ERR;
+        }
+
+        f->atypes[i - 3] = types[j];
+    }
+
+    if (ffi_prep_cif(&f->cif, FFI_DEFAULT_ABI, nargs, f->rtype, f->atypes) != FFI_OK) {
+        Jim_Free(f->atypes);
+        Jim_Free(f);
+        return JIM_ERR;
+    }
+
+    sprintf(buf, "ffi.function%ld", Jim_GetId(interp));
+    Jim_CreateCommand(interp, buf, JimFunctionHandlerCommand, f, JimFunctionDelProc);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+
+    return JIM_OK;
+}
+
+static int JimDlopenCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    char buf[32];
+    const char *path;
+    void *h;
+    int len;
+
+    if (argc != 2) {
+        Jim_WrongNumArgs(interp, 1, argv, "path");
+        return JIM_ERR;
+    }
+
+    path = Jim_GetString(argv[1], &len);
+    if (len == 0) {
+        path = NULL;
+    }
+
+    h = dlopen(path, RTLD_LAZY);
+    if (h == NULL) {
+        Jim_SetResultFormatted(interp, "failed to load %s", path);
+        return JIM_ERR;
+    }
+
+    sprintf(buf, "ffi.library%ld", Jim_GetId(interp));
+    Jim_CreateCommand(interp, buf, JimLibraryHandlerCommand, h, JimLibraryDelProc);
+    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+
+    return JIM_OK;
+}
+
+int Jim_ffiInit(Jim_Interp *interp)
+{
+    if (Jim_PackageProvide(interp, "ffi", "1.0", JIM_ERRMSG))
+        return JIM_ERR;
+
+    Jim_CreateCommand(interp, "ffi.short", JimShortCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.ushort", JimUshortCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.int", JimIntCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.uint", JimUintCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.long", JimLongCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.ulong", JimUlongCmd, 0, 0);
+
+    Jim_CreateCommand(interp, "ffi.pointer", JimPointerCmd, 0, 0);
+
+    Jim_CreateCommand(interp, "ffi.string", JimStringCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.buffer", JimBufferCmd, 0, 0);
+
+    Jim_CreateCommand(interp, "ffi.void", JimVoidCmd, 0, 0);
+
+    Jim_CreateCommand(interp, "ffi.dlopen", JimDlopenCmd, 0, 0);
+
+    return JIM_OK;
+}

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -43,6 +43,7 @@
 #include <jim.h>
 
 struct ffi_var {
+    size_t size;
     union {
         void *vp;
 
@@ -127,11 +128,11 @@ static int JimVarHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
         return JIM_OK;
 
     case OPT_SIZE:
-        if (var->type->size > INT_MAX) {
+        if (var->size > INT_MAX) {
             Jim_SetResultFormatted(interp, "bad variable size for: %#s", argv[1]);
             return JIM_ERR;
         }
-        Jim_SetResultInt(interp, (int) var->type->size);
+        Jim_SetResultInt(interp, (int) var->size);
         return JIM_OK;
 
     case OPT_RAW:
@@ -139,7 +140,7 @@ static int JimVarHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
             Jim_SetResultFormatted(interp, "bad variable size for: %#s", argv[1]);
             return JIM_ERR;
         }
-        Jim_SetResultString(interp, (char *) var->addr, (int) var->type->size);
+        Jim_SetResultString(interp, (char *) var->addr, (int) var->size);
         return JIM_OK;
     }
 
@@ -179,6 +180,7 @@ static void Jim_NewInt8(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_sint8;
     var->to_str = Jim_Int8ToStr;
     var->addr = &var->val.i8;
+    var->size = sizeof(var->val.i8);
 }
 
 static void Jim_Uint8ToStr(Jim_Interp *interp, const struct ffi_var *var)
@@ -196,6 +198,7 @@ static void Jim_NewUint8(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_uint8;
     var->to_str = Jim_Uint8ToStr;
     var->addr = &var->val.ui8;
+    var->size = sizeof(var->val.ui8);
 }
 
 /* {u,}int16 methods */
@@ -215,6 +218,7 @@ static void Jim_NewInt16(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_sint16;
     var->to_str = Jim_Int16ToStr;
     var->addr = &var->val.i16;
+    var->size = sizeof(var->val.i16);
 }
 
 static void Jim_Uint16ToStr(Jim_Interp *interp, const struct ffi_var *var)
@@ -232,6 +236,7 @@ static void Jim_NewUint16(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_uint16;
     var->to_str = Jim_Uint16ToStr;
     var->addr = &var->val.ui16;
+    var->size = sizeof(var->val.ui16);
 }
 
 /* {u,}int32 methods */
@@ -251,6 +256,7 @@ static void Jim_NewInt32(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_sint32;
     var->to_str = Jim_Int32ToStr;
     var->addr = &var->val.i32;
+    var->size = sizeof(var->val.i32);
 }
 
 static void Jim_Uint32ToStr(Jim_Interp *interp, const struct ffi_var *var)
@@ -268,6 +274,7 @@ static void Jim_NewUint32(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_uint32;
     var->to_str = Jim_Uint32ToStr;
     var->addr = &var->val.ui32;
+    var->size = sizeof(var->val.ui32);
 }
 
 /* {u,}int64 methods */
@@ -289,6 +296,7 @@ static void Jim_NewInt64(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_sint64;
     var->to_str = Jim_Int64ToStr;
     var->addr = &var->val.i64;
+    var->size = sizeof(var->val.i64);
 }
 
 static void Jim_Uint64ToStr(Jim_Interp *interp, const struct ffi_var *var)
@@ -306,6 +314,7 @@ static void Jim_NewUint64(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_uint64;
     var->to_str = Jim_Uint64ToStr;
     var->addr = &var->val.ui64;
+    var->size = sizeof(var->val.ui64);
 }
 
 #endif
@@ -331,6 +340,7 @@ static void Jim_NewChar(Jim_Interp *interp, const char val)
     var->type = &ffi_type_schar;
     var->to_str = Jim_CharToStr;
     var->addr = &var->val.c;
+    var->size = sizeof(var->val.c);
 }
 
 static void Jim_UcharToStr(Jim_Interp *interp, const struct ffi_var *var)
@@ -348,6 +358,7 @@ static void Jim_NewUchar(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_uchar;
     var->to_str = Jim_UcharToStr;
     var->addr = &var->val.uc;
+    var->size = sizeof(var->val.uc);
 }
 
 /* short methods */
@@ -367,6 +378,7 @@ static void Jim_NewShort(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_sshort;
     var->to_str = Jim_ShortToStr;
     var->addr = &var->val.s;
+    var->size = sizeof(var->val.s);
 }
 
 static void Jim_UshortToStr(Jim_Interp *interp, const struct ffi_var *var)
@@ -384,6 +396,7 @@ static void Jim_NewUshort(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_ushort;
     var->to_str = Jim_UshortToStr;
     var->addr = &var->val.us;
+    var->size = sizeof(var->val.us);
 }
 
 /* int methods */
@@ -405,6 +418,7 @@ static void Jim_NewIntNoAlloc(Jim_Interp *interp,
     var->type = &ffi_type_sint;
     var->to_str = Jim_IntToStr;
     var->addr = &var->val.i;
+    var->size = sizeof(var->val.i);
 }
 
 static void Jim_NewInt(Jim_Interp *interp, const jim_wide val)
@@ -417,6 +431,7 @@ static void Jim_NewInt(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_sint;
     var->to_str = Jim_IntToStr;
     var->addr = &var->val.i;
+    var->size = sizeof(var->val.i);
 }
 
 static void Jim_UintToStr(Jim_Interp *interp, const struct ffi_var *var)
@@ -434,6 +449,7 @@ static void Jim_NewUint(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_uint;
     var->to_str = Jim_UintToStr;
     var->addr = &var->val.ui;
+    var->size = sizeof(var->val.ui);
 }
 
 /* long methods */
@@ -453,6 +469,7 @@ static void Jim_NewLong(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_slong;
     var->to_str = Jim_LongToStr;
     var->addr = &var->val.l;
+    var->size = sizeof(var->val.l);
 }
 
 static void Jim_UlongToStr(Jim_Interp *interp, const struct ffi_var *var)
@@ -470,6 +487,7 @@ static void Jim_NewUlong(Jim_Interp *interp, const jim_wide val)
     var->type = &ffi_type_ulong;
     var->to_str = Jim_UlongToStr;
     var->addr = &var->val.ul;
+    var->size = sizeof(var->val.ul);
 }
 
 /* float methods */
@@ -492,6 +510,7 @@ static void Jim_NewFloat(Jim_Interp *interp, const double val)
     var->type = &ffi_type_float;
     var->to_str = Jim_FloatToStr;
     var->addr = &var->val.f;
+    var->size = sizeof(var->val.f);
 }
 
 /* double methods */
@@ -514,6 +533,7 @@ static void Jim_NewDouble(Jim_Interp *interp, const double val)
     var->type = &ffi_type_double;
     var->to_str = Jim_DoubleToStr;
     var->addr = &var->val.d;
+    var->size = sizeof(var->val.d);
 }
 
 /* pointer methods */
@@ -539,6 +559,7 @@ static void Jim_NewPointerBase(Jim_Interp *interp,
     var->type = &ffi_type_pointer;
     var->to_str = Jim_PointerToStr;
     var->addr = &var->val.vp;
+    var->size = sizeof(var->val.vp);
 }
 
 static void Jim_NewPointer(Jim_Interp *interp, void *p)
@@ -568,7 +589,7 @@ static void Jim_BufferToStr(Jim_Interp *interp, const struct ffi_var *var)
     Jim_SetResultString(interp, var->val.vp, -1);
 }
 
-static void Jim_NewBuffer(Jim_Interp *interp, void *p)
+static void Jim_NewBuffer(Jim_Interp *interp, void *p, const size_t size)
 {
     char buf[32];
     struct ffi_var *var;
@@ -583,6 +604,7 @@ static void Jim_NewBuffer(Jim_Interp *interp, void *p)
     var->type = &ffi_type_pointer;
     var->to_str = Jim_BufferToStr;
     var->addr = &var->val.vp;
+    var->size = size;
 }
 
 /* int commands */
@@ -804,9 +826,9 @@ static int JimPointerCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 static int JimStringCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     static const char * const options[] = { "at", "copy", NULL };
-    const char *s;
+    char *s;
     jim_wide addr;
-    long size;
+    long llen;
     int option, len;
     enum { OPT_AT, OPT_COPY };
 
@@ -825,11 +847,11 @@ static int JimStringCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
             return JIM_ERR;
         }
 
-        s = Jim_GetString(argv[2], &len);
-        Jim_NewBuffer(interp, (void *) Jim_StrDupLen(s, len));
+        s = (char *) Jim_GetString(argv[2], &len);
+        Jim_NewBuffer(interp, (void *) Jim_StrDupLen(s, len), (size_t) len);
     } else {
         if ((argc != 3) && (argc != 4)) {
-            Jim_WrongNumArgs(interp, 1, argv, "at addr ?size?");
+            Jim_WrongNumArgs(interp, 1, argv, "at addr ?len?");
             return JIM_ERR;
         }
 
@@ -838,20 +860,23 @@ static int JimStringCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
             return JIM_ERR;
         }
 
+        s = (char *) (uintptr_t) addr;
+
         if (argc == 3) {
-            Jim_SetResultString(interp, (char *) (uintptr_t) addr, -1);
+            Jim_SetResultString(interp, s, -1);
         } else {
-            if (Jim_GetLong(interp, argv[3], &size) != JIM_OK) {
+            if (Jim_GetLong(interp, argv[3], &llen) != JIM_OK) {
                 Jim_SetResultFormatted(interp, "invalid size: %#s", argv[3]);
                 return JIM_ERR;
             }
 
-            if ((size < 0) || (size > INT_MAX)) {
+            if ((llen < 0) || (llen > (INT_MAX - 1))) {
                 Jim_SetResultFormatted(interp, "bad size: %#s", argv[3]);
                 return JIM_ERR;
             }
 
-            Jim_SetResultString(interp, (char *) (uintptr_t) addr, (int) size);
+            s[llen] = '\0';
+            Jim_SetResultString(interp, s, (int) (llen + 1));
         }
     }
 
@@ -877,7 +902,7 @@ static int JimBufferCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    Jim_NewBuffer(interp, Jim_Alloc((int) len));
+    Jim_NewBuffer(interp, Jim_Alloc((int) len), (size_t) len);
     return JIM_OK;
 }
 
@@ -902,6 +927,7 @@ static int JimVoidCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     var->type = &ffi_type_void;
     var->to_str = Jim_VoidToStr;
     var->addr = NULL;
+    var->size = 0;
 
     sprintf(buf, "ffi.void%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimVarDelProc);

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -1351,28 +1351,16 @@ int Jim_ffiInit(Jim_Interp *interp)
         return JIM_ERR;
     }
 
-    null_var.val.vp = NULL;
-    null_var.type = &ffi_type_pointer;
-    null_var.to_str = Jim_PointerToStr;
-    null_var.addr = &null_var.val.vp;
     Jim_NewPointerBase(interp, &null_var, NULL, buf, NULL);
     if (Jim_SetVariable(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, "null", -1)), Jim_NewStringObj(interp, buf, -1)) != JIM_OK) {
         return JIM_ERR;
     }
 
-    zero_var.val.i = 0;
-    zero_var.type = &ffi_type_sint;
-    zero_var.to_str = Jim_IntToStr;
-    zero_var.addr = &zero_var.val.i;
     Jim_NewIntNoAlloc(interp, &zero_var, 0, buf);
     if (Jim_SetVariable(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, "zero", -1)), Jim_NewStringObj(interp, buf, -1)) != JIM_OK) {
         return JIM_ERR;
     }
 
-    one_var.val.i = 1;
-    one_var.type = &ffi_type_sint;
-    one_var.to_str = Jim_IntToStr;
-    one_var.addr = &one_var.val.i;
     Jim_NewIntNoAlloc(interp, &one_var, 0, buf);
     if (Jim_SetVariable(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, "one", -1)), Jim_NewStringObj(interp, buf, -1)) != JIM_OK) {
         return JIM_ERR;

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -269,7 +269,6 @@ static void Jim_NewUint32(Jim_Interp *interp, const jim_wide val)
     var->addr = &var->val.ui32;
 }
 
-
 /* {u,}int64 methods */
 
 #if INT64_MAX <= JIM_WIDE_MAX

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -1223,7 +1223,7 @@ static int JimFunctionHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *cons
         }
     }
 
-    ffi_call(&f->cif, f->p, ret, args);
+    ffi_call(&f->cif, FFI_FN(f->p), ret, args);
     Jim_Free(args);
 
     /* use the return value address as the return value, to allow one-liners */

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -221,7 +221,8 @@ static const jim_subcmd_type variable_command_table[] = {
         0,
         JIM_MODFLAG_FULLARGV
         /* Description: Returns the raw value of a variable */
-    }
+    },
+    { NULL }
 };
 
 static int JimVariableHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -994,7 +995,8 @@ static const jim_subcmd_type string_command_table[] = {
         1,
         1,
         /* Description: Creates a new string and initializes it with a given value */
-    }
+    },
+    { NULL }
 };
 
 static int JimStringCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -1160,7 +1162,8 @@ static const jim_subcmd_type struct_command_table[] = {
         0,
         0,
         /* Description: Returns the size of a struct */
-    }
+    },
+    { NULL }
 };
 
 static int JimStructHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -1414,7 +1417,8 @@ static const jim_subcmd_type library_command_table[] = {
         0,
         0,
         /* Description: Returns the library handle */
-    }
+    },
+    { NULL }
 };
 
 static int JimLibraryHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -405,6 +405,8 @@ static int JimIntBaseCmd(Jim_Interp *interp,
 
     switch (argc) {
     case 1:
+        /* always initialize integers with 0 if no value is specified */
+        val = 0;
         break;
 
     case 2:
@@ -457,6 +459,8 @@ static int JimCharCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     switch (argc) {
     case 1:
+        /* always initialize characters with '\0' if no value is specified */
+        c = '\0';
         break;
 
     case 2:
@@ -547,6 +551,8 @@ static int JimPointerCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     switch (argc) {
         case 1:
+            /* always initialize pointers with NULL if no value is specified */
+            val = (jim_wide)(intptr_t)NULL;
             break;
 
         case 2:
@@ -555,7 +561,7 @@ static int JimPointerCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
             }
             break;
 
-        case 3:
+        default:
             Jim_WrongNumArgs(interp, 1, argv, "?address?");
             return JIM_ERR;
     }

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -945,9 +945,13 @@ static int JimStringAt(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     }
 
     s = (char *)(uintptr_t)addr;
+    if (s == NULL) {
+        Jim_SetResultString(interp, "NULL string address", -1);
+        return JIM_ERR;
+    }
 
     /* in "at" mode, if no length is specified, return the string and assume
-     *  it's terminated */
+     * it's terminated */
     if (argc == 1) {
         Jim_SetResultString(interp, s, -1);
     } else {
@@ -956,12 +960,14 @@ static int JimStringAt(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
             return JIM_ERR;
         }
 
-        if ((len < 0) || (len >= INT_MAX)) {
+        /* we need to reserve room for the null byte, therefore INT_MAX is an
+         * invalid size too */
+        if ((len <= 0) || (len >= INT_MAX)) {
             Jim_SetResultFormatted(interp, "bad size: %#s", argv[1]);
             return JIM_ERR;
         }
 
-        /* otherwise, terminate it first */
+        /* terminate the string */
         s[len] = '\0';
         Jim_SetResultString(interp, s, (int)(len + 1));
     }

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -651,6 +651,7 @@ static int JimStringCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 static int JimBufferCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     long len;
+    void *p;
 
     if (argc != 2) {
         Jim_WrongNumArgs(interp, 1, argv, "len");
@@ -667,7 +668,9 @@ static int JimBufferCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    JimNewBuffer(interp, Jim_Alloc((int)len), (size_t)len);
+    p = Jim_Alloc((int)len);
+    memset(p, '\0', (size_t)len);
+    JimNewBuffer(interp, p, (size_t)len);
     return JIM_OK;
 }
 

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -1309,8 +1309,9 @@ int Jim_ffiInit(Jim_Interp *interp)
     void *self;
 
     self = dlopen(NULL, RTLD_LAZY);
-    if (self == NULL)
+    if (self == NULL) {
         return JIM_ERR;
+    }
 
     if (Jim_PackageProvide(interp, "ffi", "1.0", JIM_ERRMSG)) {
         return JIM_ERR;

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -33,6 +33,7 @@
  */
 
 #include <inttypes.h>
+#include <stdint.h>
 #include <limits.h>
 #include <dlfcn.h>
 #include <string.h>
@@ -44,6 +45,7 @@
 struct ffi_var {
     union {
         void *vp;
+
         unsigned long ul;
         long l;
         unsigned int ui;
@@ -52,6 +54,18 @@ struct ffi_var {
         short s;
         unsigned char uc;
         char c;
+
+        uint64_t ui64;
+        int64_t i64;
+        uint32_t ui32;
+        int32_t i32;
+        uint16_t ui16;
+        int16_t i16;
+        uint8_t ui8;
+        int8_t i8;
+
+        float f;
+        double d;
     } val;
     ffi_type *type;
     void (*to_str)(Jim_Interp *, const struct ffi_var *);
@@ -145,6 +159,199 @@ static struct ffi_var *Jim_NewIntBase(Jim_Interp *interp, const char *name)
     Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 
     return var;
+}
+
+/* {u,}int8 methods */
+
+static void Jim_Int8ToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.i8);
+}
+
+static void Jim_NewInt8(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "int8");
+
+    var->val.i8 = (int8_t) val;
+    var->type = &ffi_type_sint8;
+    var->to_str = Jim_Int8ToStr;
+    var->addr = &var->val.i8;
+}
+
+static void Jim_Uint8ToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.ui8);
+}
+
+static void Jim_NewUint8(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "uint8");
+
+    var->val.ui8 = (uint8_t) val;
+    var->type = &ffi_type_uint8;
+    var->to_str = Jim_Uint8ToStr;
+    var->addr = &var->val.ui8;
+}
+
+/* {u,}int16 methods */
+
+static void Jim_Int16ToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.i16);
+}
+
+static void Jim_NewInt16(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "int16");
+
+    var->val.i16 = (int16_t) val;
+    var->type = &ffi_type_sint16;
+    var->to_str = Jim_Int16ToStr;
+    var->addr = &var->val.i16;
+}
+
+static void Jim_Uint16ToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.ui16);
+}
+
+static void Jim_NewUint16(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "uint16");
+
+    var->val.ui16 = (uint16_t) val;
+    var->type = &ffi_type_uint16;
+    var->to_str = Jim_Uint16ToStr;
+    var->addr = &var->val.ui16;
+}
+
+/* {u,}int32 methods */
+
+static void Jim_Int32ToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.i32);
+}
+
+static void Jim_NewInt32(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "int32");
+
+    var->val.i32 = (int32_t) val;
+    var->type = &ffi_type_sint32;
+    var->to_str = Jim_Int32ToStr;
+    var->addr = &var->val.i32;
+}
+
+static void Jim_Uint32ToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.ui32);
+}
+
+static void Jim_NewUint32(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "uint32");
+
+    var->val.ui32 = (uint32_t) val;
+    var->type = &ffi_type_uint32;
+    var->to_str = Jim_Uint32ToStr;
+    var->addr = &var->val.ui32;
+}
+
+
+/* {u,}int64 methods */
+
+#if INT64_MAX <= JIM_WIDE_MAX
+
+static void Jim_Int64ToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.i64);
+}
+
+static void Jim_NewInt64(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "int64");
+
+    var->val.i64 = (int64_t) val;
+    var->type = &ffi_type_sint64;
+    var->to_str = Jim_Int64ToStr;
+    var->addr = &var->val.i64;
+}
+
+static void Jim_Uint64ToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    Jim_SetResultInt(interp, (jim_wide) var->val.ui64);
+}
+
+static void Jim_NewUint64(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "uint64");
+
+    var->val.ui64 = (uint64_t) val;
+    var->type = &ffi_type_uint64;
+    var->to_str = Jim_Uint64ToStr;
+    var->addr = &var->val.ui64;
+}
+
+#endif
+
+/* char methods */
+
+static void Jim_CharToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    char buf[2];
+
+    buf[0] = var->val.c;
+    buf[1] = '\0';
+    Jim_SetResultString(interp, buf, -1);
+}
+
+static void Jim_NewChar(Jim_Interp *interp, const char val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "char");
+
+    var->val.c = val;
+    var->type = &ffi_type_schar;
+    var->to_str = Jim_CharToStr;
+    var->addr = &var->val.c;
+}
+
+static void Jim_UcharToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    char buf[2];
+
+    buf[0] = (char) var->val.uc;
+    buf[1] = '\0';
+    Jim_SetResultString(interp, buf, -1);
+}
+
+static void Jim_NewUchar(Jim_Interp *interp, const jim_wide val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "uchar");
+
+    var->val.uc = (unsigned char) val;
+    var->type = &ffi_type_uchar;
+    var->to_str = Jim_UcharToStr;
+    var->addr = &var->val.uc;
 }
 
 /* short methods */
@@ -255,6 +462,50 @@ static void Jim_NewUlong(Jim_Interp *interp, const jim_wide val)
     var->addr = &var->val.ul;
 }
 
+/* float methods */
+
+static void Jim_FloatToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    char buf[JIM_DOUBLE_SPACE + 1];
+
+    sprintf(buf, "%.12g", (double) var->val.f);
+    Jim_SetResultString(interp, buf, -1);
+}
+
+static void Jim_NewFloat(Jim_Interp *interp, const double val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "float");
+
+    var->val.f = (float) val;
+    var->type = &ffi_type_float;
+    var->to_str = Jim_FloatToStr;
+    var->addr = &var->val.f;
+}
+
+/* double methods */
+
+static void Jim_DoubleToStr(Jim_Interp *interp, const struct ffi_var *var)
+{
+    char buf[JIM_DOUBLE_SPACE + 1];
+
+    sprintf(buf, "%.12g", var->val.d);
+    Jim_SetResultString(interp, buf, -1);
+}
+
+static void Jim_NewDouble(Jim_Interp *interp, const double val)
+{
+    struct ffi_var *var;
+
+    var = Jim_NewIntBase(interp, "double");
+
+    var->val.d = (double) val;
+    var->type = &ffi_type_double;
+    var->to_str = Jim_DoubleToStr;
+    var->addr = &var->val.d;
+}
+
 /* pointer methods */
 
 static void Jim_PointerToStr(Jim_Interp *interp, const struct ffi_var *var)
@@ -320,8 +571,8 @@ static void Jim_NewBuffer(Jim_Interp *interp, void *p)
 static int JimIntBaseCmd(Jim_Interp *interp,
                          int argc,
                          Jim_Obj *const *argv,
-                         const long min,
-                         const long max,
+                         const jim_wide min,
+                         const jim_wide max,
                          void (*new_obj)(Jim_Interp *, const jim_wide))
 {
     jim_wide val;
@@ -352,10 +603,88 @@ static int JimIntBaseCmd(Jim_Interp *interp,
 static int JimUintBaseCmd(Jim_Interp *interp,
                           int argc,
                           Jim_Obj *const *argv,
-                          const long max,
+                          const jim_wide max,
                           void (*new_obj)(Jim_Interp *, const jim_wide))
 {
     return JimIntBaseCmd(interp, argc, argv, 0, max, new_obj);
+}
+
+static int JimInt8Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimIntBaseCmd(interp, argc, argv, INT8_MIN, INT8_MAX, Jim_NewInt8);
+}
+
+static int JimUint8Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimUintBaseCmd(interp, argc, argv, UINT8_MAX, Jim_NewUint8);
+}
+
+static int JimInt16Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimIntBaseCmd(interp, argc, argv, INT16_MIN, INT16_MAX, Jim_NewInt16);
+}
+
+static int JimUint16Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimUintBaseCmd(interp, argc, argv, UINT16_MAX, Jim_NewUint16);
+}
+
+static int JimInt32Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimIntBaseCmd(interp, argc, argv, INT32_MIN, INT32_MAX, Jim_NewInt32);
+}
+
+static int JimUint32Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimUintBaseCmd(interp, argc, argv, UINT32_MAX, Jim_NewUint32);
+}
+
+#if INT64_MAX <= JIM_WIDE_MAX
+
+static int JimInt64Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimIntBaseCmd(interp, argc, argv, INT64_MIN, INT64_MAX, Jim_NewInt64);
+}
+
+static int JimUint64Cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimUintBaseCmd(interp, argc, argv, UINT64_MAX, Jim_NewUint64);
+}
+
+#endif
+
+static int JimCharCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    const char *s;
+    int len;
+    char c;
+
+    switch (argc) {
+    case 1:
+        break;
+
+    case 2:
+        s = Jim_GetString(argv[1], &len);
+        if (len != 1) {
+            Jim_SetResultFormatted(interp, "bad character: %#s", argv[1]);
+            return JIM_ERR;
+        }
+
+        c = s[0];
+        break;
+
+    default:
+        Jim_WrongNumArgs(interp, 1, argv, "val");
+        return JIM_ERR;
+    }
+
+    Jim_NewChar(interp, c);
+    return JIM_OK;
+}
+
+static int JimUcharCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimUintBaseCmd(interp, argc, argv, UCHAR_MAX, Jim_NewUchar);
 }
 
 static int JimShortCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -386,6 +715,45 @@ static int JimLongCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 static int JimUlongCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     return JimUintBaseCmd(interp, argc, argv, ULONG_MAX, Jim_NewUlong);
+}
+
+/* float commands */
+
+static int JimFloatBaseCmd(Jim_Interp *interp,
+                           int argc,
+                           Jim_Obj *const *argv,
+                           void (*new_obj)(Jim_Interp *, const double))
+{
+    double val;
+
+    switch (argc) {
+    case 1:
+        break;
+
+    case 2:
+        if (Jim_GetDouble(interp, argv[1], &val) != JIM_OK) {
+            Jim_SetResultFormatted(interp, "invalid double value: %#s", argv[1]);
+            return JIM_ERR;
+        }
+        break;
+
+    default:
+        Jim_WrongNumArgs(interp, 1, argv, "val");
+        return JIM_ERR;
+    }
+
+    new_obj(interp, val);
+    return JIM_OK;
+}
+
+static int JimFloatCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimFloatBaseCmd(interp, argc, argv, Jim_NewFloat);
+}
+
+static int JimDoubleCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    return JimFloatBaseCmd(interp, argc, argv, Jim_NewDouble);
 }
 
 /* pointer commands */
@@ -495,6 +863,7 @@ static int JimBufferCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 }
 
 /* misc. commands */
+
 static void Jim_VoidToStr(Jim_Interp *interp, const struct ffi_var *var)
 {
     Jim_SetResult(interp, Jim_NewEmptyStringObj(interp));
@@ -577,20 +946,46 @@ static int JimStructHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const 
 
         p = s->buf + off;
 
-        if (s->type.elements[memb] == &ffi_type_sshort) {
-            Jim_NewShort(interp, (jim_wide) (*((short *) p)));
-        } else if (s->type.elements[memb] == &ffi_type_ushort) {
-            Jim_NewUshort(interp, (jim_wide) (*((unsigned short *) p)));
-        } if (s->type.elements[memb] == &ffi_type_sint) {
-            Jim_NewInt(interp, (jim_wide) (*((int *) p)));
-        } else if (s->type.elements[memb] == &ffi_type_uint) {
-            Jim_NewUint(interp, (jim_wide) (*((unsigned int *) p)));
-        } else if (s->type.elements[memb] == &ffi_type_slong) {
-            Jim_NewLong(interp, (jim_wide) (*((long *) p)));
+        if (s->type.elements[memb] == &ffi_type_pointer) {
+            Jim_NewPointer(interp, p);
         } else if (s->type.elements[memb] == &ffi_type_ulong) {
             Jim_NewUlong(interp, (jim_wide) (*((unsigned long *) p)));
-        } else if (s->type.elements[memb] == &ffi_type_pointer) {
-            Jim_NewPointer(interp, p);
+        } else if (s->type.elements[memb] == &ffi_type_slong) {
+            Jim_NewLong(interp, (jim_wide) (*((long *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_uint) {
+            Jim_NewUint(interp, (jim_wide) (*((unsigned int *) p)));
+        } if (s->type.elements[memb] == &ffi_type_sint) {
+            Jim_NewInt(interp, (jim_wide) (*((int *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_ushort) {
+            Jim_NewUshort(interp, (jim_wide) (*((unsigned short *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_sshort) {
+            Jim_NewShort(interp, (jim_wide) (*((short *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_uchar) {
+            Jim_NewUchar(interp, (jim_wide) (*((unsigned char *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_schar) {
+            Jim_NewChar(interp, (*((char *) p)));
+#if INT64_MAX <= JIM_WIDE_MAX
+        } else if (s->type.elements[memb] == &ffi_type_uint64) {
+            Jim_NewUint64(interp, (jim_wide) (*((uint64_t *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_sint64) {
+            Jim_NewInt64(interp, (jim_wide) (*((int64_t *) p)));
+#endif
+        } else if (s->type.elements[memb] == &ffi_type_uint32) {
+            Jim_NewUint32(interp, (jim_wide) (*((uint32_t *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_sint32) {
+            Jim_NewInt32(interp, (jim_wide) (*((int32_t *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_uint16) {
+            Jim_NewUint16(interp, (jim_wide) (*((uint16_t *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_sint16) {
+            Jim_NewInt16(interp, (jim_wide) (*((int16_t *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_uint8) {
+            Jim_NewUint8(interp, (jim_wide) (*((uint8_t *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_sint8) {
+            Jim_NewInt8(interp, (jim_wide) (*((int8_t *) p)));
+        } else if (s->type.elements[memb] == &ffi_type_float) {
+            Jim_NewFloat(interp, (*((double *) p)));
+        } else {
+            Jim_NewDouble(interp, (*((double *) p)));
         }
 
         return JIM_OK;
@@ -611,11 +1006,24 @@ static int JimStructHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const 
 static int JimStructCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     static const char * const type_names[] = {
-        "short", "ushort", "int", "uint", "long", "ulong", "pointer",  NULL
+        "char", "uchar", "short", "ushort", "int", "uint", "long", "ulong",
+        "pointer", "double", "float", "int8", "uint8", "int16", "uint16",
+        "int32", "uint32",
+#if INT64_MAX <= JIM_WIDE_MAX
+        "int64", "uint64",
+#endif
+        NULL
     };
     ffi_type *types[] = {
-        &ffi_type_sshort, &ffi_type_ushort, &ffi_type_sint, &ffi_type_uint,
-        &ffi_type_slong, &ffi_type_ulong, &ffi_type_pointer
+        &ffi_type_schar, &ffi_type_uchar, &ffi_type_sshort, &ffi_type_ushort,
+        &ffi_type_sint, &ffi_type_uint, &ffi_type_slong, &ffi_type_ulong,
+        &ffi_type_pointer, &ffi_type_double, &ffi_type_float, &ffi_type_sint8,
+        &ffi_type_uint8, &ffi_type_sint16, &ffi_type_uint16, &ffi_type_sint32,
+#if INT64_MAX <= JIM_WIDE_MAX
+        &ffi_type_uint32, &ffi_type_sint64, &ffi_type_uint64
+#else
+        &ffi_type_uint32
+#endif
     };
     char buf[32];
     struct ffi_struct *s;
@@ -734,12 +1142,25 @@ static int JimLibraryHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const
 {
     char buf[32];
     static const char * const type_names[] = {
-        "short", "ushort", "int", "uint", "long", "ulong", "pointer", "void",
+        "char", "uchar", "short", "ushort", "int", "uint", "long", "ulong",
+        "pointer", "void", "double", "float" "int8", "uint8", "int16", "uint16",
+        "int32", "uint32",
+#if INT64_MAX <= JIM_WIDE_MAX
+        "int64", "uint64",
+#endif
         NULL
     };
     ffi_type *types[] = {
-        &ffi_type_sshort, &ffi_type_ushort, &ffi_type_sint, &ffi_type_uint,
-        &ffi_type_slong, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_void
+        &ffi_type_schar, &ffi_type_uchar, &ffi_type_sshort, &ffi_type_ushort,
+        &ffi_type_sint, &ffi_type_uint, &ffi_type_slong, &ffi_type_ulong,
+        &ffi_type_pointer, &ffi_type_void, &ffi_type_double, &ffi_type_float,
+        &ffi_type_sint8, &ffi_type_uint8, &ffi_type_sint16, &ffi_type_uint16,
+        &ffi_type_sint32,
+#if INT64_MAX <= JIM_WIDE_MAX
+        &ffi_type_uint32, &ffi_type_sint64, &ffi_type_uint64
+#else
+        &ffi_type_uint32
+#endif
     };
     struct ffi_func *f;
     void *h = Jim_CmdPrivData(interp);
@@ -834,12 +1255,28 @@ int Jim_ffiInit(Jim_Interp *interp)
     if (Jim_PackageProvide(interp, "ffi", "1.0", JIM_ERRMSG))
         return JIM_ERR;
 
+    Jim_CreateCommand(interp, "ffi.int8", JimInt8Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.uint8", JimUint8Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.int16", JimInt16Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.uint16", JimUint16Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.int32", JimInt32Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.uint32", JimUint32Cmd, 0, 0);
+#if INT64_MAX <= JIM_WIDE_MAX
+    Jim_CreateCommand(interp, "ffi.int64", JimInt64Cmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.uint64", JimUint64Cmd, 0, 0);
+#endif
+
+    Jim_CreateCommand(interp, "ffi.char", JimCharCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.uchar", JimUcharCmd, 0, 0);
     Jim_CreateCommand(interp, "ffi.short", JimShortCmd, 0, 0);
     Jim_CreateCommand(interp, "ffi.ushort", JimUshortCmd, 0, 0);
     Jim_CreateCommand(interp, "ffi.int", JimIntCmd, 0, 0);
     Jim_CreateCommand(interp, "ffi.uint", JimUintCmd, 0, 0);
     Jim_CreateCommand(interp, "ffi.long", JimLongCmd, 0, 0);
     Jim_CreateCommand(interp, "ffi.ulong", JimUlongCmd, 0, 0);
+
+    Jim_CreateCommand(interp, "ffi.float", JimFloatCmd, 0, 0);
+    Jim_CreateCommand(interp, "ffi.double", JimDoubleCmd, 0, 0);
 
     Jim_CreateCommand(interp, "ffi.pointer", JimPointerCmd, 0, 0);
     Jim_CreateCommand(interp, "ffi.string", JimStringCmd, 0, 0);

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -102,10 +102,10 @@ static void Jim_NewPointer(Jim_Interp *interp, void *p)
 static int JimVarHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     char buf[32];
-    static const char * const options[] = { "value", "pointer", NULL };
+    static const char * const options[] = { "value", "address", NULL };
     struct ffi_var *var = Jim_CmdPrivData(interp);
     int option;
-    enum { OPT_VALUE, OPT_POINTER };
+    enum { OPT_VALUE, OPT_ADDRESS };
 
     if (argc != 2) {
         Jim_WrongNumArgs(interp, 1, argv, "method ?args ...?");
@@ -121,7 +121,7 @@ static int JimVarHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
         var->to_str(interp, var);
         return JIM_OK;
 
-    case OPT_POINTER:
+    case OPT_ADDRESS:
         sprintf(buf, "%p", var->addr);
         Jim_SetResultString(interp, buf, -1);
         return JIM_OK;

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -734,14 +734,12 @@ static int JimLibraryHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const
 {
     char buf[32];
     static const char * const type_names[] = {
-        "short", "ushort", "int", "uint", "long", "ulong", "pointer", "string",
-        "void",
+        "short", "ushort", "int", "uint", "long", "ulong", "pointer", "void",
         NULL
     };
     ffi_type *types[] = {
         &ffi_type_sshort, &ffi_type_ushort, &ffi_type_sint, &ffi_type_uint,
-        &ffi_type_slong, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer,
-        &ffi_type_void
+        &ffi_type_slong, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_void
     };
     struct ffi_func *f;
     void *h = Jim_CmdPrivData(interp);
@@ -773,6 +771,13 @@ static int JimLibraryHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const
     f->atypes = Jim_Alloc(sizeof(char *) * nargs);
     for (i = 3; i < argc; ++i) {
         if (Jim_GetEnum(interp, argv[i], type_names, &j, "ffi type", JIM_ERRMSG) != JIM_OK) {
+            Jim_Free(f->atypes);
+            Jim_Free(f);
+            return JIM_ERR;
+        }
+
+        if (types[j] == &ffi_type_void) {
+            Jim_SetResultString(interp, "the type of a function argument cannot be void", -1);
             Jim_Free(f->atypes);
             Jim_Free(f);
             return JIM_ERR;

--- a/jim-ffi.c
+++ b/jim-ffi.c
@@ -156,7 +156,7 @@ static struct ffi_var *Jim_NewIntBase(Jim_Interp *interp, const char *name)
 
     sprintf(buf, "ffi.%s%ld", name, Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimVarDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+    Jim_SetResultString(interp, buf, -1);
 
     return var;
 }
@@ -548,7 +548,7 @@ static void Jim_NewPointer(Jim_Interp *interp, void *p)
     var = Jim_Alloc(sizeof(*var));
 
     Jim_NewPointerBase(interp, var, p, buf, JimVarDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+    Jim_SetResultString(interp, buf, -1);
 }
 
 /* buffer methods */
@@ -576,7 +576,7 @@ static void Jim_NewBuffer(Jim_Interp *interp, void *p)
 
     sprintf(buf, "ffi.buffer%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimBufferDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+    Jim_SetResultString(interp, buf, -1);
 
     var->val.vp = p;
     var->type = &ffi_type_pointer;
@@ -904,7 +904,7 @@ static int JimVoidCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     sprintf(buf, "ffi.void%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimVarHandlerCommand, var, JimVarDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+    Jim_SetResultString(interp, buf, -1);
 
     return JIM_OK;
 }
@@ -1054,7 +1054,6 @@ static int JimStructCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     }
 
     raw = Jim_GetString(argv[1], &len);
-
     s = Jim_Alloc(sizeof(*s));
     s->nmemb = argc - 1;
     s->type.elements = Jim_Alloc(sizeof(ffi_type *) * (1 + s->nmemb));
@@ -1095,7 +1094,7 @@ static int JimStructCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     sprintf(buf, "ffi.struct%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimStructHandlerCommand, s, JimStructDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+    Jim_SetResultString(interp, buf, -1);
 
     return JIM_OK;
 }
@@ -1233,7 +1232,7 @@ static int JimLibraryHandlerCommand(Jim_Interp *interp, int argc, Jim_Obj *const
 
     sprintf(buf, "ffi.function%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimFunctionHandlerCommand, f, JimFunctionDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+    Jim_SetResultString(interp, buf, -1);
 
     return JIM_OK;
 }
@@ -1256,7 +1255,7 @@ static int JimDlopenCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     sprintf(buf, "ffi.library%ld", Jim_GetId(interp));
     Jim_CreateCommand(interp, buf, JimLibraryHandlerCommand, h, JimLibraryDelProc);
-    Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
+    Jim_SetResultString(interp, buf, -1);
 
     return JIM_OK;
 }
@@ -1273,8 +1272,9 @@ int Jim_ffiInit(Jim_Interp *interp)
     void *self;
 
     self = dlopen(NULL, RTLD_LAZY);
-    if (self == NULL)
+    if (self == NULL) {
         return JIM_ERR;
+    }
 
     if (Jim_PackageProvide(interp, "ffi", "1.0", JIM_ERRMSG)) {
         return JIM_ERR;

--- a/jim.c
+++ b/jim.c
@@ -5909,8 +5909,6 @@ Jim_Obj *Jim_NewIntObj(Jim_Interp *interp, jim_wide wideValue)
 /* -----------------------------------------------------------------------------
  * Double object
  * ---------------------------------------------------------------------------*/
-#define JIM_DOUBLE_SPACE 30
-
 static void UpdateStringOfDouble(struct Jim_Obj *objPtr);
 static int SetDoubleFromAny(Jim_Interp *interp, Jim_Obj *objPtr);
 

--- a/jim.h
+++ b/jim.h
@@ -831,6 +831,7 @@ JIM_EXPORT Jim_Obj * Jim_NewIntObj (Jim_Interp *interp,
         jim_wide wideValue);
 
 /* double object */
+#define JIM_DOUBLE_SPACE 30
 JIM_EXPORT int Jim_GetDouble(Jim_Interp *interp, Jim_Obj *objPtr,
         double *doublePtr);
 JIM_EXPORT void Jim_SetDouble(Jim_Interp *interp, Jim_Obj *objPtr,


### PR DESCRIPTION
I added libffi bindings:
1) They allow the use of native functions and system calls that don't have Tcl wrappers (pretty much everything except the basics already provided, like fork() and kill())
2) Sometimes when you decide to write complex logic in C because performance is crucial, running some parts on top of a very lightweight interpreter (such as Jim) is handy: it provides stuff like exceptions and garbage collection, without much overhead
3) I'm currently working on a FOSS security software pet project: one of its components is a client that receives dynamically-generated scripts from a server, then evals them; I decided to implement it using Jim and libffi, instead of using C and temporary shared objects (or some other ugly solution), because these scripts do low-level userspace stuff