### PR TITLE
Fix test-compile warnings in autosetup/cc.tcl and auto.def

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -148,7 +148,7 @@ define tclsh [info nameofexecutable]
 
 if {![cc-check-functions _NSGetEnviron]} {
     msg-checking "Checking environ declared in unistd.h..."
-    if {[cctest -cflags {-D_GNU_SOURCE -D_POSIX_SOURCE} -includes unistd.h -code {char **ep = environ;}]} {
+    if {[cctest -cflags {-D_GNU_SOURCE -D_POSIX_SOURCE} -includes unistd.h -code {char **ep = environ; (void)ep;}]} {
         define NO_ENVIRON_EXTERN
         msg-result "yes"
     } else {

--- a/autosetup/cc.tcl
+++ b/autosetup/cc.tcl
@@ -38,12 +38,12 @@ proc cc-check-something {name code} {
 # Checks for the existence of the given function by linking
 #
 proc cctest_function {function} {
-	cctest -link 1 -declare "extern void $function\(void);" -code "$function\();"
+	cctest -cflags "-fno-builtin" -link 1 -declare "extern void $function\(void);" -code "$function\();"
 }
 
 # Checks for the existence of the given type by compiling
 proc cctest_type {type} {
-	cctest -code "$type _x;"
+	cctest -code "$type _x; (void) _x;"
 }
 
 # Checks for the existence of the given type/structure member.
@@ -80,7 +80,7 @@ proc cc-check-sizeof {args} {
 		set size unknown
 		# Try the most common sizes first
 		foreach i {4 8 1 2 16 32} {
-			if {[cctest -code "static int _x\[sizeof($type) == $i ? 1 : -1\] = { 1 };"]} {
+			if {[cctest -code "static int _x\[sizeof($type) == $i ? 1 : -1\] = { 1 }; (void) _x;"]} {
 				set size $i
 				break
 			}


### PR DESCRIPTION
Building with CFLAGS="-Werror -Wall" caused configure to fail due to
the following warnings being converted to errors:

* conflicting types for built-in function
* unused variable

When these warnings get converted to errors, they prevent the detection
of fork, isascii, isinf, isnan, math libs, long long & struct flock.

These changes prevent the warnings - the following command now works
correctly:
./configure --full CFLAGS="-Werror -Wall" && make