### PR TITLE
Use an intermediate file for asciidoc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -212,9 +212,12 @@ install-docs:
 	$(INSTALL_DATA) Tcl_shipped.html $(DESTDIR)$(docdir)/Tcl.html
 @endif
 
-Tcl.html: jim_tcl.txt
+Tcl.man.asciidoc: jim_tcl.txt
+	@tclsh@ @srcdir@/make-index $< > $@ && touch -r $< $@
+
+Tcl.html: Tcl.man.asciidoc
 @if HAVE_ASCIIDOC
-	@tclsh@ @srcdir@/make-index $> $^ | @ASCIIDOC@ -o $@ -d manpage -
+	@ASCIIDOC@ -o $@ -d manpage $<
 @else
 	@echo "asciidoc is not available"; false
 @endif


### PR DESCRIPTION
because asciidoc embeds the input file's mtime into the output html,
without this patch each package build produced a different result.

See https://reproducible-builds.org/ for why this matters.