### PR TITLE
Match the Tcl 8.6 "wrong # args" message with optional args

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -11095,7 +11095,7 @@ static void JimSetProcWrongArgs(Jim_Interp *interp, Jim_Obj *procNameObj, Jim_Cm
             }
             else {
                 /* We have plain args */
-                Jim_AppendString(interp, argmsg, "?arg...?", -1);
+                Jim_AppendString(interp, argmsg, "?arg ...?", -1);
             }
         }
         else {
@@ -12905,7 +12905,7 @@ static int Jim_LreplaceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const 
 static int Jim_LsetCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     if (argc < 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "listVar ?index...? newVal");
+        Jim_WrongNumArgs(interp, 1, argv, "listVar ?index ...? newVal");
         return JIM_ERR;
     }
     else if (argc == 3) {

--- a/jim.c
+++ b/jim.c
@@ -12905,7 +12905,7 @@ static int Jim_LreplaceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const 
 static int Jim_LsetCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     if (argc < 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "listVar ?index ...? newVal");
+        Jim_WrongNumArgs(interp, 1, argv, "listVar ?index ...? value");
         return JIM_ERR;
     }
     else if (argc == 3) {

--- a/tests/misc.test
+++ b/tests/misc.test
@@ -541,6 +541,11 @@ test lset-1.1 "lset with bad var" {
 	catch {lset badvar 1 x}
 } 1
 
+test lset-1.2 "lset error message" {
+	catch lset msg
+	set msg
+} {wrong # args: should be "lset listVar ?index ...? newVal"}
+
 test dict-1.1 "dict to string" {
 	set a [dict create abc \\ def \"]
 	set x x$a

--- a/tests/misc.test
+++ b/tests/misc.test
@@ -544,7 +544,7 @@ test lset-1.1 "lset with bad var" {
 test lset-1.2 "lset error message" {
 	catch lset msg
 	set msg
-} {wrong # args: should be "lset listVar ?index ...? newVal"}
+} {wrong # args: should be "lset listVar ?index ...? value"}
 
 test dict-1.1 "dict to string" {
 	set a [dict create abc \\ def \"]

--- a/tests/proc-new.test
+++ b/tests/proc-new.test
@@ -124,4 +124,13 @@ test proc-3.4 "invalid upref in rightargs" {
 	catch {a B}
 } 1
 
+test proc-3.5 "error message with optional args" {
+	proc a {b args} {
+		return $args
+	}
+	catch a msg
+	set msg
+} {wrong # args: should be "a b ?arg ...?"}
+
+
 testreport


### PR DESCRIPTION
Jim generally puts a space before the `...` in `?foo ...?`, so only two places had to be changed.