### PR TITLE
Add json support

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -55,6 +55,7 @@ options {
         binary    - Tcl-compatible 'binary' command
         tclprefix - Support for the tcl::prefix command
         zlib      - Interface to zlib
+        json      - JSON encode/decode
 
         These are disabled unless explicitly enabled:
 
@@ -337,6 +338,8 @@ dict set extdb attrs {
     glob      { tcl }
     history   {}
     interp    { }
+    json      { optional }
+    jsonencode { tcl optional }
     load      { static }
     mk        { cpp off }
     namespace { static }
@@ -372,6 +375,7 @@ dict set extdb info {
     load     { check {[have-feature dlopen-compat] || [cc-check-function-in-lib dlopen dl]} libdep lib_dlopen }
     mk       { check {[check-metakit]} libdep lib_mk }
     namespace { dep nshelper }
+    json     { dep jsonencode extrasrcs jsmn/jsmn.c }
     posix    { check {[have-feature waitpid]} }
     readdir  { check {[have-feature opendir]} }
     readline { pkg-config readline check {[cc-check-function-in-lib readline readline]} libdep lib_readline}
@@ -460,6 +464,14 @@ if {$jimregexp || [opt-bool jim-regexp]} {
     }
 }
 
+foreach mod $extinfo(static-c) {
+    if {[dict exists $extdb info $mod extrasrcs]} {
+        foreach src [dict get $extdb info $mod extrasrcs] {
+            lappend extra_objs {*}[file rootname $src].o
+        }
+    }
+}
+
 # poor-man's signals
 if {"signal" ni $extinfo(static-c)} {
     lappend extra_objs jim-nosignal.o
@@ -501,13 +513,19 @@ set lines {}
 foreach mod $extinfo(module-c) {
     set objs {}
     set libs [get-define LDLIBS_$mod]
-    set src jim-$mod.c
-    lappend lines "$mod.so: $src"
-    set obj [file rootname $src].o
-    lappend lines "\t\$(ECHO)\t\"\tCC\t$obj\""
-    lappend lines "\t\$(Q)\$(CC) \$(CFLAGS) \$(SHOBJ_CFLAGS) -c -o $obj $src"
+    set srcs jim-$mod.c
+    if {[dict exists $extdb info $mod extrasrcs]} {
+        lappend srcs {*}[dict get $extdb info $mod extrasrcs]
+    }
+    lappend lines "$mod.so: $srcs"
+    foreach src $srcs {
+        set obj [file rootname $src].o
+        lappend objs $obj
+        lappend lines "\t\$(ECHO)\t\"\tCC\t$obj\""
+        lappend lines "\t\$(Q)\$(CC) \$(CFLAGS) \$(SHOBJ_CFLAGS) -c -o $obj $src"
+    }
     lappend lines "\t\$(ECHO)\t\"\tLDSO\t\$@\""
-    lappend lines "\t\$(Q)\$(CC) \$(CFLAGS) \$(LDFLAGS) \$(SHOBJ_LDFLAGS) -o \$@ $obj \$(SH_LIBJIM) $libs"
+    lappend lines "\t\$(Q)\$(CC) \$(CFLAGS) \$(LDFLAGS) \$(SHOBJ_LDFLAGS) -o \$@ $objs \$(SH_LIBJIM) $libs"
     lappend lines ""
 }
 define BUILD_SHOBJS [join $lines \n]

--- a/jim-json.c
+++ b/jim-json.c
@@ -67,13 +67,19 @@ static void json_decode_schema_pop(Jim_Interp *interp, struct json_state *state,
 /**
  * Appends the schema type to schemaObj based on 'type'
  */
-static void json_decode_add_schema_type(Jim_Interp *interp, Jim_Obj *schemaObj, jsmntype_t type)
+static void json_decode_add_schema_type(Jim_Interp *interp, Jim_Obj *schemaObj, jsmntype_t type, const char *json)
 {
 	/* XXX: Could optimise storage of these strings */
 	const char *typename;
 	switch (type) {
 		case JSMN_PRIMITIVE:
-			typename = "num";
+			assert(json);
+			if (*json == 't' || *json == 'f') {
+				typename = "bool";
+			}
+			else {
+				typename = "num";
+			}
 			break;
 		case JSMN_STRING:
 			typename = "str";
@@ -134,12 +140,12 @@ json_decode_dump_container(Jim_Interp *interp, struct json_state *state, const c
 			if (list_type != JSMN_UNDEFINED) {
 				/* We can use list, so don't need subtypes */
 				Jim_ListAppendElement(interp, state->schemaObj, Jim_NewStringObj(interp, "list", -1));
-				json_decode_add_schema_type(interp, state->schemaObj, list_type);
+				json_decode_add_schema_type(interp, state->schemaObj, list_type, json + state->tok[0].start);
 				subtypes = 0;
 			}
 		}
 		if (subtypes) {
-			json_decode_add_schema_type(interp, state->schemaObj, type);
+			json_decode_add_schema_type(interp, state->schemaObj, type, NULL);
 		}
 	}
 
@@ -154,7 +160,7 @@ json_decode_dump_container(Jim_Interp *interp, struct json_state *state, const c
 
 		if (state->schemaObj && subtypes) {
 			if (state->tok->type == JSMN_STRING || state->tok->type == JSMN_PRIMITIVE) {
-				json_decode_add_schema_type(interp, state->schemaObj, state->tok->type);
+				json_decode_add_schema_type(interp, state->schemaObj, state->tok->type, json + state->tok->start);
 			}
 		}
 

--- a/jim-json.c
+++ b/jim-json.c
@@ -85,6 +85,10 @@ json_decode_dump_value(Jim_Interp *interp, struct jmsn_state *state, Jim_Obj *li
 			elem = Jim_NewStringObj(interp, json + t->start, len);
 		} else if (c == 'n') {	/* null */
 			elem = state->nullObj;
+		} else if (c == 'I') {
+			elem = Jim_NewStringObj(interp, "Inf", -1);
+		} else if (c == '-' && json[t->start + 1] == 'I') {
+			elem = Jim_NewStringObj(interp, "-Inf", -1);
 		} else {		/* number, true or false */
 			elem = Jim_NewStringObj(interp, json + t->start, len);
 		}

--- a/jim-json.c
+++ b/jim-json.c
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2015 - 2016 Svyatoslav Mishyn <juef@openmailbox.org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for
+ * any purpose with or without fee is hereby granted, provided that the
+ * above copyright notice and this permission notice appear in all
+ * copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+ * PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <jim.h>
+
+#include "jsmn/jsmn.h"
+
+struct jmsn_state {
+	Jim_Obj *nullObj;
+	jsmntok_t *tok;
+	int need_subst;
+};
+
+static void json_decode_dump_value(Jim_Interp *interp, struct jmsn_state *state, Jim_Obj *list, const char *json);
+
+/**
+ * Returns the current object (state->tok) as a Tcl list.
+ *
+ * state->tok is incremented to just past the object that was dumped.
+ */
+static Jim_Obj *
+json_decode_dump_container(Jim_Interp *interp, struct jmsn_state *state, const char *json)
+{
+	int i;
+
+	Jim_Obj *list = Jim_NewListObj(interp, NULL, 0);
+	int size = state->tok->size;
+	int type = state->tok->type;
+
+	state->tok++;
+
+	for (i = 0; i < size; i++) {
+		if (type == JSMN_OBJECT) {
+			/* Dump the object key */
+			json_decode_dump_value(interp, state, list, json);
+		}
+		/* Dump the array or object value */
+		json_decode_dump_value(interp, state, list, json);
+	}
+	return list;
+}
+
+/**
+ * Appends the value at state->tok to 'list' and increments state->tok to just
+ * past that token.
+ */
+static void
+json_decode_dump_value(Jim_Interp *interp, struct jmsn_state *state, Jim_Obj *list, const char *json)
+{
+	Jim_Obj		*newList, *elem;
+	unsigned char	 c;
+	int		 len;
+	const jsmntok_t *t = state->tok;
+
+	if (t->type == JSMN_STRING || t->type == JSMN_PRIMITIVE) {
+		assert(t->start && t->end);
+		len = t->end - t->start;
+		c = (unsigned char)json[t->start];
+
+		if (t->type == JSMN_STRING) {
+			/* Do we need to process backslash escapes? */
+			if (state->need_subst == 0 && memchr(json + t->start, '\\', len) != NULL) {
+				state->need_subst = 1;
+			}
+			elem = Jim_NewStringObj(interp, json + t->start, len);
+		} else if (c == 'n') {	/* null */
+			elem = state->nullObj;
+		} else {		/* number, true or false */
+			elem = Jim_NewStringObj(interp, json + t->start, len);
+		}
+
+		Jim_ListAppendElement(interp, list, elem);
+		state->tok++;
+	}
+	else {
+		newList = json_decode_dump_container(interp, state, json);
+		Jim_ListAppendElement(interp, list, newList);
+	}
+}
+
+/* Parses the options ?-null string? *state.
+ * Any options not present are not set.
+ *
+ * Returns JIM_OK or JIM_ERR and sets an error result.
+ */
+static int parse_json_decode_options(Jim_Interp *interp, int argc, Jim_Obj *const argv[], struct jmsn_state *state)
+{
+	static const char * const options[] = { "-null", NULL };
+	enum { OPT_NULL, };
+	int i;
+
+	for (i = 1; i < argc - 1; i++) {
+		int option;
+		if (Jim_GetEnum(interp, argv[i], options, &option, NULL, JIM_ERRMSG | JIM_ENUM_ABBREV) != JIM_OK) {
+			return JIM_ERR;
+		}
+		switch (option) {
+			case OPT_NULL:
+				i++;
+				Jim_IncrRefCount(argv[i]);
+				Jim_DecrRefCount(interp, state->nullObj);
+				state->nullObj = argv[i];
+				break;
+		}
+	}
+
+	if (i != argc - 1) {
+		Jim_WrongNumArgs(interp, 1, argv,
+			"?-null nullvalue? json");
+		return JIM_ERR;
+	}
+
+	return JIM_OK;
+}
+
+static jsmntok_t *
+json_decode_tokenize(Jim_Interp *interp, const char *json, size_t len)
+{
+	jsmntok_t	*t;
+	jsmn_parser	 parser;
+	int n;
+
+	jsmn_init(&parser);
+	n = jsmn_parse(&parser, json, len, NULL, 0);
+
+error:
+	switch (n) {
+		case JSMN_ERROR_INVAL:
+			Jim_SetResultString(interp, "invalid JSON string", -1);
+			return NULL;
+
+		case JSMN_ERROR_PART:
+			Jim_SetResultString(interp, "truncated JSON string", -1);
+			return NULL;
+
+		case 0:
+			Jim_SetResultString(interp, "root element must be an object or an array", -1);
+			return NULL;
+
+		default:
+			break;
+	}
+
+	if (n < 0) {
+		return NULL;
+	}
+
+	t = Jim_Alloc(n * sizeof(*t));
+
+	jsmn_init(&parser);
+	n = jsmn_parse(&parser, json, len, t, n);
+	if (t->type != JSMN_OBJECT && t->type != JSMN_ARRAY) {
+		n = 0;
+	}
+	if (n <= 0) {
+		Jim_Free(t);
+		goto error;
+	}
+
+	return t;
+}
+
+static int
+json_decode(Jim_Interp *interp, int argc, Jim_Obj *const argv[])
+{
+	Jim_Obj		*list;
+	jsmntok_t	*tokens;
+	const char	*json;
+	int		 len;
+	int ret = JIM_ERR;
+
+	struct jmsn_state state;
+
+	state.need_subst = 0;
+	state.nullObj = Jim_NewStringObj(interp, "null", -1);
+	Jim_IncrRefCount(state.nullObj);
+
+	if (parse_json_decode_options(interp, argc, argv, &state) != JIM_OK) {
+		goto done;
+	}
+
+	json = Jim_GetString(argv[argc - 1], &len);
+
+	if (!len) {
+		Jim_SetResultString(interp, "empty JSON string", -1);
+		goto done;
+	}
+	if ((tokens = json_decode_tokenize(interp, json, len)) == NULL) {
+		goto done;
+	}
+	state.tok = tokens;
+
+	list = json_decode_dump_container(interp, &state, json);
+	Jim_Free(tokens);
+	ret = JIM_OK;
+
+	if (state.need_subst) {
+		/* Subsitute backslashes in the returned dictionary.
+		 * Need to be careful of refcounts.
+		 * Note that Jim_SubstObj() supports a few more escapes than
+		 * JSON requires, but should give the same result for all legal escapes.
+		 */
+		Jim_Obj *newList;
+		Jim_IncrRefCount(list);
+		Jim_SubstObj(interp, list, &newList, JIM_SUBST_FLAG | JIM_SUBST_NOCMD | JIM_SUBST_NOVAR);
+		Jim_SetResult(interp, newList);
+		Jim_DecrRefCount(interp, list);
+	}
+	else {
+		Jim_SetResult(interp, list);
+	}
+
+done:
+	Jim_DecrRefCount(interp, state.nullObj);
+
+	return ret;
+}
+
+int
+Jim_jsonInit(Jim_Interp *interp)
+{
+	if (Jim_PackageProvide(interp, "json", "1.0", JIM_ERRMSG) != JIM_OK) {
+		return JIM_ERR;
+	}
+
+	Jim_CreateCommand(interp, "json::decode", json_decode, NULL, NULL);
+	/* Load the Tcl implementation of the json encoder if possible */
+	Jim_PackageRequire(interp, "jsonencode", 0);
+	return JIM_OK;
+}

--- a/jim-json.c
+++ b/jim-json.c
@@ -112,9 +112,10 @@ static json_schema_t json_decode_get_type(const jsmntok_t *tok, const char *json
 			/* Return mixed by default - need other checks to determine list instead */
 			return JSON_MIXED;
 		default:
-			fprintf(stderr, "tok->type=%d, token=%s\n", tok->type, json + tok->start);
 			assert(0);
 	}
+	/* NOTREACHED */
+	return JSON_NONE;
 }
 
 /**

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -5332,16 +5332,17 @@ independently (but synchronously) of the main interpreter.
     alias for +'parentcmd'+ in the parent interpreter, with the given, fixed arguments.
     The alias may be deleted in the child with 'rename'.
 
-json: json::encode, json::decode
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+json::encode
+~~~~~~~~~~~~
 
-The optional 'json' package includes a Tcl -> JSON encoder and a JSON -> Tcl decoder.
+The Tcl -> JSON encoder is part of the optional 'json' package.
 
 +*json::encode* 'value ?schema?'+::
 
 Encode a Tcl value as JSON according to the schema (defaults to +'str'+). The following schema types are supported:
 * 'str' - Tcl string -> JSON string
-* 'num' - Tcl value -> bare numeric value or true, false, null
+* 'num' - Tcl value -> bare numeric value or null
+* 'bool' - Tcl boolean value -> true, false
 * 'obj ?name subschema ...?' - Tcl dict -> JSON object. For each dict key matching 'name', the corresponding 'subschema'
 is applied. The special name +'*'+ matches any keys not otherwise matched, otherwise the default +'str'+ is used.
 * 'list ?subschema?' - Tcl list -> JSON array. The 'subschema' (default +'str'+) is applied for each element of the list/array.
@@ -5353,6 +5354,8 @@ The following are examples:
     [ "1", "2", "true", "false", "null", "5.0" ]
     . json::encode {1 2 true false null 5.0} {list num}
     [ 1, 2, true, false, null, 5.0 ]
+    . json::encode {0 1 2 true false 5.0 off} {list bool}
+    [ false, true, true, true, false, true, false ]
     . json::encode {a 1 b hello c {3 4}} obj
     { "a":"1", "b":"hello", "c":"3 4" }
     . json::encode {a 1 b hello c {3 4}} {obj a num c {list num}}
@@ -5363,16 +5366,22 @@ The following are examples:
     { "a":1, "b":3.0, "c":"hello", "d":null }
 ----
 
+json::decode
+~~~~~~~~~~~~
+
+The JSON -> Tcl decoder is part of the optional 'json' package.
+
 +*json::decode* ?*-null* 'string'? ?*-schema*? 'json-string'+::
 
-Decodes the given JSON string into a Tcl data structure. If '+-schema+' is specified, returns a
+Decodes the given JSON string (must be array or object) into a Tcl data structure. If '+-schema+' is specified, returns a
 list of +'{data schema}'+ where the schema is compatible with `json::encode`. Otherwise just returns the data.
-Decoding is as follows:
-* object -> dict
-* array -> list
-* number, true, false -> as-is
-* string -> string
-* null -> supplied null string or the default +'"null"'+
+Decoding is as follows (with schema types listed in parentheses):
+* object -> dict ('obj')
+* array -> list ('mixed' or 'list')
+* number -> as-is ('num')
+* boolean -> as-is ('bool')
+* string -> string ('str')
+* null -> supplied null string or the default +'"null"'+ ('num')
  ::
  Note that an object decoded into a dict will return the keys in the same order as the original string.
 ----
@@ -5383,7 +5392,7 @@ Decoding is as follows:
     . json::decode -schema {{"a":1, "b":2}}
     {a 1 b 2} {obj a num b num}
     . json::decode -schema {[1, 2, {a:"b", c:false}, "hello"]}
-    {1 2 {a b c false} hello} {mixed num num {obj a str c num} str}
+    {1 2 {a b c false} hello} {mixed num num {obj a str c bool} str}
 ----
 
 [[BuiltinVariables]]

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -5331,6 +5331,49 @@ independently (but synchronously) of the main interpreter.
     alias for +'parentcmd'+ in the parent interpreter, with the given, fixed arguments.
     The alias may be deleted in the child with 'rename'.
 
+json
+~~~~
+
+The optional 'json' package includes a Tcl -> JSON encoder and a JSON -> Tcl decoder.
+
++*json::encode* 'value ?schema?'+::
+
+Encode a Tcl value as JSON according to the schema (defaults to +'str'+). The following schema types are supported:
+* 'str' - Tcl string -> JSON string
+* 'num' - Tcl value -> bare numeric value or true, false, null
+* 'obj ?name subschema ...?' - Tcl dict -> JSON object. For each dict key matching 'name', the corresponding 'subschema'
+is applied. The special name +'*'+ matches any keys not otherwise matched, otherwise the default +'str'+ is used.
+* 'list ?subschema?' - Tcl list -> JSON array. The 'subschema' (default +'str'+) is applied for each element of the list/array.
+* 'mixed ?subschema ...?' = Tcl list -> JSON array. Each 'subschema' is applied for the corresponding element of the list/array.
+  ::
+The following are examples:
+----
+    . json::encode {1 2 true false null 5.0} list
+    [ "1", "2", "true", "false", "null", "5.0" ]
+    . json::encode {1 2 true false null 5.0} {list num}
+    [ 1, 2, true, false, null, 5.0 ]
+    . json::encode {a 1 b hello c {3 4}} obj
+    { "a":"1", "b":"hello", "c":"3 4" }
+    . json::encode {a 1 b hello c {3 4}} {obj a num c {list num}}
+    { "a":1, "b":"hello", "c":[ 3, 4 ] }
+    . json::encode {true true {abc def}} {mixed str num obj}
+    [ "true", true, { "abc":"def" } ]
+    . json::encode {a 1 b 3.0 c hello d null} {obj c str * num}
+    { "a":1, "b":3.0, "c":"hello", "d":null }
+----
+
++*json::decode* ?*-null* 'string'? 'json-string'+::
+
+Decodes the given JSON string into a Tcl data structure.
+Decoding is as follows:
+* object -> dict
+* array -> list
+* number, true, false -> as-is
+* string -> string
+* null -> supplied null string or the default +'"null"'+
+ ::
+ Note that an object decoded into a dict will return the keys in the same order as the original string.
+
 [[BuiltinVariables]]
 BUILT-IN VARIABLES
 ------------------

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -59,6 +59,7 @@ Changes since 0.78
 3. Add support for `aio lock -wait`
 4. Add `signal block` to prevent delivery of signals
 5. Add support for `file split`
+6. Add support for `json::encode` and `json::decode`
 
 Changes between 0.77 and 0.78
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -5331,8 +5332,8 @@ independently (but synchronously) of the main interpreter.
     alias for +'parentcmd'+ in the parent interpreter, with the given, fixed arguments.
     The alias may be deleted in the child with 'rename'.
 
-json
-~~~~
+json: json::encode, json::decode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The optional 'json' package includes a Tcl -> JSON encoder and a JSON -> Tcl decoder.
 
@@ -5362,9 +5363,10 @@ The following are examples:
     { "a":1, "b":3.0, "c":"hello", "d":null }
 ----
 
-+*json::decode* ?*-null* 'string'? 'json-string'+::
++*json::decode* ?*-null* 'string'? ?*-schema*? 'json-string'+::
 
-Decodes the given JSON string into a Tcl data structure.
+Decodes the given JSON string into a Tcl data structure. If '+-schema+' is specified, returns a
+list of +'{data schema}'+ where the schema is compatible with `json::encode`. Otherwise just returns the data.
 Decoding is as follows:
 * object -> dict
 * array -> list
@@ -5373,6 +5375,16 @@ Decoding is as follows:
 * null -> supplied null string or the default +'"null"'+
  ::
  Note that an object decoded into a dict will return the keys in the same order as the original string.
+----
+    . json::decode {[1, 2]}
+    {1 2}
+    . json::decode -schema {[1, 2]}
+    {1 2} {list num}
+    . json::decode -schema {{"a":1, "b":2}}
+    {a 1 b 2} {obj a num b num}
+    . json::decode -schema {[1, 2, {a:"b", c:false}, "hello"]}
+    {1 2 {a b c false} hello} {mixed num num {obj a str c num} str}
+----
 
 [[BuiltinVariables]]
 BUILT-IN VARIABLES

--- a/jsmn/LICENSE
+++ b/jsmn/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2010 Serge A. Zaitsev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/jsmn/jsmn.c
+++ b/jsmn/jsmn.c
@@ -1,0 +1,314 @@
+#include "jsmn.h"
+
+/**
+ * Allocates a fresh unused token from the token pool.
+ */
+static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser,
+		jsmntok_t *tokens, size_t num_tokens) {
+	jsmntok_t *tok;
+	if (parser->toknext >= num_tokens) {
+		return NULL;
+	}
+	tok = &tokens[parser->toknext++];
+	tok->start = tok->end = -1;
+	tok->size = 0;
+#ifdef JSMN_PARENT_LINKS
+	tok->parent = -1;
+#endif
+	return tok;
+}
+
+/**
+ * Fills token type and boundaries.
+ */
+static void jsmn_fill_token(jsmntok_t *token, jsmntype_t type,
+                            int start, int end) {
+	token->type = type;
+	token->start = start;
+	token->end = end;
+	token->size = 0;
+}
+
+/**
+ * Fills next available token with JSON primitive.
+ */
+static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
+		size_t len, jsmntok_t *tokens, size_t num_tokens) {
+	jsmntok_t *token;
+	int start;
+
+	start = parser->pos;
+
+	for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+		switch (js[parser->pos]) {
+#ifndef JSMN_STRICT
+			/* In strict mode primitive must be followed by "," or "}" or "]" */
+			case ':':
+#endif
+			case '\t' : case '\r' : case '\n' : case ' ' :
+			case ','  : case ']'  : case '}' :
+				goto found;
+		}
+		if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
+			parser->pos = start;
+			return JSMN_ERROR_INVAL;
+		}
+	}
+#ifdef JSMN_STRICT
+	/* In strict mode primitive must be followed by a comma/object/array */
+	parser->pos = start;
+	return JSMN_ERROR_PART;
+#endif
+
+found:
+	if (tokens == NULL) {
+		parser->pos--;
+		return 0;
+	}
+	token = jsmn_alloc_token(parser, tokens, num_tokens);
+	if (token == NULL) {
+		parser->pos = start;
+		return JSMN_ERROR_NOMEM;
+	}
+	jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+	token->parent = parser->toksuper;
+#endif
+	parser->pos--;
+	return 0;
+}
+
+/**
+ * Fills next token with JSON string.
+ */
+static int jsmn_parse_string(jsmn_parser *parser, const char *js,
+		size_t len, jsmntok_t *tokens, size_t num_tokens) {
+	jsmntok_t *token;
+
+	int start = parser->pos;
+
+	parser->pos++;
+
+	/* Skip starting quote */
+	for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+		char c = js[parser->pos];
+
+		/* Quote: end of string */
+		if (c == '\"') {
+			if (tokens == NULL) {
+				return 0;
+			}
+			token = jsmn_alloc_token(parser, tokens, num_tokens);
+			if (token == NULL) {
+				parser->pos = start;
+				return JSMN_ERROR_NOMEM;
+			}
+			jsmn_fill_token(token, JSMN_STRING, start+1, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+			token->parent = parser->toksuper;
+#endif
+			return 0;
+		}
+
+		/* Backslash: Quoted symbol expected */
+		if (c == '\\' && parser->pos + 1 < len) {
+			int i;
+			parser->pos++;
+			switch (js[parser->pos]) {
+				/* Allowed escaped symbols */
+				case '\"': case '/' : case '\\' : case 'b' :
+				case 'f' : case 'r' : case 'n'  : case 't' :
+					break;
+				/* Allows escaped symbol \uXXXX */
+				case 'u':
+					parser->pos++;
+					for(i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0'; i++) {
+						/* If it isn't a hex character we have an error */
+						if(!((js[parser->pos] >= 48 && js[parser->pos] <= 57) || /* 0-9 */
+									(js[parser->pos] >= 65 && js[parser->pos] <= 70) || /* A-F */
+									(js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
+							parser->pos = start;
+							return JSMN_ERROR_INVAL;
+						}
+						parser->pos++;
+					}
+					parser->pos--;
+					break;
+				/* Unexpected symbol */
+				default:
+					parser->pos = start;
+					return JSMN_ERROR_INVAL;
+			}
+		}
+	}
+	parser->pos = start;
+	return JSMN_ERROR_PART;
+}
+
+/**
+ * Parse JSON string and fill tokens.
+ */
+int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
+		jsmntok_t *tokens, unsigned int num_tokens) {
+	int r;
+	int i;
+	jsmntok_t *token;
+	int count = parser->toknext;
+
+	for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+		char c;
+		jsmntype_t type;
+
+		c = js[parser->pos];
+		switch (c) {
+			case '{': case '[':
+				count++;
+				if (tokens == NULL) {
+					break;
+				}
+				token = jsmn_alloc_token(parser, tokens, num_tokens);
+				if (token == NULL)
+					return JSMN_ERROR_NOMEM;
+				if (parser->toksuper != -1) {
+					tokens[parser->toksuper].size++;
+#ifdef JSMN_PARENT_LINKS
+					token->parent = parser->toksuper;
+#endif
+				}
+				token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+				token->start = parser->pos;
+				parser->toksuper = parser->toknext - 1;
+				break;
+			case '}': case ']':
+				if (tokens == NULL)
+					break;
+				type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+#ifdef JSMN_PARENT_LINKS
+				if (parser->toknext < 1) {
+					return JSMN_ERROR_INVAL;
+				}
+				token = &tokens[parser->toknext - 1];
+				for (;;) {
+					if (token->start != -1 && token->end == -1) {
+						if (token->type != type) {
+							return JSMN_ERROR_INVAL;
+						}
+						token->end = parser->pos + 1;
+						parser->toksuper = token->parent;
+						break;
+					}
+					if (token->parent == -1) {
+						if(token->type != type || parser->toksuper == -1) {
+							return JSMN_ERROR_INVAL;
+						}
+						break;
+					}
+					token = &tokens[token->parent];
+				}
+#else
+				for (i = parser->toknext - 1; i >= 0; i--) {
+					token = &tokens[i];
+					if (token->start != -1 && token->end == -1) {
+						if (token->type != type) {
+							return JSMN_ERROR_INVAL;
+						}
+						parser->toksuper = -1;
+						token->end = parser->pos + 1;
+						break;
+					}
+				}
+				/* Error if unmatched closing bracket */
+				if (i == -1) return JSMN_ERROR_INVAL;
+				for (; i >= 0; i--) {
+					token = &tokens[i];
+					if (token->start != -1 && token->end == -1) {
+						parser->toksuper = i;
+						break;
+					}
+				}
+#endif
+				break;
+			case '\"':
+				r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
+				if (r < 0) return r;
+				count++;
+				if (parser->toksuper != -1 && tokens != NULL)
+					tokens[parser->toksuper].size++;
+				break;
+			case '\t' : case '\r' : case '\n' : case ' ':
+				break;
+			case ':':
+				parser->toksuper = parser->toknext - 1;
+				break;
+			case ',':
+				if (tokens != NULL && parser->toksuper != -1 &&
+						tokens[parser->toksuper].type != JSMN_ARRAY &&
+						tokens[parser->toksuper].type != JSMN_OBJECT) {
+#ifdef JSMN_PARENT_LINKS
+					parser->toksuper = tokens[parser->toksuper].parent;
+#else
+					for (i = parser->toknext - 1; i >= 0; i--) {
+						if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
+							if (tokens[i].start != -1 && tokens[i].end == -1) {
+								parser->toksuper = i;
+								break;
+							}
+						}
+					}
+#endif
+				}
+				break;
+#ifdef JSMN_STRICT
+			/* In strict mode primitives are: numbers and booleans */
+			case '-': case '0': case '1' : case '2': case '3' : case '4':
+			case '5': case '6': case '7' : case '8': case '9':
+			case 't': case 'f': case 'n' :
+				/* And they must not be keys of the object */
+				if (tokens != NULL && parser->toksuper != -1) {
+					jsmntok_t *t = &tokens[parser->toksuper];
+					if (t->type == JSMN_OBJECT ||
+							(t->type == JSMN_STRING && t->size != 0)) {
+						return JSMN_ERROR_INVAL;
+					}
+				}
+#else
+			/* In non-strict mode every unquoted value is a primitive */
+			default:
+#endif
+				r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
+				if (r < 0) return r;
+				count++;
+				if (parser->toksuper != -1 && tokens != NULL)
+					tokens[parser->toksuper].size++;
+				break;
+
+#ifdef JSMN_STRICT
+			/* Unexpected char in strict mode */
+			default:
+				return JSMN_ERROR_INVAL;
+#endif
+		}
+	}
+
+	if (tokens != NULL) {
+		for (i = parser->toknext - 1; i >= 0; i--) {
+			/* Unmatched opened object or array */
+			if (tokens[i].start != -1 && tokens[i].end == -1) {
+				return JSMN_ERROR_PART;
+			}
+		}
+	}
+
+	return count;
+}
+
+/**
+ * Creates a new parser based over a given  buffer with an array of tokens
+ * available.
+ */
+void jsmn_init(jsmn_parser *parser) {
+	parser->pos = 0;
+	parser->toknext = 0;
+	parser->toksuper = -1;
+}
+

--- a/jsmn/jsmn.c
+++ b/jsmn/jsmn.c
@@ -170,6 +170,10 @@ int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
 				if (token == NULL)
 					return JSMN_ERROR_NOMEM;
 				if (parser->toksuper != -1) {
+					if (tokens[parser->toksuper].type == JSMN_OBJECT) {
+						/* Object keys must be strings, not objects or arrays */
+						return JSMN_ERROR_INVAL;
+					}
 					tokens[parser->toksuper].size++;
 #ifdef JSMN_PARENT_LINKS
 					token->parent = parser->toksuper;

--- a/jsmn/jsmn.h
+++ b/jsmn/jsmn.h
@@ -1,0 +1,76 @@
+#ifndef __JSMN_H_
+#define __JSMN_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * JSON type identifier. Basic types are:
+ * 	o Object
+ * 	o Array
+ * 	o String
+ * 	o Other primitive: number, boolean (true/false) or null
+ */
+typedef enum {
+	JSMN_UNDEFINED = 0,
+	JSMN_OBJECT = 1,
+	JSMN_ARRAY = 2,
+	JSMN_STRING = 3,
+	JSMN_PRIMITIVE = 4
+} jsmntype_t;
+
+enum jsmnerr {
+	/* Not enough tokens were provided */
+	JSMN_ERROR_NOMEM = -1,
+	/* Invalid character inside JSON string */
+	JSMN_ERROR_INVAL = -2,
+	/* The string is not a full JSON packet, more bytes expected */
+	JSMN_ERROR_PART = -3
+};
+
+/**
+ * JSON token description.
+ * @param		type	type (object, array, string etc.)
+ * @param		start	start position in JSON data string
+ * @param		end		end position in JSON data string
+ */
+typedef struct {
+	jsmntype_t type;
+	int start;
+	int end;
+	int size;
+#ifdef JSMN_PARENT_LINKS
+	int parent;
+#endif
+} jsmntok_t;
+
+/**
+ * JSON parser. Contains an array of token blocks available. Also stores
+ * the string being parsed now and current position in that string
+ */
+typedef struct {
+	unsigned int pos; /* offset in the JSON string */
+	unsigned int toknext; /* next token to allocate */
+	int toksuper; /* superior token node, e.g parent object or array */
+} jsmn_parser;
+
+/**
+ * Create JSON parser over an array of tokens
+ */
+void jsmn_init(jsmn_parser *parser);
+
+/**
+ * Run JSON parser. It parses a JSON data string into and array of tokens, each describing
+ * a single JSON object.
+ */
+int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
+		jsmntok_t *tokens, unsigned int num_tokens);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __JSMN_H_ */

--- a/jsonencode.tcl
+++ b/jsonencode.tcl
@@ -12,7 +12,8 @@
 #
 # The schema provides the type information for the value.
 # str = string
-# num = numeric
+# num = numeric (or null)
+# bool = boolean
 # obj ... = object. parameters are 'name' 'subschema' where the name matches the dict.
 # list ... = array. parameters are 'subschema' for the elements of the list/array.
 # mixed ... = array of mixed types. parameters are types for each element of the list/array.
@@ -41,6 +42,14 @@ proc json::encode.num {value {dummy {}}} {
 		append value inity
 	}
 	return $value
+}
+
+# Encode a boolean
+proc json::encode.bool {value {dummy {}}} {
+	if {$value} {
+		return true
+	}
+	return false
 }
 
 # Encode an object (dictionary)

--- a/jsonencode.tcl
+++ b/jsonencode.tcl
@@ -37,6 +37,9 @@ proc json::encode. {args} {
 
 # Encode a number
 proc json::encode.num {value {dummy {}}} {
+	if {$value in {Inf -Inf}} {
+		append value inity
+	}
 	return $value
 }
 

--- a/jsonencode.tcl
+++ b/jsonencode.tcl
@@ -1,0 +1,88 @@
+# Implements 'json::encode'
+#
+# (c) 2019 Steve Bennett <steveb@workware.net.au>
+#
+# See LICENCE in this directory for licensing.
+
+# Encode Tcl objects as JSON
+# dict -> object
+# list -> array
+# numeric -> number
+# string -> string
+#
+# The schema provides the type information for the value.
+# str = string
+# num = numeric
+# obj ... = object. parameters are 'name' 'subschema' where the name matches the dict.
+# list ... = array. parameters are 'subschema' for the elements of the list/array.
+# mixed ... = array of mixed types. parameters are types for each element of the list/array.
+
+# Top level JSON encoder which encodes the given
+# value based on the schema
+proc json::encode {value {schema str}} {
+	json::encode.[lindex $schema 0] $value [lrange $schema 1 end]
+}
+
+# Encode a string
+proc json::encode.str {value {dummy {}}} {
+	# Strictly we should be converting \x00 through \x1F to unicode escapes
+	# And anything outside the BMP to a UTF-16 surrogate pair
+	return \"[string map [list \\ \\\\ \" \\" \f \\f \n \\n / \\/ \b \\b \r \\r \t \\t] $value]\"
+}
+
+# If no type is given, also encode as a string
+proc json::encode. {args} {
+	tailcall json::encode.str {*}$args
+}
+
+# Encode a number
+proc json::encode.num {value {dummy {}}} {
+	return $value
+}
+
+# Encode an object (dictionary)
+proc json::encode.obj {obj {schema {}}} {
+	set result "\{"
+	set sep " "
+	foreach k [lsort [dict keys $obj]] {
+		if {[dict exists $schema $k]} {
+			set type [dict get $schema $k]
+		} elseif {[dict exists $schema *]} {
+			set type [dict get $schema *]
+		} else {
+			set type str
+		}
+		append result $sep\"$k\":
+
+		append result [json::encode.[lindex $type 0] [dict get $obj $k] [lrange $type 1 end]]
+		set sep ", "
+	}
+	append result " \}"
+}
+
+# Encode an array (list)
+proc json::encode.list {list {type str}} {
+	set result "\["
+	set sep " "
+	foreach l $list {
+		append result $sep
+		append result [json::encode.[lindex $type 0] $l [lrange $type 1 end]]
+		set sep ", "
+	}
+	append result " \]"
+}
+
+# Encode a mixed-type array (list)
+# Must be as many types as there are elements of the list
+proc json::encode.mixed {list types} {
+	set result "\["
+	set sep " "
+	foreach l $list type $types {
+		append result $sep
+		append result [json::encode.[lindex $type 0] $l [lrange $type 1 end]]
+		set sep ", "
+	}
+	append result " \]"
+}
+
+# vim: se ts=4:

--- a/make-index
+++ b/make-index
@@ -16,13 +16,13 @@ while {[gets $f buf] >= 0} {
 			incr c
 			set target cmd_$c
 			set lines [linsert $lines end-1 "\[\[$target\]\]"]
-			set prevlist [split $prev ":, "]
+			set prevlist [split $prev ", "]
 		} else {
 			set target _[string map {:: _} $prev]
 			set prevlist [list $prev]
 		}
 		foreach cmd $prevlist {
-			set cmd [string trim $cmd]
+			set cmd [string trim $cmd :]
 			if {[regexp {^[a-z.:]+$} $cmd]} {
 				lappend commands [list $cmd $target]
 				set cdict($cmd) $target

--- a/tests/json.test
+++ b/tests/json.test
@@ -59,6 +59,10 @@ test json-decode-012 {default null value} {
 	dict get [json::decode $json] homepage
 } {null}
 
+test json-decode-2.1 {Number forms} {
+	json::decode {[ 1, 2, 3.0, 4, Infinity, NaN, -Infinity, -0.0, 1e5, -1e-5 ]}
+} {1 2 3.0 4 Inf NaN -Inf -0.0 1e5 -1e-5}
+
 unset -nocomplain json
 
 test json-encode-1.1 {String with backslashes}  {
@@ -70,8 +74,8 @@ test json-encode-1.2 {String with special chars} {
 } {"Various \n special \b characters \t and \/slash\/ \r too"}
 
 test json-encode-1.3 {Array of numbers} {
-	json::encode {1 2 3.0 4} {list num}
-} {[ 1, 2, 3.0, 4 ]}
+	json::encode {1 2 3.0 4 Inf NaN -Inf -0.0 1e5 -1e-5} {list num}
+} {[ 1, 2, 3.0, 4, Infinity, NaN, -Infinity, -0.0, 1e5, -1e-5 ]}
 
 test json-encode-1.4 {Array of strings} {
 	json::encode {1 2 3.0 4} list

--- a/tests/json.test
+++ b/tests/json.test
@@ -59,9 +59,38 @@ test json-decode-012 {default null value} {
 	dict get [json::decode $json] homepage
 } {null}
 
-test json-decode-2.1 {Number forms} {
+test json-decode-1.1 {Number forms} {
 	json::decode {[ 1, 2, 3.0, 4, Infinity, NaN, -Infinity, -0.0, 1e5, -1e-5 ]}
 } {1 2 3.0 4 Inf NaN -Inf -0.0 1e5 -1e-5}
+
+test json-2.1 {schema tests} {
+	lindex [json::decode -schema {[]}] 1
+} {list str}
+
+test json-2.2 {schema tests} {
+	lindex [json::decode -schema {[1, 2]}] 1
+} {list num}
+
+test json-2.3 {schema tests} {
+	lindex [json::decode -schema {[1, 2, [3, 4], 4, 6]}] 1
+} {mixed num num {list num} num num}
+
+test json-2.4 {schema tests} {
+	lindex [json::decode -schema {{"a":1, "b":2}}] 1
+} {obj a num b num}
+
+test json-2.5 {schema tests} {
+	lindex [json::decode -schema {[1, 2, {a:"b", c:false}, "hello"]}] 1
+} {mixed num num {obj a str c num} str}
+
+test json-2.6 {schema tests} {
+	lindex [json::decode -schema {[1, 2, {a:["b", 1, true, Infinity]}]}] 1
+} {mixed num num {obj a {mixed str num num num}}}
+
+test json-2.7 {schema tests} {
+	lindex [json::decode -schema {[1, 2, {a:["b", 1, true, ["d", "e", "f"]]}]}] 1
+} {mixed num num {obj a {mixed str num num {list str}}}}
+
 
 unset -nocomplain json
 

--- a/tests/json.test
+++ b/tests/json.test
@@ -65,7 +65,7 @@ test json-decode-1.1 {Number forms} {
 
 test json-2.1 {schema tests} {
 	lindex [json::decode -schema {[]}] 1
-} {list str}
+} {list}
 
 test json-2.2 {schema tests} {
 	lindex [json::decode -schema {[1, 2]}] 1
@@ -90,6 +90,10 @@ test json-2.6 {schema tests} {
 test json-2.7 {schema tests} {
 	lindex [json::decode -schema {[1, 2, {a:["b", 1, true, ["d", "e", "f"]]}]}] 1
 } {mixed num num {obj a {mixed str num bool {list str}}}}
+
+test json-2.8 {schema tests} {
+	lindex [json::decode -schema {[1, 2, true, false]}] 1
+} {mixed num num bool bool}
 
 
 unset -nocomplain json

--- a/tests/json.test
+++ b/tests/json.test
@@ -81,15 +81,15 @@ test json-2.4 {schema tests} {
 
 test json-2.5 {schema tests} {
 	lindex [json::decode -schema {[1, 2, {a:"b", c:false}, "hello"]}] 1
-} {mixed num num {obj a str c num} str}
+} {mixed num num {obj a str c bool} str}
 
 test json-2.6 {schema tests} {
 	lindex [json::decode -schema {[1, 2, {a:["b", 1, true, Infinity]}]}] 1
-} {mixed num num {obj a {mixed str num num num}}}
+} {mixed num num {obj a {mixed str num bool num}}}
 
 test json-2.7 {schema tests} {
 	lindex [json::decode -schema {[1, 2, {a:["b", 1, true, ["d", "e", "f"]]}]}] 1
-} {mixed num num {obj a {mixed str num num {list str}}}}
+} {mixed num num {obj a {mixed str num bool {list str}}}}
 
 
 unset -nocomplain json
@@ -109,7 +109,6 @@ test json-encode-1.3 {Array of numbers} {
 test json-encode-1.4 {Array of strings} {
 	json::encode {1 2 3.0 4} list
 } {[ "1", "2", "3.0", "4" ]}
-
 
 test json-encode-1.5 {Array of objects} {
 	json::encode {{state NY city {New York} postalCode 10021 streetAddress {21 2nd Street}} {state CA city {Los Angeles} postalCode 10345 streetAddress {15 Hale St}}} {list obj postalCode num}
@@ -134,5 +133,10 @@ test json-encode-1.9 {Array of mixed types} {
 test json-encode-1.10 {Array of objects} {
 	json::encode {{state NY city {New York} postalCode 10021 streetAddress {21 2nd Street}} {state CA city {Los Angeles} postalCode 10345 streetAddress {15 Hale St}}} {list obj postalCode num}
 } {[ { "city":"New York", "postalCode":10021, "state":"NY", "streetAddress":"21 2nd Street" }, { "city":"Los Angeles", "postalCode":10345, "state":"CA", "streetAddress":"15 Hale St" } ]}
+
+test json-encode-1.11 {Forms of boolean} {
+	json::encode {-5 4 1 0 yes no true false} {list bool}
+} {[ true, true, true, false, true, false, true, false ]}
+
 
 testreport

--- a/tests/json.test
+++ b/tests/json.test
@@ -1,0 +1,105 @@
+source [file dirname [info script]]/testing.tcl
+
+needs cmd json::decode json
+needs cmd json::encode json
+
+set json {
+{
+	"fossil":"9c65b5432e4aeecf3556e5550c338ce93fd861cc",
+	"timestamp":1435827337,
+	"command":"timeline/checkin",
+	"procTimeUs":3333,
+	"procTimeMs":3,
+	"homepage":null,
+	"payload":{
+		"limit":1,
+		"timeline":[{
+			"type":"checkin",
+			"uuid":"f8b17edee7ff4f16517601c40eb713602aed7a52",
+			"isLeaf":true,
+			"timestamp":1435318826,
+			"user":"juef",
+			"comment":"adwaita-icon-theme: update to 3.17.3",
+			"parents":["de628be645cc62429d630f9234c56d1fddfdc2a3"],
+			"tags":["trunk"]
+		}]
+	}
+}}
+
+test json-decode-001 {top level keys} {
+	lsort [dict keys [json::decode $json]]
+} {command fossil homepage payload procTimeMs procTimeUs timestamp}
+
+# Note that the decode will return the keys/values in order
+test json-decode-002 {object value} {
+	dict get [json::decode $json] payload
+} {limit 1 timeline {{type checkin uuid f8b17edee7ff4f16517601c40eb713602aed7a52 isLeaf true timestamp 1435318826 user juef comment {adwaita-icon-theme: update to 3.17.3} parents de628be645cc62429d630f9234c56d1fddfdc2a3 tags trunk}}}
+
+test json-decode-003 {object nested value} {
+	dict get [json::decode $json] payload timeline
+} {{type checkin uuid f8b17edee7ff4f16517601c40eb713602aed7a52 isLeaf true timestamp 1435318826 user juef comment {adwaita-icon-theme: update to 3.17.3} parents de628be645cc62429d630f9234c56d1fddfdc2a3 tags trunk}}
+
+test json-decode-004 {array entry from nested value} {
+	lindex [dict get [json::decode $json] payload timeline] 0
+} {type checkin uuid f8b17edee7ff4f16517601c40eb713602aed7a52 isLeaf true timestamp 1435318826 user juef comment {adwaita-icon-theme: update to 3.17.3} parents de628be645cc62429d630f9234c56d1fddfdc2a3 tags trunk}
+
+test json-decode-005 {object value from child array entry} {
+	dict get [lindex [dict get [json::decode $json] payload timeline] 0] comment
+} {adwaita-icon-theme: update to 3.17.3}
+
+test json-decode-006 {unicode escape} {
+	dict get [json::decode {{"key":"\u2022"}}] key
+} \u2022
+
+test json-decode-011 {null subsitution} {
+	dict get [json::decode -null NULL $json] homepage
+} {NULL}
+
+test json-decode-012 {default null value} {
+	dict get [json::decode $json] homepage
+} {null}
+
+unset -nocomplain json
+
+test json-encode-1.1 {String with backslashes}  {
+	json::encode {A "quoted string containing \backslashes\"}
+} {"A \"quoted string containing \\backslashes\\\""}
+
+test json-encode-1.2 {String with special chars} {
+	json::encode "Various \n special \b characters \t and /slash/ \r too"
+} {"Various \n special \b characters \t and \/slash\/ \r too"}
+
+test json-encode-1.3 {Array of numbers} {
+	json::encode {1 2 3.0 4} {list num}
+} {[ 1, 2, 3.0, 4 ]}
+
+test json-encode-1.4 {Array of strings} {
+	json::encode {1 2 3.0 4} list
+} {[ "1", "2", "3.0", "4" ]}
+
+
+test json-encode-1.5 {Array of objects} {
+	json::encode {{state NY city {New York} postalCode 10021 streetAddress {21 2nd Street}} {state CA city {Los Angeles} postalCode 10345 streetAddress {15 Hale St}}} {list obj postalCode num}
+} {[ { "city":"New York", "postalCode":10021, "state":"NY", "streetAddress":"21 2nd Street" }, { "city":"Los Angeles", "postalCode":10345, "state":"CA", "streetAddress":"15 Hale St" } ]}
+
+test json-encode-1.6 {Simple typeless object} {
+	json::encode {home {212 555-1234} fax {646 555-4567}} obj
+} {{ "fax":"646 555-4567", "home":"212 555-1234" }}
+
+test json-encode-1.7 {Primitives as num} {
+	json::encode {a false b null c true} {obj a num b num c num}
+} {{ "a":false, "b":null, "c":true }}
+
+test json-encode-1.8 {Complex schema} {
+	json::encode {Person {firstName John age 25 lastName Smith years {1972 1980 1995 2002} PhoneNumbers {home {212 555-1234} fax {646 555-4567}} Address {state NY city {New York} postalCode 10021 streetAddress {21 2nd Street}}}} {obj Person {obj age num Address {obj postalCode num} PhoneNumbers obj years {list num}}}
+} {{ "Person":{ "Address":{ "city":"New York", "postalCode":10021, "state":"NY", "streetAddress":"21 2nd Street" }, "PhoneNumbers":{ "fax":"646 555-4567", "home":"212 555-1234" }, "age":25, "firstName":"John", "lastName":"Smith", "years":[ 1972, 1980, 1995, 2002 ] } }}
+
+test json-encode-1.9 {Array of mixed types} {
+	json::encode {{a b c d} 44} {mixed list num}
+} {[ [ "a", "b", "c", "d" ], 44 ]}
+
+test json-encode-1.10 {Array of objects} {
+	json::encode {{state NY city {New York} postalCode 10021 streetAddress {21 2nd Street}} {state CA city {Los Angeles} postalCode 10345 streetAddress {15 Hale St}}} {list obj postalCode num}
+} {[ { "city":"New York", "postalCode":10021, "state":"NY", "streetAddress":"21 2nd Street" }, { "city":"Los Angeles", "postalCode":10345, "state":"CA", "streetAddress":"15 Hale St" } ]}
+
+testreport


### PR DESCRIPTION
JSON is a common data interchange format. While json encoding is easy to do efficiently in Tcl, decoding really needs a C-based implementation. This pull request adds light-weight implementations of both as json::encode and json::decode.