### PR TITLE
Add AppVeyor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ addons:
     packages:
       - libsqlite3-dev
 before_script:
-  - ./configure --with-ext="oo tree binary sqlite3" --enable-utf8 --ipv6 --disable-docs
+  - ./configure --with-ext="oo tree binary sqlite3 zlib" --enable-utf8 --ipv6 --disable-docs
 script:
   - make test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+version: "0.76.0.{build}"
+install:
+  - cmd: set MSYSTEM=MINGW32
+  - cmd: C:\msys64\usr\bin\bash -lc "pacman --sync --noconfirm make mingw-w64-i686-gcc"
+build_script:
+  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; ./configure --with-ext='oo tree binary tclprefix zlib'"
+  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; make"
+test_script:
+  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; make test"
+artifacts:
+  - path: jimsh.exe

--- a/tests/zlib.test
+++ b/tests/zlib.test
@@ -11,9 +11,10 @@
 # this file, and for a DISCLAIMER OF ALL WARRANTIES.
 
 source [file dirname [info script]]/testing.tcl
-source [file dirname [info script]]/testing.tcl
 
 needs cmd zlib
+
+testConstraint regexp [expr {[info commands regexp] eq {regexp}}]
 
 test zlib-1.1 {zlib deflate usage 1} -returnCodes error -body {
     zlib deflate
@@ -39,9 +40,10 @@ test zlib-1.6 {zlib inflate usage 3} -returnCodes error -body {
     zlib inflate afdfdfdsfdsfsd f
 } -result {expected integer but got "f"}
 
-test zlib-1.7 {zlib inflate usage 4} -returnCodes error -body {
+test zlib-1.7 {zlib inflate usage 4} \
+        -constraints regexp -returnCodes error -body {
     zlib inflate afdfdfdsfdsfsd 0
-} -result {buffer size must be 0 to 2147483647}
+} -match regexp -result {buffer size must be 0 to (2147483647|0x7fffffff)}
 
 test zlib-2.1 {zlib deflate/inflate} {
     zlib inflate [zlib deflate abcdefghijklm]
@@ -51,9 +53,10 @@ test zlib-2.2 {zlib deflate/inflate level and size known} {
     zlib inflate [zlib deflate abcdefghijklm 9] 13
 } abcdefghijklm
 
-test zlib-2.3 {zlib deflate/inflate bad size} -returnCodes error -body {
+test zlib-2.3 {zlib deflate/inflate bad size} \
+        -constraints regexp -returnCodes error -body {
     zlib inflate [zlib deflate abcdefghijklm 9] 0
-} -result {buffer size must be 0 to 2147483647}
+} -match regexp -result {buffer size must be 0 to (2147483647|0x7fffffff)}
 
 test zlib-2.4 {zlib deflate/inflate wrong size} {
     zlib inflate [zlib deflate abcdefghijklm] 6
@@ -83,9 +86,10 @@ test zlib-3.6 {zlib gunzip usage 5} -returnCodes error -body {
     zlib gunzip aaa -buffersize a
 } -result {wrong # args: should be "data ?-buffersize size?"}
 
-test zlib-3.7 {zlib gunzip usage 6} -returnCodes error -body {
+test zlib-3.7 {zlib gunzip usage 6} \
+        -constraints regexp -returnCodes error -body {
     zlib gunzip aaa -buffersize 0
-} -result {buffer size must be 0 to 2147483647}
+} -match regexp -result {buffer size must be 0 to (2147483647|0x7fffffff)}
 
 test zlib-3.8 {zlib gzip usage 1} -returnCodes error -body {
     zlib gzip


### PR DESCRIPTION
This runs AppVeyor CI to build Jim (with the additional extensions oo, tree, binary, tclprefix, zlib <s>and win32</s>), run the tests and package the Windows binary for every commit. However, the tests currently fail:

```
exec-3.5 ERR redirecting output to file
At      : exec.test:107
Expected: 'rc=ok return result=First line
Second line'
Got     : 'rc=error result=/usr/bin/echo: write error: Bad file descriptor'
exec-3.6 ERR redirecting output to file
At      : exec.test:112
Expected: 'rc=ok return result=First line
Second line'
Got     : 'rc=error result=/usr/bin/echo: write error: Bad file descriptor'
exec-4.3 ERR redirecting output and stderr to file
At      : exec.test:139
Expected: 'rc=ok return result={} {first line
foo bar}'
Got     : 'rc=error result='
exec-12.1 ERR reaping background processes
At      : exec.test:345
Expected: '0'
Got     : 'couldn't'
exec-15.5 ERR standard error redirection
At      : exec.test:388
Expected: 'rc=ok return result=First line
foo bar'
Got     : 'rc=error result='
       exec.test: Total    76   Passed    71  Skipped     0  Failed     5
------------------------------------------------------------
FAILED: 5
	exec.test:107	exec-3.5
	exec.test:112	exec-3.6
	exec.test:139	exec-4.3
	exec.test:345	exec-12.1
	exec.test:388	exec-15.5
------------------------------------------------------------
```

Each of the failed tests involves [exec] appending the output of a command to a file. E.g. (this is the MSYS2 shell),

```
$ ./jimsh.exe -e 'exec echo "First line" >> new.file' && cat new.file
/usr/bin/echo: write error: Bad file descriptor
```

However, the `>` redirect works:

```
$ ./jimsh.exe -e 'exec echo "First line" > new.file' && cat new.file

First line

```

At a glance, I can't find the precise reason why this happens but it looks like a bug. I'll investigate later.