### PR TITLE
.gitignore: add generated file /examples.api/Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 config.log
 tags
 /Makefile
+/examples.api/Makefile
 /tests/Makefile
 Tcl.html
 jimautoconf.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -212,7 +212,7 @@ clean:
 
 distclean: clean
 	rm -f jimautoconf.h jim-config.h Makefile config.log @srcdir@/autosetup/jimsh0@EXEEXT@ build-jim-ext
-	rm -f jimtcl.pc tests/Makefile
+	rm -f jimtcl.pc tests/Makefile examples.api/Makefile
 
 ship: Tcl.html
 	cp $< Tcl_shipped.html


### PR DESCRIPTION
When building in-tree, the generated file is not ignored and the
tree appears as dirty.

Add the generated file to .gitignore.

Signed-off-by: Antonio Borneo <borneo.antonio@gmail.com>