### PR TITLE
Fix makefile dependencies

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -115,7 +115,7 @@ uninstall:
 test check: $(JIMSH)
 	cd @srcdir@/tests; $(DEF_LD_PATH) $(MAKE) jimsh=@builddir@/jimsh TOPSRCDIR=..
 
-$(OBJS): Makefile $(wildcard *.h)
+$(OBJS) jimsh.o initjimsh.o: Makefile $(wildcard *.h)
 
 @if JIM_UTF8
 # Generate the unicode case mapping


### PR DESCRIPTION
Not all objects were dependent on the Makefile/headers, so the following
build sequence resulted in failure:

./configure CFLAGS="--coverage" LDFLAGS="--coverage" && make
./configure && make