### PR TITLE
Fix buffer underrun in utf8_index()

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -66,7 +66,7 @@ int utf8_strlen(const char *str, int bytelen)
     if (bytelen < 0) {
         bytelen = strlen(str);
     }
-    while (bytelen) {
+    while (bytelen > 0) {
         int c;
         int l = utf8_tounicode(str, &c);
         charlen++;


### PR DESCRIPTION
Trivial fix for a buffer underrun in utf8_index() if the string ends with a UTF-8 sequence.