### PR TITLE
Memory & Resource fixes

### DIFF
--- a/jim-exec.c
+++ b/jim-exec.c
@@ -1402,6 +1402,7 @@ JimWinFindExecutable(const char *originalName, char fullPath[MAX_PATH])
 
     for (i = 0; i < (int) (sizeof(extensions) / sizeof(extensions[0])); i++) {
         snprintf(fullPath, MAX_PATH, "%s%s", originalName, extensions[i]);
+        fullPath[MAX_PATH-1] = 0;
 
         if (SearchPath(NULL, fullPath, NULL, MAX_PATH, fullPath, NULL) == 0) {
             continue;

--- a/jim-exec.c
+++ b/jim-exec.c
@@ -1048,9 +1048,14 @@ badargs:
 
         if (inputId != JIM_BAD_FD) {
             JimCloseFd(inputId);
+            inputId = JIM_BAD_FD;
         }
         if (outputId != JIM_BAD_FD) {
             JimCloseFd(outputId);
+            if (outputId == lastOutputId) {
+                lastOutputId = JIM_BAD_FD;
+            }
+            outputId = JIM_BAD_FD;
         }
         inputId = pipeIds[0];
         pipeIds[0] = pipeIds[1] = JIM_BAD_FD;
@@ -1064,12 +1069,15 @@ badargs:
   cleanup:
     if (inputId != JIM_BAD_FD) {
         JimCloseFd(inputId);
+        inputId = JIM_BAD_FD;
     }
     if (lastOutputId != JIM_BAD_FD) {
         JimCloseFd(lastOutputId);
+        lastOutputId = JIM_BAD_FD;
     }
     if (errorId != JIM_BAD_FD) {
         JimCloseFd(errorId);
+        errorId = JIM_BAD_FD;
     }
     Jim_Free(arg_array);
 

--- a/jim-interactive.c
+++ b/jim-interactive.c
@@ -23,13 +23,13 @@ char *Jim_HistoryGetline(const char *prompt)
     return linenoise(prompt);
 #else
     int len;
-    char *line = malloc(MAX_LINE_LEN);
+    char *line = Jim_Alloc(MAX_LINE_LEN);
 
     fputs(prompt, stdout);
     fflush(stdout);
 
     if (fgets(line, MAX_LINE_LEN, stdin) == NULL) {
-        free(line);
+    	Jim_Free(line);
         return NULL;
     }
     len = strlen(line);
@@ -139,7 +139,7 @@ int Jim_InteractivePrompt(Jim_Interp *interp)
                 Jim_AppendString(interp, scriptObjPtr, "\n", 1);
             }
             Jim_AppendString(interp, scriptObjPtr, line, -1);
-            free(line);
+            Jim_Free(line);
             if (Jim_ScriptIsComplete(interp, scriptObjPtr, &state))
                 break;
 

--- a/jim-interactive.c
+++ b/jim-interactive.c
@@ -113,6 +113,7 @@ int Jim_InteractivePrompt(Jim_Interp *interp)
             else {
                 snprintf(prompt, sizeof(prompt) - 3, "[%s] . ", retcodestr);
             }
+            prompt[sizeof(prompt) - 1] = '\x0'; /* Force termination */
         }
         else {
             strcpy(prompt, ". ");

--- a/jim-package.c
+++ b/jim-package.c
@@ -51,6 +51,7 @@ static char *JimFindPackage(Jim_Interp *interp, Jim_Obj *prefixListObj, const ch
         /* Loadable modules are tried first */
 #ifdef jim_ext_load
         snprintf(buf, JIM_PATH_LEN, "%s/%s.so", prefix, pkgName);
+        buf[JIM_PATH_LEN - 1] = '\x0'; /* Force termination */
         if (access(buf, R_OK) == 0) {
             return buf;
         }
@@ -61,6 +62,7 @@ static char *JimFindPackage(Jim_Interp *interp, Jim_Obj *prefixListObj, const ch
         else {
             snprintf(buf, JIM_PATH_LEN, "%s/%s.tcl", prefix, pkgName);
         }
+        buf[JIM_PATH_LEN - 1] = '\x0'; /* Force termination */
 
         if (access(buf, R_OK) == 0) {
             return buf;

--- a/jim-signal.c
+++ b/jim-signal.c
@@ -23,7 +23,7 @@
 
 static jim_wide *sigloc;
 static jim_wide sigsblocked;
-static struct sigaction *sa_old;
+static struct sigaction sa_old[MAX_SIGNALS];
 static struct {
     int status;
     const char *name;
@@ -222,10 +222,6 @@ static int do_signal_cmd(Jim_Interp *interp, int action, int argc, Jim_Obj *cons
                 case SIGNAL_ACTION_HANDLE:
                 case SIGNAL_ACTION_IGNORE:
                     if (siginfo[sig].status == SIGNAL_ACTION_DEFAULT) {
-                        if (!sa_old) {
-                            /* Allocate the structure the first time through */
-                            sa_old = Jim_Alloc(sizeof(*sa_old) * MAX_SIGNALS);
-                        }
                         sigaction(sig, &sa, &sa_old[sig]);
                     }
                     else {
@@ -235,9 +231,7 @@ static int do_signal_cmd(Jim_Interp *interp, int action, int argc, Jim_Obj *cons
 
                 case SIGNAL_ACTION_DEFAULT:
                     /* Restore old handler */
-                    if (sa_old) {
-                        sigaction(sig, &sa_old[sig], 0);
-                    }
+                    sigaction(sig, &sa_old[sig], 0);
             }
             siginfo[sig].status = action;
         }

--- a/jimregexp.c
+++ b/jimregexp.c
@@ -252,7 +252,7 @@ int regcomp(regex_t *preg, const char *exp, int cflags)
 
 	/* Allocate space. */
 	preg->proglen = (strlen(exp) + 1) * 5;
-	preg->program = malloc(preg->proglen * sizeof(int));
+	preg->program = Jim_Alloc(preg->proglen * sizeof(int));
 	if (preg->program == NULL)
 		FAIL(preg, REG_ERR_NOMEM);
 
@@ -976,7 +976,7 @@ static void reg_grow(regex_t *preg, int n)
 {
 	if (preg->p + n >= preg->proglen) {
 		preg->proglen = (preg->p + n) * 2;
-		preg->program = realloc(preg->program, preg->proglen * sizeof(int));
+		preg->program = Jim_Realloc(preg->program, preg->proglen * sizeof(int));
 	}
 }
 
@@ -1870,7 +1870,7 @@ size_t regerror(int errcode, const regex_t *preg, char *errbuf,  size_t errbuf_s
 
 void regfree(regex_t *preg)
 {
-	free(preg->program);
+	Jim_Free(preg->program);
 }
 
 #endif

--- a/linenoise.c
+++ b/linenoise.c
@@ -1538,6 +1538,7 @@ char *linenoise(const char *prompt)
             return NULL;
         }
     }
+    buf[sizeof(buf) - 1] = '\x0'; /* Force termination */
     return strdup(buf);
 }
 

--- a/sqlite3/jim-sqlite3.c
+++ b/sqlite3/jim-sqlite3.c
@@ -903,7 +903,7 @@ static char *local_getline(char *zPrompt, FILE *in){
   while( !eol ){
     if( n+100>nLine ){
       nLine = nLine*2 + 100;
-      zLine = realloc(zLine, nLine);
+      zLine = Jim_Realloc(zLine, nLine);
       if( zLine==0 ) return 0;
     }
     if( fgets(&zLine[n], nLine - n, in)==0 ){
@@ -922,7 +922,7 @@ static char *local_getline(char *zPrompt, FILE *in){
       eol = 1;
     }
   }
-  zLine = realloc( zLine, n+1 );
+  zLine = Jim_Realloc( zLine, n+1 );
   return zLine;
 }
 


### PR DESCRIPTION
Hi Steve,

Here's some changes to fix:
- a memory leak
- possible null non-termination problems with snprintf
- Usage of malloc/realloc/free rather than Jim_ variants
- Prevention of double-closing file descriptors

Regards,

Evan