### PR TITLE
Add the tcl_platform(engine) array element.

### DIFF
--- a/Tcl_shipped.html
+++ b/Tcl_shipped.html
@@ -7887,6 +7887,7 @@ by the Tcl library.</p></div>
 <div class="literalblock">
 <div class="content">
 <pre><code>tcl_platform(byteOrder)     = littleEndian
+tcl_platform(engine)        = Jim
 tcl_platform(os)            = Darwin
 tcl_platform(platform)      = unix
 tcl_platform(pointerSize)   = 8

--- a/jim.c
+++ b/jim.c
@@ -5478,6 +5478,7 @@ Jim_Interp *Jim_CreateInterp(void)
     Jim_SetVariableStrWithStr(i, JIM_LIBPATH, TCL_LIBRARY);
     Jim_SetVariableStrWithStr(i, JIM_INTERACTIVE, "0");
 
+    Jim_SetVariableStrWithStr(i, "tcl_platform(engine)", "Jim");
     Jim_SetVariableStrWithStr(i, "tcl_platform(os)", TCL_PLATFORM_OS);
     Jim_SetVariableStrWithStr(i, "tcl_platform(platform)", TCL_PLATFORM_PLATFORM);
     Jim_SetVariableStrWithStr(i, "tcl_platform(pathSeparator)", TCL_PLATFORM_PATH_SEPARATOR);

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -4984,6 +4984,7 @@ The following global variables are set by jimsh.
     example of the contents of this array.
 
     tcl_platform(byteOrder)     = littleEndian
+    tcl_platform(engine)        = Jim
     tcl_platform(os)            = Darwin
     tcl_platform(platform)      = unix
     tcl_platform(pointerSize)   = 8

--- a/tests/jim.test
+++ b/tests/jim.test
@@ -3501,5 +3501,8 @@ test regression-1.2 {open/close from non-global namespace} {
 	expr {$f in [info channels]}
 } {0}
 
+test regression-1.3 {value of tcl_platform(engine)} {
+  set ::tcl_platform(engine)
+} {Jim}
 
 testreport


### PR DESCRIPTION
The TIP ( http://tip.tcl.tk/440 ) may or may not get approved; however, several other implementations of Tcl already have -OR- will be adding the tcl_platform(engine) element either way.

Please consider accepting this pull request.
