### PR TITLE
Add some tests for paths identified as untested by gcov.

### DIFF
--- a/jim-tclprefix.c
+++ b/jim-tclprefix.c
@@ -128,7 +128,6 @@ static int Jim_TclPrefixCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const
             }
             return JIM_ERR;
         }
-        break;
 
         case OPT_ALL:
             if (argc != 4) {
@@ -184,7 +183,7 @@ static int Jim_TclPrefixCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const
                 return JIM_OK;
             }
     }
-    return JIM_ERR;
+    return JIM_ERR; /* Cannot ever get here */
 }
 
 int Jim_tclprefixInit(Jim_Interp *interp)

--- a/tests/format.test
+++ b/tests/format.test
@@ -508,6 +508,10 @@ test format-16.4 {format %b} {
     format %b 1234567
 } {100101101011010000111}
 
+test format-16.5 {format %b} {
+    list [catch {format %b badvalue} msg] $msg
+} {1 {expected integer but got "badvalue"}}
+
 # cleanup
 catch {unset a}
 catch {unset b}

--- a/tests/prefix.test
+++ b/tests/prefix.test
@@ -20,6 +20,9 @@ testConstraint namespace [expr {[info commands namespace] ne ""}]
 test string-26.1 {tcl::prefix, too few args} -body {
     tcl::prefix match a
 } -returnCodes 1 -match glob -result {wrong # args: should be "tcl::prefix match ?options*? table string"}
+test string-26.1.1 {tcl::prefix, too few args} -body {
+    tcl::prefix
+} -returnCodes 1 -match glob -result {wrong # args: should be "tcl::prefix subcommand ?arg ...?"}
 test string-26.2 {tcl::prefix, bad args} -body {
     tcl::prefix match a b c
 } -returnCodes 1 -result {bad option "a": must be -error, -exact, or -message}
@@ -27,6 +30,9 @@ test string-26.2.1 {tcl::prefix, empty table} -body {
     tcl::prefix match {} foo
 } -returnCodes 1 -result {bad option "foo": no valid options}
 
+test string-26.2.2 {tcl::prefix, bad args} -body {
+    tcl::prefix badoption
+} -returnCodes 1 -result {bad option "badoption": must be all, longest, or match}
 
 
 test string-26.3.1 {tcl::prefix, bad args} -body {

--- a/tests/regexp.test
+++ b/tests/regexp.test
@@ -222,6 +222,10 @@ test regexp-6.8 {regexp errors} jim {
 test regexp-6.9 {regexp errors, -start bad int check} {
     list [catch {regexp -start bogus {^$} {}} msg] $msg
 } {1 {bad index "bogus": must be integer?[+-]integer? or end?[+-]integer?}}
+test regexp-6.10 {regexp errors, -start too few args} {
+    list [catch {regexp -all -start} msg] $msg
+} {1 {wrong # args: should be "regexp ?-switch ...? exp string ?matchVar? ?subMatchVar ...?"}}
+
 
 test regexp-7.1 {basic regsub operation} {
     list [regsub aa+ xaxaaaxaa 111&222 foo] $foo
@@ -388,6 +392,10 @@ test regexp-11.11 {regsub without final variable name returns value} {
 test regexp-11.12 {regsub without final variable name returns value} {
     regsub -all b(\[^d\]*)d abcdeabcfde {,&,\1,}
 } {a,bcd,c,ea,bcfd,cf,e}
+test regexp-11.13 {regsub errors, -start too few args} {
+    list [catch {regsub -all -nocase -nocase -start} msg] $msg
+} {1 {wrong # args: should be "regsub ?-switch ...? exp string subSpec ?varName?"}}
+
 
 # This test crashes on the Mac unless you increase the Stack Space to about 1
 # Meg.  This is probably bigger than most users want... 


### PR DESCRIPTION
Also prune a 'break' which was unreachable.