### PR TITLE
add POSIX lock/unlock methods to aio objects

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -104,7 +104,7 @@ cc-check-functions ualarm lstat fork vfork system select execvpe
 cc-check-functions backtrace geteuid mkstemp realpath strptime isatty
 cc-check-functions regcomp waitpid sigaction sys_signame sys_siglist isascii
 cc-check-functions syslog opendir readlink sleep usleep pipe getaddrinfo utimes
-cc-check-functions shutdown socketpair isinf isnan link symlink fsync dup
+cc-check-functions shutdown socketpair isinf isnan link symlink fsync dup lockf
 
 if {[cc-check-functions sysinfo]} {
     cc-with {-includes sys/sysinfo.h} {

--- a/auto.def
+++ b/auto.def
@@ -104,7 +104,7 @@ cc-check-functions ualarm lstat fork vfork system select execvpe
 cc-check-functions backtrace geteuid mkstemp realpath strptime isatty
 cc-check-functions regcomp waitpid sigaction sys_signame sys_siglist isascii
 cc-check-functions syslog opendir readlink sleep usleep pipe getaddrinfo utimes
-cc-check-functions shutdown socketpair isinf isnan link symlink fsync dup lockf
+cc-check-functions shutdown socketpair isinf isnan link symlink fsync dup
 
 if {[cc-check-functions sysinfo]} {
     cc-with {-includes sys/sysinfo.h} {

--- a/jim-aio.c
+++ b/jim-aio.c
@@ -1159,12 +1159,12 @@ static int aio_cmd_verify(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 }
 #endif /* JIM_BOOTSTRAP */
 
-#ifdef HAVE_LOCKF
 static int aio_cmd_lock(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     AioFile *af = Jim_CmdPrivData(interp);
+    struct flock fl = { F_WRLCK, SEEK_SET, 0, 0 };
 
-    switch (lockf(af->fd, F_TLOCK, 0))
+    switch (fcntl(af->fd, F_SETLK, &fl))
     {
         case 0:
             Jim_SetResultInt(interp, 1);
@@ -1190,11 +1190,11 @@ static int aio_cmd_lock(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 static int aio_cmd_unlock(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     AioFile *af = Jim_CmdPrivData(interp);
+    struct flock fl = { F_UNLCK, SEEK_SET, 0, 0 };
 
-    Jim_SetResultInt(interp, lockf(af->fd, F_ULOCK, 0) == 0);
+    Jim_SetResultInt(interp, fcntl(af->fd, F_SETLK, &fl) == 0);
     return JIM_OK;
 }
-#endif
 
 static const jim_subcmd_type aio_command_table[] = {
     {   "read",
@@ -1370,7 +1370,6 @@ static const jim_subcmd_type aio_command_table[] = {
         /* Description: Verifies the certificate of a SSL/TLS channel */
     },
 #endif /* JIM_BOOTSTRAP */
-#if defined(HAVE_LOCKF) && !defined(JIM_BOOTSTRAP)
     {   "lock",
 	NULL,
         aio_cmd_lock,
@@ -1385,7 +1384,6 @@ static const jim_subcmd_type aio_command_table[] = {
         0,
         /* Description: Relase a lock. */
     },
-#endif
     { NULL }
 };
 

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -56,6 +56,7 @@ Changes between 0.76 and 0.77
 1. Add support for `aio sync`
 2. Add SSL and TLS support in aio
 3. Added `zlib`
+4. Add support for `aio lock` and `aio unlock`
 
 Changes between 0.75 and 0.76
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -4511,6 +4512,14 @@ aio
 +$handle *isatty*+::
     Returns 1 if the stream is a tty device.
 
++$handle *lock*+::
+    Apply a POSIX lock to the open file associated with the handle using
+    lockf(3). Only available on platforms that support lockf(3).
+    The handle must be open for write access.
+    Returns 1 if the lock was successfully obtained, 0 otherwise.
+    An error occurs if the handle is not suitable for locking (e.g.
+    if it is not open for write)
+
 +$handle *ndelay ?0|1?*+::
     Set O_NDELAY (if arg). Returns current/new setting.
     Note that in general ANSI I/O interacts badly with non-blocking I/O.
@@ -4546,6 +4555,10 @@ aio
 
 +$handle *ssl* *?-server cert priv?*+::
     Initiates a SSL/TLS session and returns a new stream
+
++$handle *unlock*+::
+    Release a POSIX lock previously acquired by `aio lock`. Only available
+    on platforms that support lockf(3).
 
 +$handle *verify*+::
     Verifies the certificate of a SSL/TLS stream peer

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -4525,7 +4525,7 @@ aio
 
 +$handle *lock*+::
     Apply a POSIX lock to the open file associated with the handle using
-    lockf(3). Only available on platforms that support lockf(3).
+    fcntl(2).
     The handle must be open for write access.
     Returns 1 if the lock was successfully obtained, 0 otherwise.
     An error occurs if the handle is not suitable for locking (e.g.
@@ -4568,8 +4568,7 @@ aio
     Initiates a SSL/TLS session and returns a new stream
 
 +$handle *unlock*+::
-    Release a POSIX lock previously acquired by `aio lock`. Only available
-    on platforms that support lockf(3).
+    Release a POSIX lock previously acquired by `aio lock`.
 
 +$handle *verify*+::
     Verifies the certificate of a SSL/TLS stream peer

--- a/tests/lock.test
+++ b/tests/lock.test
@@ -1,0 +1,60 @@
+# This test file covers POSIX file locking
+#
+# This file contains a collection of tests for one or more of the Tcl built-in
+# commands. Sourcing this file into Tcl runs the tests and generates output
+# for errors.  No output means no errors were found.
+#
+# Copyright (c) 2003-2009 Donal K. Fellows
+# See the file "license.terms" for information on usage and redistribution of
+# this file, and for a DISCLAIMER OF ALL WARRANTIES.
+
+source [file dirname [info script]]/testing.tcl
+
+set fh [open locktest.file w]
+
+test lock-1.1 {grab lock} {
+	$fh lock
+} 1
+
+test lock-1.2 {grab lock again} {
+	$fh lock
+} 1
+
+test lock-1.j {release lock} {
+	$fh unlock
+} 1
+
+test lock-1.4 {release lock again} {
+	$fh unlock
+} 1
+
+test lock-1.5 {grab lock from sub-process} {
+	switch [set pid [os.fork]] {
+	    -1 { error "Fork error." }
+	    0 {
+		# Child process
+		$fh lock
+		sleep 2
+		puts $fh [$fh unlock]
+		exit
+	    }
+	    default {
+		sleep 1
+		set stat [$fh lock]
+		set stat
+	    }
+	}
+} 0
+
+# fcntl() allows unlock on non-held lock so unlock will always return 1
+#set x [os.wait $pid]
+#test lock-1.6 {check unlock in child process} {
+#	$fh seek 0 start
+#	$fh read 1
+#} 1
+
+$fh close
+file delete locktest.file
+
+testreport
+


### PR DESCRIPTION
Hi,

Would you consider adding these lock/unlock methods to the aio object?
I usually then wrap these  in {file lock} and {file unlock} commands.

Thanks.