### PR TITLE
Boolean contstants in expr, `string is boolean` classification

### DIFF
--- a/jim.h
+++ b/jim.h
@@ -816,6 +816,10 @@ JIM_EXPORT int Jim_EvalExpression (Jim_Interp *interp,
 JIM_EXPORT int Jim_GetBoolFromExpr (Jim_Interp *interp,
         Jim_Obj *exprObjPtr, int *boolPtr);
 
+/* boolean object */
+JIM_EXPORT int Jim_GetBoolean(Jim_Interp *interp, Jim_Obj *objPtr,
+        int *booleanPtr);
+
 /* integer object */
 JIM_EXPORT int Jim_GetWide (Jim_Interp *interp, Jim_Obj *objPtr,
         jim_wide *widePtr);

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -56,6 +56,8 @@ Changes between 0.76 and 0.77
 1. Add support for `aio sync`
 2. Add SSL and TLS support in aio
 3. Added `zlib`
+4. Added support for boolean constants in `expr`
+5. `string is` now supports 'boolean' class
 
 Changes between 0.75 and 0.76
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -706,23 +708,29 @@ If no numeric interpretation is possible, then an operand is left
 as a string (and only a limited set of operators may be applied to
 it).
 
+String constants representing boolean constants
+(+'0'+, +'1'+, +'false'+, +'off'+, +'no'+, +'true'+, +'on'+, +'yes'+)
+are also recognized and can be used in logical operations.
+
 1. Operands may be specified in any of the following ways:
 
 2. As a numeric value, either integer or floating-point.
 
-3. As a Tcl variable, using standard '$' notation.
+3. As one of valid boolean constants
+
+4. As a Tcl variable, using standard '$' notation.
 The variable's value will be used as the operand.
 
-4. As a string enclosed in double-quotes.
+5. As a string enclosed in double-quotes.
 The expression parser will perform backslash, variable, and
 command substitutions on the information between the quotes,
 and use the resulting value as the operand
 
-5. As a string enclosed in braces.
+6. As a string enclosed in braces.
 The characters between the open brace and matching close brace
 will be used as the operand without any substitutions.
 
-6. As a Tcl command enclosed in brackets.
+7. As a Tcl command enclosed in brackets.
 The command will be executed and its result will be used as
 the operand.
 
@@ -860,7 +868,7 @@ In any case, overflow and underflow are generally not detected
 reliably for intermediate results.
 
 Conversion among internal representations for integer, floating-point,
-and string operands is done automatically as needed.
+string operands is done automatically as needed.
 For arithmetic computations, integers are used until some
 floating-point number is introduced, after which floating-point is used.
 For example,
@@ -3906,6 +3914,7 @@ The legal options (which may be abbreviated) are:
   +alnum+;;  Any alphabet or digit character.
   +alpha+;;  Any alphabet character.
   +ascii+;;  Any character with a value less than 128 (those that are in the 7-bit ascii range).
+  +boolean+;;  Any of the valid string formats for a boolean value in Tcl (0, false, no, off, 1, true, yes, on)
   +control+;; Any control character.
   +digit+;;  Any digit character.
   +double+;; Any of the valid forms for a double in Tcl, with optional surrounding whitespace.
@@ -3920,6 +3929,8 @@ The legal options (which may be abbreviated) are:
   +xdigit+;; Any hexadecimal digit character ([0-9A-Fa-f]).
  ::
     Note that string classification does +'not'+ respect UTF-8. See UTF-8 AND UNICODE
+ ::
+    Note that only +'lowercase'+ boolean values are recognized (Tcl accepts any case).
 
 +*string last* 'string1 string2 ?lastIndex?'+::
     Search +'string2'+ for a sequence of characters that exactly match

--- a/tests/expr-new.test
+++ b/tests/expr-new.test
@@ -574,6 +574,42 @@ test expr-20.7 {handling of compile error in runtime case} {
     list [catch {expr + {[error foo]}} msg]
 } {1}
 
+test expr-21.1 {checking boolean 0} {
+  expr 0
+} 0
+test expr-21.2 {checking boolean 0} {
+  expr {0 || 0}
+} 0
+test expr-21.3 {checking boolean false} {
+  expr {0 || false}
+} 0
+test expr-21.4 {checking boolean no} {
+  expr {0 || no}
+} 0
+test expr-21.5 {checking boolean off} {
+  expr {0 || off}
+} 0
+test expr-21.6 {checking boolean 1} {
+  expr {0 || 1}
+} 1
+test expr-21.7 {checking boolean true} {
+  expr {0 || true}
+} 1
+test expr-21.8 {checking boolean yes} {
+  expr {0 || yes}
+} 1
+test expr-21.9 {checking boolean on} {
+  expr {0 || on}
+} 1
+test expr-21.7 {checking boolean mixed case} {
+  set res 0
+  try {
+    expr {0 || True}
+  } on error {msg} {
+    set res 1
+  }
+} 1
+
 # cleanup
 if {[info exists a]} {
     unset a

--- a/tests/string.test
+++ b/tests/string.test
@@ -232,10 +232,10 @@ test string-6.4 {string is, too many args} jim {
 } {1 {wrong # args: should be "string is class ?-strict? str"}}
 test string-6.5 {string is, class check} jim {
     list [catch {string is bogus str} msg] $msg
-} {1 {bad class "bogus": must be alnum, alpha, ascii, control, digit, double, graph, integer, lower, print, punct, space, upper, or xdigit}}
+} {1 {bad class "bogus": must be alnum, alpha, ascii, boolean, control, digit, double, graph, integer, lower, print, punct, space, upper, or xdigit}}
 test string-6.6 {string is, ambiguous class} jim {
     list [catch {string is al str} msg] $msg
-} {1 {ambiguous class "al": must be alnum, alpha, ascii, control, digit, double, graph, integer, lower, print, punct, space, upper, or xdigit}}
+} {1 {ambiguous class "al": must be alnum, alpha, ascii, boolean, control, digit, double, graph, integer, lower, print, punct, space, upper, or xdigit}}
 test string-6.10 {string is, ok on empty} {
     string is alpha {}
 } 1
@@ -389,7 +389,39 @@ test string-6.88 {string is punct} {
 test string-6.89 {string is xdigit} {
     list [string is xdigit  0123456789\u0061bcdefABCDEFg]
 } 0
-
+test string-6.90 {string is boolean, true} {
+    list [string is boolean 0]
+} 1
+test string-6.91 {string is boolean, true} {
+    list [string is boolean false]
+} 1
+test string-6.92 {string is boolean, true} {
+    list [string is boolean no]
+} 1
+test string-6.93 {string is boolean, true} {
+    list [string is boolean off]
+} 1
+test string-6.94 {string is boolean, true} {
+    list [string is boolean 1]
+} 1
+test string-6.95 {string is boolean, true} {
+    list [string is boolean true]
+} 1
+test string-6.96 {string is boolean, true} {
+    list [string is boolean yes]
+} 1
+test string-6.97 {string is boolean, true} {
+    list [string is boolean on]
+} 1
+test string-6.98 {string is boolean, not boolean string, false} {
+    list [string is boolean a]
+} 0
+test string-6.99 {string is boolean, special character, false} {
+    list [string is boolean -]
+} 0
+test string-6.10 {string is boolean, mixed case, false} {
+    list [string is boolean True]
+} 0
 test string-7.1 {string last, too few args} {
     list [catch {string last a} msg]
 } {1}

--- a/tests/while.test
+++ b/tests/while.test
@@ -110,6 +110,10 @@ test while-old-5.2 {while return result} {
     set x 1
     while {$x} {set x 0}
 } {}
+test while-old-5.3 {while return result} {
+    set x true
+    while {$x} {set x 0}
+} {}
 
 # cleanup
 testreport


### PR DESCRIPTION
* named boolean values in `expr` are internally converted to int
* named constants are lower-case only