### PR TITLE
Fix environment argument for Windows CreateProcess

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ install:
   - cmd: set MSYSTEM=MINGW32
   - cmd: C:\msys64\usr\bin\bash -lc "pacman --sync --noconfirm make mingw-w64-i686-gcc"
 build_script:
-  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; ./configure --full --with-ext='zlib' --disable-docs"
+  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; ./configure --full --with-ext='zlib win32' --disable-docs"
   - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; make"
 test_script:
   - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; make test"

--- a/jim-exec.c
+++ b/jim-exec.c
@@ -119,7 +119,7 @@ int Jim_execInit(Jim_Interp *interp)
     static fdtype JimOpenForRead(const char *filename);
     static FILE *JimFdOpenForRead(fdtype fd);
     static int JimPipe(fdtype pipefd[2]);
-    static pidtype JimStartWinProcess(Jim_Interp *interp, char **argv, char *env,
+    static pidtype JimStartWinProcess(Jim_Interp *interp, char **argv, char **env,
         fdtype inputId, fdtype outputId, fdtype errorId);
     static int JimErrno(void);
 #else
@@ -984,7 +984,7 @@ badargs:
         /* Now fork the child */
 
 #ifdef __MINGW32__
-        pid = JimStartWinProcess(interp, &arg_array[firstArg], save_environ ? save_environ[0] : NULL, inputId, outputId, errorId);
+        pid = JimStartWinProcess(interp, &arg_array[firstArg], save_environ, inputId, outputId, errorId);
         if (pid == JIM_BAD_PID) {
             Jim_SetResultFormatted(interp, "couldn't exec \"%s\"", arg_array[firstArg]);
             goto error;
@@ -1510,7 +1510,7 @@ JimWinBuildCommandLine(Jim_Interp *interp, char **argv)
 }
 
 static pidtype
-JimStartWinProcess(Jim_Interp *interp, char **argv, char *env, fdtype inputId, fdtype outputId, fdtype errorId)
+JimStartWinProcess(Jim_Interp *interp, char **argv, char **env, fdtype inputId, fdtype outputId, fdtype errorId)
 {
     STARTUPINFO startInfo;
     PROCESS_INFORMATION procInfo;
@@ -1584,8 +1584,41 @@ JimStartWinProcess(Jim_Interp *interp, char **argv, char *env, fdtype inputId, f
         goto end;
     }
 
-    if (!CreateProcess(NULL, (char *)Jim_String(cmdLineObj), NULL, NULL, TRUE,
-            0, env, NULL, &startInfo, &procInfo)) {
+    char* env2 = NULL;
+    if (env) {
+        /* CreateProcess requires a different environment format
+         * Variables must be in one block with a null at the end
+         * of each variable, and another null after the last
+         * terminating null
+         * Create new environment
+         */
+        unsigned long env_length = 0;
+        char** envptr = env;
+        /* Count total size of environment */
+        while (*envptr != NULL)
+        {
+            env_length += strlen(*envptr) + 1;
+            envptr++;
+        }
+        /* Allocate space for new environment block */
+        env2 = (char*)malloc(env_length + 1);
+        envptr = env;
+        char* env2ptr = env2;
+        /* Copy variables into new environment block */
+        while (*envptr != NULL)
+        {
+            strcpy(env2ptr, *envptr);
+            env2ptr += strlen(*envptr) + 1;
+            envptr++;
+        }
+        /* Add extra termination null */
+        *env2ptr = 0;
+    }
+
+    BOOL result = CreateProcess(NULL, (char *)Jim_String(cmdLineObj), NULL, NULL, TRUE,
+                                      0, env2, NULL, &startInfo, &procInfo);
+    free(env2);
+    if (!result) {
         goto end;
     }
 

--- a/jim-win32.c
+++ b/jim-win32.c
@@ -92,7 +92,7 @@ Win32ErrorObj(Jim_Interp *interp, const char * szPrefix, DWORD dwError)
 static int
 Win32_ShellExecute(Jim_Interp *interp, int objc, Jim_Obj * const *objv)
 {
-    int r;
+    HINSTANCE r;
     const char *verb, *file, *parm = NULL;
     char cwd[MAX_PATH + 1];
 
@@ -105,11 +105,11 @@ Win32_ShellExecute(Jim_Interp *interp, int objc, Jim_Obj * const *objv)
     GetCurrentDirectoryA(MAX_PATH + 1, cwd);
     if (objc == 4)
         parm = Jim_String(objv[3]);
-    r = (int)ShellExecuteA(NULL, verb, file, parm, cwd, SW_SHOWNORMAL);
-    if (r < 33)
+    r = ShellExecuteA(NULL, verb, file, parm, cwd, SW_SHOWNORMAL);
+    if ((jim_wide)r < 33)
         Jim_SetResult(interp,
             Win32ErrorObj(interp, "ShellExecute", GetLastError()));
-    return (r < 33) ? JIM_ERR : JIM_OK;
+    return ((jim_wide)r < 33) ? JIM_ERR : JIM_OK;
 }
 
 
@@ -163,7 +163,7 @@ Win32_CloseWindow(Jim_Interp *interp, int objc, Jim_Obj * const *objv)
 static int
 Win32_GetActiveWindow(Jim_Interp *interp, int objc, Jim_Obj * const *objv)
 {
-    Jim_SetResult(interp, Jim_NewIntObj(interp, (DWORD)GetActiveWindow()));
+    Jim_SetResult(interp, Jim_NewIntObj(interp, (jim_wide)GetActiveWindow()));
     return JIM_OK;
 }
 


### PR DESCRIPTION
Required a different environment format - was previously causing errors and failing to execute some commands

This is what has been causing the failures on appveyor build tests