### PR TITLE
Separate out Jim specific tests

### DIFF
--- a/tests/expr-base.test
+++ b/tests/expr-base.test
@@ -7,7 +7,6 @@ set good_testcases {
 	8			8
 	00			0
 	07			7
-	08			8
 	0x5			5
 	0x0			0
 	0x00		0
@@ -23,6 +22,11 @@ foreach {str exp} $good_testcases {
 	test expr-base-1.[incr i] "expr conversion" [list expr [list $str]] $exp
 }
 
+# JimTCL specifically does not adhere to the octal default for numbers starting with zero
+test expr-base-2.1 {expr conversion jim specific} -constraints jim -body {
+    expr [list "08"]
+} -result {8}
+
 set bad_testcases {
 	{0x + 1}
 	x
@@ -34,6 +38,6 @@ set bad_testcases {
 
 set i 0
 foreach str $bad_testcases {
-	test expr-base-2.[incr i] "expr conversion failure" -returnCodes error -body [list expr $str] -match glob -result "*"
+	test expr-base-3.[incr i] "expr conversion failure" -returnCodes error -body [list expr $str] -match glob -result "*"
 }
 testreport

--- a/tests/expr-new.test
+++ b/tests/expr-new.test
@@ -294,7 +294,12 @@ test expr-9.10 {CompileRelationalExpr: error compiling relational arm} {
 test expr-10.1 {CompileShiftExpr: just add expr} {expr 4+-2} 2
 test expr-10.2 {CompileShiftExpr: just add expr} {expr 0xff-2} 253
 test expr-10.3 {CompileShiftExpr: just add expr} {expr -1--2} 1
-test expr-10.4 {CompileShiftExpr: just add expr} {expr 1-0123} -122
+
+# JimTCL specifically does not adhere to the octal default for numbers starting with zero
+test expr-10.4 {CompileShiftExpr: just add expr} -constraints jim -body {
+    expr 1-0123
+} -result {-122}
+
 test expr-10.5 {CompileShiftExpr: error in add expr} {
     catch {expr x+3} msg
 } {1}
@@ -316,7 +321,11 @@ test expr-10.11 {CompileShiftExpr: runtime error} {
 test expr-11.1 {CompileAddExpr: just multiply expr} {expr 4*-2} -8
 test expr-11.2 {CompileAddExpr: just multiply expr} {expr 0xff%2} 1
 test expr-11.3 {CompileAddExpr: just multiply expr} {expr -1/2} -1
-test expr-11.4 {CompileAddExpr: just multiply expr} {expr 7891%0123} 19
+# JimTCL specifically does not adhere to the octal default for numbers starting with zero
+test expr-11.4 {CompileAddExpr: just multiply expr} -constraints jim -body {
+    expr 7891%0123
+} -result {19}
+
 test expr-11.5 {CompileAddExpr: error in multiply expr} {
     catch {expr x*3} msg
 } {1}
@@ -367,7 +376,11 @@ test expr-12.11 {CompileMultiplyExpr: runtime error} {
 } {1}
 
 test expr-13.1 {CompileUnaryExpr: unary exprs} {expr -0xff} -255
-test expr-13.2 {CompileUnaryExpr: unary exprs} {expr +000123} 123
+# JimTCL specifically does not adhere to the octal default for numbers starting with zero
+test expr-13.2 {CompileUnaryExpr: unary exprs} -constraints jim -body {
+    expr +000123
+} -result {123}
+
 test expr-13.3 {CompileUnaryExpr: unary exprs} {expr +--++36} 36
 test expr-13.4 {CompileUnaryExpr: unary exprs} {expr !2} 0
 test expr-13.5 {CompileUnaryExpr: unary exprs} {expr +--+-62.0} -62.0
@@ -400,7 +413,11 @@ test expr-13.16 {CompileUnaryExpr: error in primary expr} {
 test expr-14.1 {CompilePrimaryExpr: literal primary} {expr 1} 1
 test expr-14.2 {CompilePrimaryExpr: literal primary} {expr 123} 123
 test expr-14.3 {CompilePrimaryExpr: literal primary} {expr 0xff} 255
-test expr-14.4 {CompilePrimaryExpr: literal primary} {expr 00010} 10
+# JimTCL specifically does not adhere to the octal default for numbers starting with zero
+test expr-14.4 {CompilePrimaryExpr: literal primary} -constraints jim -body {
+    expr 00010
+} -result {10}
+
 test expr-14.5 {CompilePrimaryExpr: literal primary} {expr 62.0} 62.0
 test expr-14.6 {CompilePrimaryExpr: literal primary} {
     expr 3.1400000

--- a/tests/lsort.test
+++ b/tests/lsort.test
@@ -149,9 +149,12 @@ test lsort-3.9 {SortCompare procedure, -integer option} {
 test lsort-3.10 {SortCompare procedure, -integer option} {
     list [catch {lsort -integer {3 q}} msg] $msg
 } {1 {expected integer but got "q"}}
-test lsort-3.11 {SortCompare procedure, -integer option} {
+# JimTCL specifically does not adhere to the octal default for numbers starting with zero
+test lsort-3.11 {SortCompare procedure, -integer option} -constraints jim -body {
     lsort -integer {35 21 0x20 30 023 100 8}
-} {8 21 023 30 0x20 35 100}
+} -result {8 21 023 30 0x20 35 100}
+
+
 test lsort-3.15 {SortCompare procedure, -command option} {
     proc cmp {a b} {
 	error "comparison error"
@@ -176,9 +179,11 @@ test lsort-3.18 {SortCompare procedure, -command option} {
     }
     lsort -command cmp {48 6 18 22 21 35 36}
 } {48 36 35 22 21 18 6}
-test lsort-3.19 {SortCompare procedure, -decreasing option} {
+# JimTCL specifically does not adhere to the octal default for numbers starting with zero
+test lsort-3.19 {SortCompare procedure, -decreasing optio} -constraints jim -body {
     lsort -decreasing -integer {35 21 0x20 30 023 100 8}
-} {100 35 0x20 30 023 21 8}
+} -result {100 35 0x20 30 023 21 8}
+
 test lsort-3.20 {SortCompare procedure, -real option} -body {
     lsort -real {6...4 3}
 } -returnCodes error -result {expected floating-point number but got "6...4"}


### PR DESCRIPTION

These tests were failing when run with tclsh, due to the differing Jim policy on octal number representation, so I added constraint 'jim' to them.