### PR TITLE
json: implement -index option

### DIFF
--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -5371,10 +5371,12 @@ json::decode
 
 The JSON -> Tcl decoder is part of the optional 'json' package.
 
-+*json::decode* ?*-null* 'string'? ?*-schema*? 'json-string'+::
++*json::decode* ?*-index*? ?*-null* 'string'? ?*-schema*? 'json-string'+::
 
-Decodes the given JSON string (must be array or object) into a Tcl data structure. If '+-schema+' is specified, returns a
-list of +'{data schema}'+ where the schema is compatible with `json::encode`. Otherwise just returns the data.
+Decodes the given JSON string (must be array or object) into a Tcl data structure. If '+-index+' is specified,
+decodes JSON arrays as dictionaries with numeric keys. This makes it possible to retrieve data from nested
+arrays and dictionaries with just '+dict get+'. With the option '+-schema+' returns a list of +'{data schema}'+
+where the schema is compatible with `json::encode`. Otherwise just returns the data.
 Decoding is as follows (with schema types listed in parentheses):
 * object -> dict ('obj')
 * array -> list ('mixed' or 'list')
@@ -5393,6 +5395,8 @@ Decoding is as follows (with schema types listed in parentheses):
     {a 1 b 2} {obj a num b num}
     . json::decode -schema {[1, 2, {a:"b", c:false}, "hello"]}
     {1 2 {a b c false} hello} {mixed num num {obj a str c bool} str}
+    . json::decode -index {["foo", "bar"]}
+    {0 foo 1 bar}
 ----
 
 [[BuiltinVariables]]

--- a/tests/json.test
+++ b/tests/json.test
@@ -99,6 +99,30 @@ test json-2.9 {schema tests} {
 	lindex [json::decode -schema {[{a:1},{b:2}]}] 1
 } {mixed {obj a num} {obj b num}}
 
+
+test json-3.1 {-index array} {
+	json::decode -index \
+		{[null, 1, 2, true, false, "hello"]}
+} {0 null 1 1 2 2 3 true 4 false 5 hello}
+
+test json-3.2 {-index array and object} {
+	json::decode -index \
+		{{"outer": [{"key": "value"}, {"key2": "value2"}]}}
+} {outer {0 {key value} 1 {key2 value2}}}
+
+test json-3.3 {-index array with -schema} {
+	json::decode -index -schema \
+		{[null, 1, 2, true, false, "hello"]}
+} "{0 null 1 1 2 2 3 true 4 false 5 hello}\
+   {mixed num num num bool bool str}"
+
+test json-3.4 {-index array with -schema 2} {
+	json::decode -index -schema \
+		{{"outer": [{"key": "value"}, {"key2": "value2"}]}}
+} "{outer {0 {key value} 1 {key2 value2}}}\
+   {obj outer {mixed {obj key str} {obj key2 str}}}"
+
+
 unset -nocomplain json
 
 test json-encode-1.1 {String with backslashes}  {


### PR DESCRIPTION
This is my implementation of `-index` for `json::decode`.  I have decided not to switch the schema to an index dict format because that would lead to something like `{mixed num bool str}` becoming `{SPECIAL_TYPE_KEY mixed 0 num 1 bool 2 str}` and then for use consistency `{obj key num key2 str}` becoming `{SPECIAL_TYPE_KEY obj key num key2 str}`.  No matter what you chose for `SPECIAL_TYPE_KEY`, in the latter case it could conflict with a key given by the user.  This would be a potential source of errors and in some cases security problems.