### PR TITLE
jim: make the Jim memory allocator replaceable

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -615,24 +615,25 @@ static void JimPanicDump(int condition, const char *fmt, ...)
  * Memory allocation
  * ---------------------------------------------------------------------------*/
 
-void *Jim_Alloc(int size)
+void *JimDefaultAllocator(void *ptr, size_t size)
 {
-    return size ? malloc(size) : NULL;
+    if (size == 0) {
+        free(ptr);
+        return NULL;
+    }
+    else if (ptr) {
+        return realloc(ptr, size);
+    }
+    else {
+        return malloc(size);
+    }
 }
 
-void Jim_Free(void *ptr)
-{
-    free(ptr);
-}
-
-void *Jim_Realloc(void *ptr, int size)
-{
-    return realloc(ptr, size);
-}
+void *(*Jim_Allocator)(void *ptr, size_t size) = JimDefaultAllocator;
 
 char *Jim_StrDup(const char *s)
 {
-    return strdup(s);
+    return Jim_StrDupLen(s, strlen(s));
 }
 
 char *Jim_StrDupLen(const char *s, int l)

--- a/jim.h
+++ b/jim.h
@@ -599,9 +599,17 @@ typedef struct Jim_Reference {
 #define JIM_EXPORT
 
 /* Memory allocation */
-JIM_EXPORT void *Jim_Alloc (int size);
-JIM_EXPORT void *Jim_Realloc(void *ptr, int size);
-JIM_EXPORT void Jim_Free (void *ptr);
+
+/* The default Jim Allocator can be replaced by assigning to Jim_Allocator.
+ * This function does malloc/realloc/free depending on the arguments.
+ * If size is 0, ptr is freed.
+ * Otherwise malloc or realloc is done depending on whether ptr is NULL.
+ */
+JIM_EXPORT void *(*Jim_Allocator)(void *ptr, size_t size);
+
+#define Jim_Free(P) Jim_Allocator((P), 0)
+#define Jim_Realloc(P, S) Jim_Allocator((P), (S))
+#define Jim_Alloc(S) Jim_Allocator(NULL, (S))
 JIM_EXPORT char * Jim_StrDup (const char *s);
 JIM_EXPORT char *Jim_StrDupLen(const char *s, int l);
 


### PR DESCRIPTION
For those concerned about handling out-of-memory situations, or debugging allocation, this allows the allocator to be replaced with a custom version.
