### PR TITLE
appveyor.yml: build with ipv6, math, sqlite3, ssl

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,15 @@
 version: "0.78.0.{build}"
 install:
   - cmd: set MSYSTEM=MINGW32
-  - cmd: C:\msys64\usr\bin\bash -lc "pacman --sync --noconfirm make mingw-w64-i686-gcc"
+  - cmd: C:\msys64\usr\bin\bash -lc "pacman --sync --noconfirm make mingw-w64-i686-gcc mingw-w64-i686-sqlite3"
   - cmd: cd C:\projects & mklink /D %APPVEYOR_PROJECT_NAME% %APPVEYOR_PROJECT_SLUG% & exit 0
 build_script:
-  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; ./configure --full --ipv6 --math --ssl --with-ext='zlib win32' --disable-docs"
+  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; ./configure --full --ipv6 --math --ssl --with-ext='sqlite3 win32 zlib' --disable-docs"
   - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; make"
 test_script:
   - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; make test"
 after_build:
   - cmd: copy jimsh.exe jimsh_debug.exe
-  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; strip jimsh.exe; 7z a jimsh.zip jimsh.exe jimsh_debug.exe /c/msys64/mingw32/bin/{libcrypto-1_1.dll,libgcc_s_dw2-1.dll,libssl-1_1.dll,libwinpthread-1.dll,zlib1.dll}"
+  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; strip jimsh.exe; 7z a jimsh.zip jimsh.exe jimsh_debug.exe /c/msys64/mingw32/bin/{libcrypto-1_1.dll,libgcc_s_dw2-1.dll,libsqlite3-0.dll,libssl-1_1.dll,libwinpthread-1.dll,zlib1.dll}"
 artifacts:
   - path: jimsh.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ version: "0.78.0.{build}"
 install:
   - cmd: set MSYSTEM=MINGW32
   - cmd: C:\msys64\usr\bin\bash -lc "pacman --sync --noconfirm make mingw-w64-i686-gcc"
+  - cmd: cd C:\projects & mklink /D %APPVEYOR_PROJECT_NAME% %APPVEYOR_PROJECT_SLUG% & exit 0
 build_script:
   - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; ./configure --full --ipv6 --math --ssl --with-ext='zlib win32' --disable-docs"
   - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; make"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ install:
   - cmd: set MSYSTEM=MINGW32
   - cmd: C:\msys64\usr\bin\bash -lc "pacman --sync --noconfirm make mingw-w64-i686-gcc"
 build_script:
-  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; ./configure --full --with-ext='zlib win32' --disable-docs"
+  - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; ./configure --full --ipv6 --math --ssl --with-ext='zlib win32' --disable-docs"
   - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; make"
 test_script:
   - cmd: C:\msys64\usr\bin\bash -lc "cd /c/projects/jimtcl; make test"


### PR DESCRIPTION
Also add a project directory path fix that seems to be necessary to enable CI in GitHub forks of the repo.