### PR TITLE
TIP 461: Separate Numeric and String Comparison Operators

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -7981,15 +7981,19 @@ enum
     JIM_EXPROP_STRNE,
     JIM_EXPROP_STRIN,
     JIM_EXPROP_STRNI,
+    JIM_EXPROP_STRLT,
+    JIM_EXPROP_STRGT,
+    JIM_EXPROP_STRLE,
+    JIM_EXPROP_STRGE,
 
     /* Unary operators (numbers) */
-    JIM_EXPROP_NOT,             /* 47 */
+    JIM_EXPROP_NOT,             /* 51 */
     JIM_EXPROP_BITNOT,
     JIM_EXPROP_UNARYMINUS,
     JIM_EXPROP_UNARYPLUS,
 
     /* Functions */
-    JIM_EXPROP_FUNC_INT,      /* 51 */
+    JIM_EXPROP_FUNC_INT,      /* 55 */
     JIM_EXPROP_FUNC_WIDE,
     JIM_EXPROP_FUNC_ABS,
     JIM_EXPROP_FUNC_DOUBLE,
@@ -7998,7 +8002,7 @@ enum
     JIM_EXPROP_FUNC_SRAND,
 
     /* math functions from libm */
-    JIM_EXPROP_FUNC_SIN,        /* 65 */
+    JIM_EXPROP_FUNC_SIN,        /* 69 */
     JIM_EXPROP_FUNC_COS,
     JIM_EXPROP_FUNC_TAN,
     JIM_EXPROP_FUNC_ASIN,
@@ -8561,7 +8565,7 @@ static int JimExprOpStrBin(Jim_Interp *interp, struct JimExprNode *node)
 {
     Jim_Obj *A, *B;
     jim_wide wC;
-    int rc;
+    int comp, rc;
 
     if ((rc = JimExprGetTerm(interp, node->left, &A)) != JIM_OK) {
         return rc;
@@ -8577,6 +8581,21 @@ static int JimExprOpStrBin(Jim_Interp *interp, struct JimExprNode *node)
             wC = Jim_StringEqObj(A, B);
             if (node->type == JIM_EXPROP_STRNE) {
                 wC = !wC;
+            }
+            break;
+        case JIM_EXPROP_STRLT:
+        case JIM_EXPROP_STRGT:
+        case JIM_EXPROP_STRLE:
+        case JIM_EXPROP_STRGE:
+            comp = Jim_StringCompareObj(interp, A, B, 0);
+            if (node->type == JIM_EXPROP_STRLT) {
+                wC = comp == -1;
+            } else if (node->type == JIM_EXPROP_STRGT) {
+                wC = comp == 1;
+            } else if (node->type == JIM_EXPROP_STRLE) {
+                wC = comp == -1 || comp == 0;
+            } else /* JIM_EXPROP_STRGE */ {
+                wC = comp == 0 || comp == 1;
             }
             break;
         case JIM_EXPROP_STRIN:
@@ -8723,6 +8742,13 @@ static const struct Jim_ExprOperator Jim_ExprOperators[] = {
 
     OPRINIT("in", 55, 2, JimExprOpStrBin),
     OPRINIT("ni", 55, 2, JimExprOpStrBin),
+
+    /* Precedence must be higher than ==, !=, eq, ne but lower than
+       <, >, <=, >= */
+    OPRINIT("lt", 75, 2, JimExprOpStrBin),
+    OPRINIT("gt", 75, 2, JimExprOpStrBin),
+    OPRINIT("le", 75, 2, JimExprOpStrBin),
+    OPRINIT("ge", 75, 2, JimExprOpStrBin),
 
     OPRINIT_ATTR("!", 150, 1, JimExprOpNumUnary, OP_RIGHT_ASSOC),
     OPRINIT_ATTR("~", 150, 1, JimExprOpIntUnary, OP_RIGHT_ASSOC),

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -826,6 +826,12 @@ of precedence:
     These operators may be applied to strings as well as numeric operands,
     in which case string comparison is used.
 
++lt  gt  le  ge+::
+    Boolean less, greater, less than or equal, and greater than or equal.
+    Each operator produces 1 if the condition is true, 0 otherwise.
+    These operators differ from the above in that they use string comparison
+    for all operands, including numeric.
+
 +==  !=+::
     Boolean equal and not equal.  Each operator produces a zero/one result.
     Valid for all operand types. *Note* that values will be converted to integers

--- a/tests/expr-new.test
+++ b/tests/expr-new.test
@@ -262,6 +262,28 @@ test expr-8.11 {CompileEqualityExpr: error compiling equality arm} {
 } {1}
 
 
+test expr-8.36 {CompileEqualtyExpr: string comparison ops} {
+    set x 012
+    set y 0x0
+    list [expr {$x < $y}] [expr {$x lt $y}] [expr {$x lt $x}]
+} {0 1 0}
+test expr-8.37 {CompileEqualtyExpr: string comparison ops} {
+    set x 012
+    set y 0x0
+    list [expr {$x <= $y}] [expr {$x le $y}] [expr {$x le $x}]
+} {0 1 1}
+test expr-8.38 {CompileEqualtyExpr: string comparison ops} {
+    set x 012
+    set y 0x0
+    list [expr {$x > $y}] [expr {$x gt $y}] [expr {$x gt $x}]
+} {1 0 0}
+test expr-8.39 {CompileEqualtyExpr: string comparison ops} {
+    set x 012
+    set y 0x0
+    list [expr {$x >= $y}] [expr {$x ge $y}] [expr {$x ge $x}]
+} {1 0 1}
+
+
 test expr-9.1 {CompileRelationalExpr: just shift expr} {expr 3<<2} 12
 test expr-9.2 {CompileRelationalExpr: just shift expr} {expr 0xff>>2} 63
 test expr-9.3 {CompileRelationalExpr: just shift expr} {expr -1>>2} -1


### PR DESCRIPTION
This implements the operators `lt`, `gt`, `le`, `ge`.  [TIP 461](https://core.tcl-lang.org/tips/doc/trunk/tip/461.md).