### PR TITLE
Fixed socket support on MinGW

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -127,6 +127,9 @@ switch -glob -- $host_os {
         define TCL_PLATFORM_OS $host_os
         define TCL_PLATFORM_PLATFORM windows
         define TCL_PLATFORM_PATH_SEPARATOR {;}
+        if {[cc-check-function-in-lib socket ws2_32]} {
+             define-append LDLIBS [get-define lib_socket]
+        }
     }
     default {
         # Note that cygwin is considered a unix platform

--- a/jim-eventloop.c
+++ b/jim-eventloop.c
@@ -376,7 +376,7 @@ int Jim_ProcessEvents(Jim_Interp *interp, int flags)
         }
     }
 
-#ifdef HAVE_SELECT
+#if defined(HAVE_SELECT) || defined(__MINGW32__)
     if (flags & JIM_FILE_EVENTS) {
         int retval;
         struct timeval tv, *tvp = NULL;
@@ -389,7 +389,11 @@ int Jim_ProcessEvents(Jim_Interp *interp, int flags)
 
         /* Check file events */
         while (fe != NULL) {
+#ifdef __MINGW32__
+            SOCKET fd = _get_osfhandle(fileno(fe->handle));
+#else
             int fd = fileno(fe->handle);
+#endif
 
             if (fe->mask & JIM_EVENT_READABLE)
                 FD_SET(fd, &rfds);
@@ -420,7 +424,11 @@ int Jim_ProcessEvents(Jim_Interp *interp, int flags)
         else if (retval > 0) {
             fe = eventLoop->fileEventHead;
             while (fe != NULL) {
+#ifdef __MINGW32__
+                SOCKET fd = _get_osfhandle(fileno(fe->handle));
+#else
                 int fd = fileno(fe->handle);
+#endif
                 int mask = 0;
 
                 if ((fe->mask & JIM_EVENT_READABLE) && FD_ISSET(fd, &rfds))


### PR DESCRIPTION
Socket support on MinGW is severely broken, because the Win32 API distinguishes between SOCKET (handles) and file descriptors (managed by the CRT). Also, FILE \* APIs do not play nicely with sockets.

(btw: tested on x86_64, because that's where Windows quirks shine)
