### PR TITLE
utf8: optimize utf8_index()

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -89,12 +89,13 @@ int utf8_strwidth(const char *str, int charlen)
     return width;
 }
 
+/* Idea from http://canonical.org/~kragen/strlen-utf8.html */
 int utf8_index(const char *str, int index)
 {
     const char *s = str;
-    while (index--) {
-        int c;
-        s += utf8_tounicode(s, &c);
+    while (index) {
+        s++;
+        if ((*s & 0xc0) != 0x80) index--;
     }
     return s - str;
 }


### PR DESCRIPTION
The function `utf8_index()` in utf8.c performs unnecessary character length decoding via `utf8_tounicode()` when indexing a UTF-8 string.  I used the idea from <http://canonical.org/~kragen/strlen-utf8.html> to get rid of the call to `utf8_tounicode()`.  This speeds up `utf8_index()` considerably.  It halves the run time of a `regexp` and `string range`-heavy JSON decoding benchmark that I will attach shortly.