### PR TITLE
Avoid re-defining _GNU_SOURCE

### DIFF
--- a/jim-aio.c
+++ b/jim-aio.c
@@ -39,7 +39,9 @@
 
 #include "jimautoconf.h"
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>

--- a/jim-exec.c
+++ b/jim-exec.c
@@ -20,7 +20,9 @@
  * express or implied warranty.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <string.h>
 #include <ctype.h>
 

--- a/jim.c
+++ b/jim.c
@@ -41,7 +41,9 @@
  * official policies, either expressed or implied, of the Jim Tcl Project.
  **/
 #define JIM_OPTIMIZATION        /* comment to avoid optimizations and reduce size */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE             /* Mostly just for environ */
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
pkgconfig for SDL causes _GNU_SOURCE to be defined on the commandline,
hence causing an error when these source files re-define it.