### PR TITLE
Fix #148 - oo errors with no class variables.

### DIFF
--- a/oo.tcl
+++ b/oo.tcl
@@ -69,7 +69,7 @@ proc class {classname {baseclasses {}} classvars} {
 			# Note that we can't use 'dict with' here because
 			# the dict isn't updated until the body completes.
 			foreach __ [$self vars] {upvar 1 instvars($__) $__}
-			unset __
+			unset -nocomplain __
 			eval $__body
 		}
 	}


### PR DESCRIPTION
https://github.com/msteveb/jimtcl/issues/148

Good catch Steve.  I forgot about -nocomplain.  Used it here.  I'm sure it's faster than the other 2 ways.