### PR TITLE
Fix 3 build errors when building Jim on Windows.

### DIFF
--- a/autosetup/autosetup
+++ b/autosetup/autosetup
@@ -43,7 +43,10 @@ proc main {argv} {
 	# 'misc' is needed before we can do anything, so set a temporary libdir
 	# in case this is the development version
 	set autosetup(libdir) [file dirname $::argv0]/lib
+puts stderr "libdir:$autosetup(libdir)"
 	use misc
+source [file join [file dirname $::argv0] jim-misc.auto]
+if {[llength [info commands cc-check-inline]] == 0} {error "cc-check-inline not found"}
 
 	# (a)
 	set autosetup(dir) [realdir [file dirname [realpath $::argv0]]]

--- a/make-c-ext.tcl
+++ b/make-c-ext.tcl
@@ -16,6 +16,9 @@ if {![string match *.tcl $source]} {
 set sourcelines {}
 set f [open $source]
 while {[gets $f buf] >= 0} {
+    # remove carriage returns (inserted by git??) not filtered out by bootstrap shell jimsh0.
+    regsub {\r} $buf "" buf
+    #puts stderr "[file tail $source]:[string length $buf]:$buf"
 	# Remove comment lines
 	regsub {^[ \t]*#.*$} $buf "" buf
 	# Escape quotes and backlashes

--- a/parse-unidata.tcl
+++ b/parse-unidata.tcl
@@ -33,6 +33,8 @@ lassign $argv unicodefile widthfile
 
 set f [open $unicodefile]
 while {[gets $f buf] >= 0} {
+    # remove carriage returns (inserted by git??) not filtered out by bootstrap shell jimsh0.
+    regsub {\r} $buf "" buf
 	set title ""
 	set lower ""
 	set upper ""


### PR DESCRIPTION
Steve, you're welcome to pull this if you like, or base your own patch on this technique.

This patch was developed on MSYS2 64-bit on Windows 10.  It's probably needed on any Windows host, since those are very likely to use jimsh0 bootstrap shell, because they're likely to find no other tclsh on their search path.

Fix syntax errors in _unicode_mapping.c.  parse-unidata.tcl output incorrect C file with spurious newlines if it ran on bootstrap shell jimsh0, and UnicodeData.txt happened to contain carriage returns for any reason.  This could easily happen when using git on Windows.

make-c-ext.tcl output incorrect C files with spurious newlines if it ran on bootstrap shell jimsh0, and the source .tcl file happened to contain carriage returns for any reason.  This could easily happen when using git on Windows.  This caused gcc errors regarding unterminated quoted strings and/or misplaced backslashes.

jim-misc.auto was not sourced properly, even though 'use' threw no error.  This led to "unknown command cc-check-inline" if you configured with line editing enabled.

This version can configure with --full and all optional extensions explicitly enabled by --with-ext, and make, and pass all tests except skipped ones.