### PR TITLE
autosetup: keep clean the source tree on out-of-tree build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -211,7 +211,7 @@ clean:
 @endif
 
 distclean: clean
-	rm -f jimautoconf.h jim-config.h Makefile config.log @srcdir@/autosetup/jimsh0@EXEEXT@ build-jim-ext
+	rm -f jimautoconf.h jim-config.h Makefile config.log jimsh0@EXEEXT@ build-jim-ext
 	rm -f jimtcl.pc tests/Makefile examples.api/Makefile
 
 ship: Tcl.html

--- a/autosetup/autosetup-find-tclsh
+++ b/autosetup/autosetup-find-tclsh
@@ -1,17 +1,17 @@
 #!/bin/sh
 # Looks for a suitable tclsh or jimsh in the PATH
-# If not found, builds a bootstrap jimsh from source
+# If not found, builds a bootstrap jimsh in current dir from source
 # Prefer $autosetup_tclsh if is set in the environment
-d=`dirname "$0"`
-{ "$d/jimsh0" "$d/autosetup-test-tclsh"; } 2>/dev/null && exit 0
-PATH="$PATH:$d"; export PATH
+d="`dirname "$0"`"
+{ "./jimsh0" "$d/autosetup-test-tclsh"; } 2>/dev/null && exit 0
+PATH="$PATH:."; export PATH
 for tclsh in $autosetup_tclsh jimsh tclsh tclsh8.5 tclsh8.6 tclsh8.7; do
 	{ $tclsh "$d/autosetup-test-tclsh"; } 2>/dev/null && exit 0
 done
 echo 1>&2 "No installed jimsh or tclsh, building local bootstrap jimsh0"
 for cc in ${CC_FOR_BUILD:-cc} gcc; do
-	{ $cc -o "$d/jimsh0" "$d/jimsh0.c"; } 2>/dev/null || continue
-	"$d/jimsh0" "$d/autosetup-test-tclsh" && exit 0
+	{ $cc -o "jimsh0" "$d/jimsh0.c"; } 2>/dev/null || continue
+	"./jimsh0" "$d/autosetup-test-tclsh" && exit 0
 done
 echo 1>&2 "No working C compiler found. Tried ${CC_FOR_BUILD:-cc} and gcc."
 echo false


### PR DESCRIPTION
Hi Steve,
clearly this patch should be split to be applied to
   https://github.com/msteveb/autosetup
too, but to have a complete and working setup, I've only pushed this in jimtcl.
Please let me know if it's ok for you and how to proceed for autosetup.
Antonio


If the build host doesn't have neither jimsh nor tclsh installed,
during 'configure' the autosetup will build 'autosetup/jimsh0'
inside the source tree. This happens also when out-of-tree build
is used.
Making dirty the source tree during out-of-tree build causes
applications that use jimtcl as submodule (e.g. OpenOCD) to fail
at 'make distcheck'.

Modify 'autosetup-find-tclsh' to build 'jimsh0' in the current
folder. For jimtcl project it would be the root of the source tree
or the root of the out-of-tree build.
Update 'Makefile.in' to search for 'jimsh0' in the new path during
'distclean'.

Reported-by: Paul Fertser <fercerpav@gmail.com>
Signed-off-by: Antonio Borneo <borneo.antonio@gmail.com>