### PR TITLE
core: dicts (and arrays) now preserve insertion order

### DIFF
--- a/jim-array.c
+++ b/jim-array.c
@@ -114,7 +114,8 @@ static int array_cmd_unset(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_OK;
     }
 
-    if (Jim_DictPairs(interp, objPtr, &dictValuesObj, &len) != JIM_OK) {
+    dictValuesObj = Jim_DictPairs(interp, objPtr, &len);
+    if (dictValuesObj == NULL) {
         /* Variable is not an array - tclsh ignores this and returns nothing - be compatible */
         Jim_SetResultString(interp, "", -1);
         return JIM_OK;
@@ -128,7 +129,6 @@ static int array_cmd_unset(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
             Jim_DictAddElement(interp, resultObj, dictValuesObj[i], dictValuesObj[i + 1]);
         }
     }
-    Jim_Free(dictValuesObj);
 
     Jim_SetVariable(interp, argv[0], resultObj);
     return JIM_OK;

--- a/jim.c
+++ b/jim.c
@@ -7450,10 +7450,12 @@ static int SetDictFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr)
 
         /* Now add all the elements to the hash table */
         for (i = 0; i < listlen; i += 2) {
-            if (JimDictAdd(dict, dict->table[i])) {
-                /* A duplicate key, so skip this pair */
-                Jim_DecrRefCount(interp, dict->table[i]);
-                Jim_DecrRefCount(interp, dict->table[i + 1]);
+            int tvoffset = JimDictAdd(dict, dict->table[i]);
+            if (tvoffset) {
+                /* A duplicate key, so replace the value but and don't add a new entry */
+                JimDictAdd(dict, dict->table[i]);
+                Jim_DecrRefCount(interp, dict->table[tvoffset]);
+                dict->table[tvoffset] = dict->table[i + 1];
             }
             else {
                 if (dict->len != i) {

--- a/jim.c
+++ b/jim.c
@@ -7453,9 +7453,12 @@ static int SetDictFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr)
             int tvoffset = JimDictAdd(dict, dict->table[i]);
             if (tvoffset) {
                 /* A duplicate key, so replace the value but and don't add a new entry */
-                JimDictAdd(dict, dict->table[i]);
+                /* Discard the old value */
                 Jim_DecrRefCount(interp, dict->table[tvoffset]);
+                /* Set the new value */
                 dict->table[tvoffset] = dict->table[i + 1];
+                /* Discard the duplicate key */
+                Jim_DecrRefCount(interp, dict->table[i]);
             }
             else {
                 if (dict->len != i) {

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -64,6 +64,7 @@ Changes between 0.78 and 0.79
 8. `regsub` now fully supports +{backslash}A+
 9. Add `socket pty` to create a pseudo-tty pair
 10. Null characters (\x00) are now supported in variable and proc names
+11. dictionaries and arrays now preserve insertion order, matching Tcl and the documentation
 
 Changes between 0.77 and 0.78
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/array.test
+++ b/tests/array.test
@@ -111,7 +111,7 @@ test array-1.19 "array unset non-array" -body {
 
 test array-1.20 "array stat" -body {
 	set output [array stat a]
-	regexp "1 entries in table.*number of buckets with 1 entries: 1" $output
+	regexp "entries in table.*buckets" $output
 } -result {1}
 
 test array-1.21 "array stat non-array" -body {

--- a/tests/dict.test
+++ b/tests/dict.test
@@ -278,4 +278,11 @@ test dict-25.4 {removal of keys that hash earlier} {
 	dict get $parsed formPost {text file}
 } Hello.
 
+test dict-25.5 {list to dict, duplicate keys} {
+	set l [list a 1 a 2 a 3]
+	# make sure there is no string rep
+	lappend l b 4
+	dict get $l a
+} {3}
+
 testreport

--- a/tests/dict.test
+++ b/tests/dict.test
@@ -270,4 +270,12 @@ test dict-25.3 {dict ordering} {
 	dict keys $d
 } {a 0 2}
 
+test dict-25.4 {removal of keys that hash earlier} {
+	set parsed {formPost {text {This is text.} {text file} Hello. {image file} abc}}
+
+	dict unset parsed formPost text
+	dict unset parsed formPost {image file}
+	dict get $parsed formPost {text file}
+} Hello.
+
 testreport

--- a/tests/dict.test
+++ b/tests/dict.test
@@ -249,4 +249,25 @@ test dict-24.4 {dict/list shimmering with lappend and foreach} {
 	llength $a
 } 12
 
+# As of 0.79, dicts maintain insertion order
+test dict-25.1 {dict ordering} {
+	dict keys {a x 0 y}
+} {a 0}
+
+test dict-25.2 {dict ordering} {
+	dict keys {0 x a y}
+} {0 a}
+
+test dict-25.3 {dict ordering} {
+	set d [dict create a y 0 x 2 z]
+	dict set d 1 w
+	dict keys $d
+} {a 0 2 1}
+
+test dict-25.3 {dict ordering} {
+	set d [dict create a y 0 x 2 z]
+	dict set d 0 w
+	dict keys $d
+} {a 0 2}
+
 testreport

--- a/tests/dict2.test
+++ b/tests/dict2.test
@@ -1273,7 +1273,7 @@ test dict-23.4 {dict with usage} -body {
 
 test dict-23.5 {dict with badvar} -constraints jim -body {
 	dict with dictnulls {lsort [info locals]}
-} -returnCodes ok -result [list \0ghi kl\0m ab\0c de\0f]
+} -returnCodes ok -result [list ab\0c de\0f \0ghi kl\0m]
 
 test dict-23.6 {dict with baddict} -body {
 	dict with dictbad {}

--- a/tests/runall.tcl
+++ b/tests/runall.tcl
@@ -55,7 +55,9 @@ if {[info commands interp] eq ""} {
 
 			# Extract the counts
 			foreach var {pass fail skip tests} {
-				incr total($var) [$i eval "set testinfo(num$var)"]
+				catch {
+					incr total($var) [$i eval "set testinfo(num$var)"]
+				}
 			}
 			$i delete
 		}


### PR DESCRIPTION
Although the documentation has always stated that, like Tcl,
insertion order of dictionaries was preserved, this has never
been the case. Instead, dictionaries were implemented as simple
hash tables that did not preserve order.

Now, a new implementation of dictionaries preserves insertion
order and has a number of other benefits.

Instead of hashing keys and storing keys and values in the hash table,
the keys and values are not stored in a separate table, exactly as
lists are stored, with alternating key, value pairs. Iterating over the
dictionary is exactly like iterating over a list, where the order is consistent.

The hash table uses closed hashing rather than open hashing to avoid
allocatation of hash entry structures. Instead a fixed (but expandable)
hash table maps the key hash to the offset in the key/value table.
This use of offsets means that if the key/value table grows, the offsets
remain valid. Likewise, if the hash table needs to grow, the key, value table
remains unchanged.

In addition to the offset (which indexes to the value, and 0 means the hash table entry is unused),
the original hash is stored in the hash table. This reduces the need for object
comparisons on hash entry collisions.

The collision resolution algorithm is the same as that used by Python:

	peturb >>= 5;
	idx = (5 * idx + 1 + peturb) & dict->sizemask;

In order to reduce collisions, the hash table is expanded once it reaches
half full. This is more conservative that Python where the table is expanded
when it is two thirds full.

In addition, the new faster hashing algorithm from Tcl 8.7 is used.
This the hash for integers to be calculated efficiently without requiring
them to be converted to string form first.

This implementation is modelled largely on the Python dict implementation.

Overall the performance should be an improvement over the current implementation,
whilst preserving order. Dictionary creating and insertion should be faster
as hash entries do not need to be allocated and resizing should be slightly faster.
Entry lookup should be about the same, except may be faster for pure integer keys.

Below are some indicative benchmarks.

```
                                                    OLD     NEW
dict-create-1.1  Create empty dict               97.2ns       .
dict-create-1.2  Create small dict                440ns    -27%
dict-create-1.3  Create medium dict              1.54us    -57%
dict-create-1.4  Create large dict (int keys)     130us    -80%
dict-create-1.5  Create large dict (string keys)  143us    -75%
   dict-set-1.1  Replace existing item            258ns    -34%
   dict-set-1.2  Replace nonexistent item         365ns    -49%
dict-exists-1.1  Find existing item              55.7ns     -5%
dict-exists-1.2  Find nonexistent item           55.0ns     -5%
```

Signed-off-by: Steve Bennett <steveb@workware.net.au>