### PR TITLE
Add logging functions - not actually used yet though

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -122,6 +122,7 @@ static void JimPanicDump(int fail_condition, const char *fmt, ...);
 /* A shared empty string for the objects string representation.
  * Jim_InvalidateStringRep knows about it and doesn't try to free it. */
 static char JimEmptyStringRep[] = "";
+static const char* JimNewline = "\n";
 
 /* -----------------------------------------------------------------------------
  * Required prototypes of not exported functions
@@ -141,6 +142,8 @@ static int JimSign(jim_wide w);
 static int JimValidName(Jim_Interp *interp, const char *type, Jim_Obj *nameObjPtr);
 static void JimPrngSeed(Jim_Interp *interp, unsigned char *seed, int seedLen);
 static void JimRandomBytes(Jim_Interp *interp, void *dest, unsigned int len);
+static void DefaultLogFunction(const char* logData, void* log_param);
+Jim_log_details defaultLogging = { DefaultLogFunction, NULL, JIM_LOG_NONE };
 
 
 /* Fast access to the int (wide) value of an object which is known to be of int type */
@@ -5430,6 +5433,90 @@ int Jim_IsBigEndian(void)
     return uval.c[0] == 1;
 }
 
+int Jim_SetLogLevel(Jim_Interp *interp, int logLevel)
+{
+	if ((logLevel < JIM_LOG_NONE) || (logLevel > JIM_LOG_MAX_VALUE)) {
+		Jim_SetResultFormatted(interp, "Invalid debug level value - valid range is %d (None) to %d (everything)\n", JIM_LOG_NONE, JIM_LOG_MAX_VALUE);
+		return JIM_ERR;
+	}
+	interp->logDetails.currentLogLevel = logLevel;
+	return JIM_OK;
+}
+
+void Jim_SetLogDetails(Jim_Interp *interp, Jim_log_details* logDetails)
+{
+	if (logDetails != NULL) {
+		interp->logDetails.currentLogLevel = logDetails->currentLogLevel;
+		interp->logDetails.logFunction     = logDetails->logFunction;
+		interp->logDetails.log_param       = logDetails->log_param;
+	}
+}
+
+/* [loglevel] */
+static int Jim_LogLevelCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+	if (argc != 1 && argc != 2) {
+		Jim_WrongNumArgs(interp, 1, argv, "loglevel ?newValue?");
+		return JIM_ERR;
+	}
+	if (argc == 1) {
+		Jim_Obj *objPtr;
+		objPtr = Jim_NewIntObj(interp, interp->logDetails.currentLogLevel);
+		if (!objPtr)
+			return JIM_ERR;
+		Jim_SetResult(interp, objPtr);
+		return JIM_OK;
+	}
+	/* argc == 2 case. */
+	long newvalue = 0;
+    if (Jim_GetLong(interp, argv[1], &newvalue) != JIM_OK)
+		return JIM_ERR;
+	if (Jim_SetLogLevel(interp, newvalue) != JIM_OK)
+		return JIM_ERR;
+
+	Jim_SetResult(interp, argv[1]);
+	return JIM_OK;
+}
+
+static void DefaultLogFunction(const char* logData, void* log_param)
+{
+	printf( "%s", logData );
+}
+
+void JimLog( struct Jim_Interp *interp, Jim_Log_Level level, const char* function, const char *format, ...) {
+
+	if ( JIM_LOG_IS_LOG_LEVEL_IS_MET( interp, level ) )
+	{
+		int len;
+		int function_prefix_length = strlen(function) + 2;
+		static const int JimNewlineLength = sizeof(JimNewline) - 1;
+
+		va_list args;
+		va_start(args, format);
+
+		/* Determine the length of the output string */
+		len = vsnprintf( NULL, 0, format, args ) + function_prefix_length + JimNewlineLength + interp->evalDepth + 1;
+		if (len > 0) {
+			char* newstring = (char*) malloc(len);
+			if (!newstring)
+				return;
+			memset( newstring, ' ', len );
+			/* Prefix function name into the log line, indented */
+			snprintf( &newstring[interp->evalDepth], function_prefix_length + 1, "%s: ", function);
+			/* Add the log detail */
+			vsnprintf( &newstring[interp->evalDepth+function_prefix_length], len - function_prefix_length, format, args);
+			/* Add a newline */
+			strncat( newstring, JimNewline, len );
+			newstring[len-1] = '\x00';
+
+			/* Send to the log function */
+			interp->logDetails.logFunction( newstring, interp->logDetails.log_param );
+			free(newstring);
+		}
+	    va_end(args);
+	}
+}
+
 /* -----------------------------------------------------------------------------
  * Interpreter related functions
  * ---------------------------------------------------------------------------*/
@@ -5439,6 +5526,10 @@ Jim_Interp *Jim_CreateInterp(void)
     Jim_Interp *i = Jim_Alloc(sizeof(*i));
 
     memset(i, 0, sizeof(*i));
+
+    i->logDetails.logFunction     = defaultLogging.logFunction;
+    i->logDetails.log_param       = defaultLogging.log_param;
+    i->logDetails.currentLogLevel = defaultLogging.currentLogLevel;
 
     i->maxCallFrameDepth = JIM_MAX_CALLFRAME_DEPTH;
     i->maxEvalDepth = JIM_MAX_EVAL_DEPTH;
@@ -15257,6 +15348,7 @@ static const struct {
     {"local", Jim_LocalCoreCommand},
     {"upcall", Jim_UpcallCoreCommand},
     {"apply", Jim_ApplyCoreCommand},
+	{"loglevel", Jim_LogLevelCoreCommand },
     {NULL, NULL},
 };
 

--- a/jim.h
+++ b/jim.h
@@ -494,6 +494,26 @@ typedef struct Jim_PrngState {
     unsigned int i, j;
 } Jim_PrngState;
 
+typedef enum {
+	JIM_LOG_NONE = 0,
+	JIM_LOG_ERROR,
+	JIM_LOG_WARNING,
+	JIM_LOG_INFO,
+	JIM_LOG_DEBUG1,
+	JIM_LOG_DEBUG2,
+	JIM_LOG_DEBUG3,
+} Jim_Log_Level;
+
+#define JIM_LOG_MAX_VALUE JIM_LOG_DEBUG3
+
+typedef struct {
+    void(*logFunction)(const char* logData, void* log_param); /* Function which will handle log output - allows redirection */
+    void* log_param;
+    Jim_Log_Level currentLogLevel;
+} Jim_log_details;
+
+extern Jim_log_details defaultLogging;
+
 /* -----------------------------------------------------------------------------
  * Jim interpreter structure.
  * Fields similar to the real Tcl interpreter structure have the same names.
@@ -553,6 +573,7 @@ typedef struct Jim_Interp {
     Jim_PrngState *prngState; /* per interpreter Random Number Gen. state. */
     struct Jim_HashTable packages; /* Provided packages hash table */
     Jim_Stack *loadHandles; /* handles of loaded modules [load] */
+    Jim_log_details logDetails; /* details of where logging data shall be sent */
 } Jim_Interp;
 
 /* Currently provided as macro that performs the increment.
@@ -894,6 +915,25 @@ JIM_EXPORT FILE *Jim_AioFilehandle(Jim_Interp *interp, Jim_Obj *command);
 /* type inspection - avoid where possible */
 JIM_EXPORT int Jim_IsDict(Jim_Obj *objPtr);
 JIM_EXPORT int Jim_IsList(Jim_Obj *objPtr);
+
+JIM_EXPORT void Jim_SetLogDetails(Jim_Interp *interp, Jim_log_details* logDetails); /* Set the details of where logging data shall be sent */
+JIM_EXPORT int Jim_SetLogLevel(Jim_Interp *interp, int logLevel);
+
+#ifndef JIM_LOGGING_DISABLE
+
+#define JIM_LOG_IS_LOG_LEVEL_IS_MET( interp, level )    ( ((struct Jim_Interp *)(interp))->logDetails.currentLogLevel >= ((Jim_Log_Level)(level)) )
+
+#define JIM_LOG( interp, level, ... )  JimLog( interp, level, __FUNCTION__, __VA_ARGS__)
+
+/* Do not use this directly - use JIM_LOG macro */
+void JimLog( struct Jim_Interp *interp, Jim_Log_Level level, const char* function, const char *fmt, ...);
+
+#else
+
+#define JIM_LOG_IS_LOG_LEVEL_IS_MET( log, level ) (0)
+#define JIM_LOG( interp, level, format, ... )
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/jimsh.c
+++ b/jimsh.c
@@ -76,6 +76,7 @@ void usage(const char* executable_name)
     printf("Options:\n");
     printf("         --version  : prints the version string\n");
     printf("         --help     : prints this text\n");
+    printf("         -d level   : sets the debug output level - %d (None) to %d (everything)\n", JIM_LOG_NONE, JIM_LOG_MAX_VALUE);
     printf("         -e CMD     : executes command CMD\n");
     printf("                      NOTE: all subsequent options will be passed as arguments to the command\n");
     printf("         [filename] : executes the script contained in the named file\n");
@@ -97,6 +98,35 @@ int main(int argc, char *const argv[])
         usage(argv[0]);
         return 0;
     }
+    else if (argc > 2 && strncmp(argv[1], "-d", 2) == 0) {
+		char* level_str;
+		if ( strlen(argv[1]) > 2 )
+		{
+			/* no space */
+			level_str = argv[1] + 2;
+			argc--;
+			argv++;
+		}
+		else
+		{
+			/* space between -d and level */
+			level_str = argv[2];
+			argc -= 2;
+			argv += 2;
+		}
+        /* set debug level */
+		if ( 1 != sscanf( level_str, "%u", &defaultLogging.currentLogLevel ) )
+		{
+			printf("Invalid debug level value - valid range is %d (None) to %d (everything)\n", JIM_LOG_NONE, JIM_LOG_MAX_VALUE);
+            return -1;
+		}
+
+        if ((defaultLogging.currentLogLevel < JIM_LOG_NONE) || (defaultLogging.currentLogLevel > JIM_LOG_MAX_VALUE)) {
+            printf("Invalid debug level value - valid range is %d (None) to %d (everything)\n", JIM_LOG_NONE, JIM_LOG_MAX_VALUE);
+            return -1;
+        }
+    }
+
 
     /* Create and initialize the interpreter */
     interp = Jim_CreateInterp();


### PR DESCRIPTION
I re-did the logging commit with just the basic logging functions.  These are unused so far, but further commits can swap existing debug prints to use them...
