### PR TITLE
jim-interp.c: fix compile warning with GCC 8.1.1

### DIFF
--- a/jim-interp.c
+++ b/jim-interp.c
@@ -139,7 +139,7 @@ static void JimInterpCopyVariable(Jim_Interp *target, Jim_Interp *source, const 
 static int JimInterpCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     Jim_Interp *child;
-    char buf[32];
+    char buf[34];
 
     if (argc != 1) {
         Jim_WrongNumArgs(interp, 1, argv, "");


### PR DESCRIPTION
GCC complains about possible truncation from snprintf()
jim-interp.c: In function ‘JimInterpCommand’:
jim-interp.c:164:46: warning: ‘%ld’ directive output may be
 truncated writing between 1 and 20 bytes into a region of size
 19 [-Wformat-truncation=]
     snprintf(buf, sizeof(buf), "interp.handle%ld", Jim_GetId(interp));
                                              ^~~
jim-interp.c:164:32: note: directive argument in the range
 [-9223372036854775807, 9223372036854775807]
     snprintf(buf, sizeof(buf), "interp.handle%ld", Jim_GetId(interp));
                                ^~~~~~~~~~~~~~~~~~
jim-interp.c:164:5: note: ‘snprintf’ output between 15 and 34 bytes
 into a destination of size 32
     snprintf(buf, sizeof(buf), "interp.handle%ld", Jim_GetId(interp));
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Antonio Borneo <borneo.antonio@gmail.com>