### PR TITLE
improve example autocompletion to complete partially typed arguments

### DIFF
--- a/initjimsh.tcl
+++ b/initjimsh.tcl
@@ -49,11 +49,13 @@ set tcl::autocomplete_commands {info tcl::prefix socket namespace array clock fi
 # Simple interactive command line completion callback
 # Explicitly knows about some commands that support "-commands"
 proc tcl::autocomplete {prefix} {
-	if {[string match "* " $prefix]} {
-		set cmd [string range $prefix 0 end-1]
+	if {[set space [string first " " $prefix]] != -1} {
+		set cmd [string range $prefix 0 $space-1]
 		if {$cmd in $::tcl::autocomplete_commands || [info channel $cmd] ne ""} {
+			set arg [string range $prefix $space+1 end]
 			# Add any results from -commands
 			return [lmap p [$cmd -commands] {
+				if {![string match "${arg}*" $p]} continue
 				function "$cmd $p"
 			}]
 		}


### PR DESCRIPTION
I know the included autocomplete function is just an example but this small change improves it so that tab will autocomplete partially typed arguments too.

See https://asciinema.org/a/dee53an94es3s332ytm2ajq2o for an example session.