### PR TITLE
Make unary "!" work with non-int booleans

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -8056,7 +8056,7 @@ static int JimExprEvalTermNode(Jim_Interp *interp, struct JimExprNode *node);
 static int JimExprOpNumUnary(Jim_Interp *interp, struct JimExprNode *node)
 {
     int intresult = 1;
-    int rc;
+    int rc, bA = 0;
     double dA, dC = 0;
     jim_wide wA, wC = 0;
     Jim_Obj *A;
@@ -8118,6 +8118,15 @@ static int JimExprOpNumUnary(Jim_Interp *interp, struct JimExprNode *node)
                 break;
             case JIM_EXPROP_NOT:
                 wC = !dA;
+                break;
+            default:
+                abort();
+        }
+    }
+    else if ((rc = Jim_GetBoolean(interp, A, &bA)) == JIM_OK) {
+        switch (node->type) {
+            case JIM_EXPROP_NOT:
+                wC = !bA;
                 break;
             default:
                 abort();

--- a/tests/expr.test
+++ b/tests/expr.test
@@ -142,4 +142,12 @@ test expr-4.1 "Shimmering" {
 	set a
 } {2}
 
+test expr-5.1 "Not" {
+	lmap x {1 0 true false on off yes no} { expr {!$x} }
+} {0 1 0 1 0 1 0 1}
+
+test expr-5.2 "Not" -body {
+	expr {!this}
+} -returnCodes error -result {syntax error in expression: "!this"}
+
 testreport


### PR DESCRIPTION
The unary `!` in Tcl 8 expressions works with all booleans: 0, 1, `true`, `false`,`yes`, `no`,`on`, `off`.  This PR implements the same capability in Jim.