### PR TITLE
Match musl error messages in aio, socket, and tty tests

### DIFF
--- a/tests/aio.test
+++ b/tests/aio.test
@@ -116,7 +116,7 @@ test aio-7.1 {close args} -constraints socket -body {
 
 test aio-7.2 {close w on non-socket} -constraints socket -body {
 	$f close w
-} -returnCodes error -result {Socket operation on non-socket}
+} -returnCodes error -match regexp -result {^(Socket operation on non-socket|Not a socket)$}
 
 test aio-7.3 {close -nodelete on non-socket} -constraints socket -body {
 	$f close -nodelete

--- a/tests/socket.test
+++ b/tests/socket.test
@@ -290,7 +290,7 @@ test socket-3.3 {listen usage} -body {
 test socket-3.4 {listen not a socket} -body {
 	set f [open [info script]]
 	$f listen 10
-} -returnCodes error -match glob -result {Socket operation on non-socket} -cleanup {
+} -returnCodes error -match regexp -result {^(Socket operation on non-socket|Not a socket)$} -cleanup {
 	$f close
 }
 
@@ -305,14 +305,14 @@ test socket-4.2 {invalid ipv4 address} -body {
 test socket-4.3 {sockname on non-socket} -body {
 	set f [open [info script]]
 	$f sockname
-} -returnCodes error -result {Socket operation on non-socket} -cleanup {
+} -returnCodes error -match regexp -result {^(Socket operation on non-socket|Not a socket)$} -cleanup {
 	$f close
 }
 
 test socket-4.4 {peername on non-socket} -body {
 	set f [open [info script]]
 	$f peername
-} -returnCodes error -result {Socket operation on non-socket} -cleanup {
+} -returnCodes error -match regexp -result {^(Socket operation on non-socket|Not a socket)$} -cleanup {
 	$f close
 }
 

--- a/tests/tty.test
+++ b/tests/tty.test
@@ -24,7 +24,7 @@ test tty-1.3 {tty bad baud} -body {
 test tty-1.4 {tty bad fd} -body {
     set f [open [file tempfile] w]
     $f tty
-} -returnCodes error -result {Inappropriate ioctl for device} -cleanup {
+} -returnCodes error -match regexp -result {^(Inappropriate ioctl for device|Not a tty)$} -cleanup {
     $f close
 }
 


### PR DESCRIPTION
In some cases they differ from what you get when you build Jim on a GNU libc system.