### PR TITLE
Fix test target for out-of-tree builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -113,7 +113,7 @@ uninstall:
 @endif
 
 test check: $(JIMSH)
-	cd @srcdir@/tests; $(DEF_LD_PATH) $(MAKE) jimsh=@builddir@/jimsh TOPSRCDIR=@top_srcdir@
+	cd @srcdir@/tests; $(DEF_LD_PATH) $(MAKE) jimsh=@builddir@/jimsh TOPSRCDIR=..
 
 $(OBJS): Makefile $(wildcard *.h)
 


### PR DESCRIPTION
Without this, jimsh cannot find tcltest.tcl properly when building out-of-tree