### PR TITLE
add line-feed as ENTER key

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -1881,6 +1881,7 @@ static int linenoiseEdit(struct current *current) {
         switch(c) {
         case SPECIAL_NONE:
             break;
+        case '\n':    /* line feed */
         case '\r':    /* enter */
             history_len--;
             free(history[history_len]);

--- a/linenoise.c
+++ b/linenoise.c
@@ -1003,18 +1003,20 @@ static int check_special(int fd)
         c = fd_read_char(fd, 50);
         if (c == '~') {
             switch (c2) {
+                case '1':
+                case '7':
+                    return SPECIAL_HOME;
                 case '2':
                     return SPECIAL_INSERT;
                 case '3':
                     return SPECIAL_DELETE;
+                case '4':
+                case '8':
+                    return SPECIAL_END;
                 case '5':
                     return SPECIAL_PAGE_UP;
                 case '6':
                     return SPECIAL_PAGE_DOWN;
-                case '7':
-                    return SPECIAL_HOME;
-                case '8':
-                    return SPECIAL_END;
             }
         }
         while (c != -1 && c != '~') {


### PR DESCRIPTION
If I build JimTcl, I can paste CR+LF lines:

~~~
$ jimsh
Welcome to Jim version 0.78
. expr 5 + 2
7
. expr 5 - 2
3
~~~

but if I try to paste LF lines, I get unexpected result:

~~~
$ jimsh
Welcome to Jim version 0.78
. expr 5 + 2expr 5 - 2
syntax error in expression: "5 + 2expr 5 - 2"
~~~

JimTcl should be able to accept LF separated input.
