### PR TITLE
0.79 msys2x64

### DIFF
--- a/autosetup/autosetup
+++ b/autosetup/autosetup
@@ -43,7 +43,10 @@ proc main {argv} {
 	# 'misc' is needed before we can do anything, so set a temporary libdir
 	# in case this is the development version
 	set autosetup(libdir) [file dirname $::argv0]/lib
+puts stderr "libdir:$autosetup(libdir)"
 	use misc
+source [file join [file dirname $::argv0] jim-misc.auto]
+if {[llength [info commands cc-check-inline]] == 0} {error "cc-check-inline not found"}
 
 	# (a)
 	set autosetup(dir) [realdir [file dirname [realpath $::argv0]]]

--- a/make-c-ext.tcl
+++ b/make-c-ext.tcl
@@ -16,6 +16,9 @@ if {![string match *.tcl $source]} {
 set sourcelines {}
 set f [open $source]
 while {[gets $f buf] >= 0} {
+    # remove carriage returns (inserted by git??) not filtered out by bootstrap shell jimsh0.
+    regsub {\r} $buf "" buf
+    #puts stderr "[file tail $source]:[string length $buf]:$buf"
 	# Remove comment lines
 	regsub {^[ \t]*#.*$} $buf "" buf
 	# Escape quotes and backlashes

--- a/parse-unidata.tcl
+++ b/parse-unidata.tcl
@@ -33,6 +33,8 @@ lassign $argv unicodefile widthfile
 
 set f [open $unicodefile]
 while {[gets $f buf] >= 0} {
+    # remove carriage returns (inserted by git??) not filtered out by bootstrap shell jimsh0.
+    regsub {\r} $buf "" buf
 	set title ""
 	set lower ""
 	set upper ""


### PR DESCRIPTION
Fixes 3 build errors when building Jim on any Windows platform where bootstrap shell jimsh0 is used.  jimsh0 is very likely to be needed when building on most Windows hosts, since they're the least likely to have their own tclsh that can be found on the search path.  These fixes were developed on MSYS2 64-bit on Windows 10.