### PR TITLE
update .gitignore adding jimtcl.pc and tests/Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 config.log
 tags
 /Makefile
+/tests/Makefile
 Tcl.html
 jimautoconf.h
 jimautoconfext.h
@@ -23,3 +24,4 @@ build-jim-ext
 *.gcno
 *.gcov
 coverage*.html
+jimtcl.pc


### PR DESCRIPTION
Commit aa4427dee716 ("Add pkg-config support: jimtcl.pc") adds the
build time file jimtcl.pc

Commit 630df0da46f4 ("Update autosetup to v0.6.8") adds running
make-template on tests/Makefile.in, producing tests/Makefile

Add both jimtcl.pc and tests/Makefile to .gitignore

Signed-off-by: Antonio Borneo <borneo.antonio@gmail.com>