### PR TITLE
core: support integer expressions in various commands

### DIFF
--- a/jim-pack.c
+++ b/jim-pack.c
@@ -290,14 +290,14 @@ static int Jim_UnpackCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
 
-    if (Jim_GetWide(interp, argv[3], &pos) != JIM_OK) {
+    if (Jim_GetWideExpr(interp, argv[3], &pos) != JIM_OK) {
         return JIM_ERR;
     }
     if (pos < 0 || (option == OPT_STR && pos % 8)) {
         Jim_SetResultFormatted(interp, "bad bitoffset: %#s", argv[3]);
         return JIM_ERR;
     }
-    if (Jim_GetWide(interp, argv[4], &width) != JIM_OK) {
+    if (Jim_GetWideExpr(interp, argv[4], &width) != JIM_OK) {
         return JIM_ERR;
     }
     if (width < 0 || (option == OPT_STR && width % 8) || (option != OPT_STR && width > sizeof(jim_wide) * 8) ||
@@ -387,14 +387,14 @@ static int Jim_PackCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
     if ((option == OPT_LE || option == OPT_BE) &&
-            Jim_GetWide(interp, argv[2], &value) != JIM_OK) {
+            Jim_GetWideExpr(interp, argv[2], &value) != JIM_OK) {
         return JIM_ERR;
     }
     if ((option == OPT_FLOATLE || option == OPT_FLOATBE) &&
             Jim_GetDouble(interp, argv[2], &fvalue) != JIM_OK) {
         return JIM_ERR;
     }
-    if (Jim_GetWide(interp, argv[4], &width) != JIM_OK) {
+    if (Jim_GetWideExpr(interp, argv[4], &width) != JIM_OK) {
         return JIM_ERR;
     }
     if (width <= 0 || (option == OPT_STR && width % 8) || (option != OPT_STR && width > sizeof(jim_wide) * 8) ||
@@ -403,7 +403,7 @@ static int Jim_PackCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         return JIM_ERR;
     }
     if (argc == 6) {
-        if (Jim_GetWide(interp, argv[5], &pos) != JIM_OK) {
+        if (Jim_GetWideExpr(interp, argv[5], &pos) != JIM_OK) {
             return JIM_ERR;
         }
         if (pos < 0 || (option == OPT_STR && pos % 8)) {

--- a/jim.c
+++ b/jim.c
@@ -6057,6 +6057,27 @@ int Jim_GetWide(Jim_Interp *interp, Jim_Obj *objPtr, jim_wide * widePtr)
     return JIM_OK;
 }
 
+int Jim_GetWideExpr(Jim_Interp *interp, Jim_Obj *objPtr, jim_wide * widePtr)
+{
+    int ret = JIM_OK;
+    if (objPtr->typePtr == &intObjType) {
+        *widePtr = JimWideValue(objPtr);
+    }
+    else {
+        ret = Jim_EvalExpression(interp, objPtr);
+        if (ret == JIM_OK) {
+            ret = Jim_GetWide(interp, Jim_GetResult(interp), widePtr);
+        }
+        else {
+            /* XXX By doing this we throw away any more detailed message,
+             * but typical integer expressions won't be very complex
+             */
+            Jim_SetResultFormatted(interp, "expected integer expression but got \"%#s\"", objPtr);
+        }
+    }
+    return ret;
+}
+
 /* Get a wide but does not set an error if the format is bad. */
 static int JimGetWideNoErr(Jim_Interp *interp, Jim_Obj *objPtr, jim_wide * widePtr)
 {
@@ -10409,7 +10430,7 @@ static int Jim_IncrCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         return JIM_ERR;
     }
     if (argc == 3) {
-        if (Jim_GetWide(interp, argv[2], &increment) != JIM_OK)
+        if (Jim_GetWideExpr(interp, argv[2], &increment) != JIM_OK)
             return JIM_ERR;
     }
     intObjPtr = Jim_GetVariable(interp, argv[1], JIM_UNSHARED);
@@ -12039,7 +12060,7 @@ static int Jim_ForCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv
 
         /* Get the stop condition (must be a variable or integer) */
         if (expr->expr->right->type == JIM_TT_EXPR_INT) {
-            if (Jim_GetWide(interp, expr->expr->right->objPtr, &stop) == JIM_ERR) {
+            if (Jim_GetWideExpr(interp, expr->expr->right->objPtr, &stop) == JIM_ERR) {
                 goto evalstart;
             }
         }
@@ -12151,14 +12172,14 @@ static int Jim_LoopCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         return JIM_ERR;
     }
 
-    if (Jim_GetWide(interp, argv[2], &i) != JIM_OK ||
-        Jim_GetWide(interp, argv[3], &limit) != JIM_OK ||
-          (argc == 6 && Jim_GetWide(interp, argv[4], &incr) != JIM_OK)) {
+    if (Jim_GetWideExpr(interp, argv[2], &i) != JIM_OK ||
+        Jim_GetWideExpr(interp, argv[3], &limit) != JIM_OK ||
+          (argc == 6 && Jim_GetWideExpr(interp, argv[4], &incr) != JIM_OK)) {
         return JIM_ERR;
     }
     bodyObjPtr = (argc == 5) ? argv[4] : argv[5];
 
-    retval = Jim_SetVariable(interp, argv[1], argv[2]);
+    retval = Jim_SetVariable(interp, argv[1], Jim_NewIntObj(interp, i));
 
     while (((i < limit && incr > 0) || (i > limit && incr < 0)) && retval == JIM_OK) {
         retval = Jim_EvalObj(interp, bodyObjPtr);
@@ -13968,7 +13989,7 @@ badcompareargs:
                     Jim_WrongNumArgs(interp, 2, argv, "string count");
                     return JIM_ERR;
                 }
-                if (Jim_GetWide(interp, argv[3], &count) != JIM_OK) {
+                if (Jim_GetWideExpr(interp, argv[3], &count) != JIM_OK) {
                     return JIM_ERR;
                 }
                 objPtr = Jim_NewStringObj(interp, "", 0);
@@ -15403,13 +15424,14 @@ static int Jim_LrangeCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
 static int Jim_LrepeatCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     Jim_Obj *objPtr;
-    long count;
+    jim_wide count;
 
-    if (argc < 2 || Jim_GetLong(interp, argv[1], &count) != JIM_OK || count < 0) {
+    if (argc < 2 || Jim_GetWideExpr(interp, argv[1], &count) != JIM_OK || count < 0) {
         Jim_WrongNumArgs(interp, 1, argv, "count ?value ...?");
         return JIM_ERR;
     }
     if (count == 0 || argc == 2) {
+        Jim_SetEmptyResult(interp);
         return JIM_OK;
     }
 
@@ -15568,14 +15590,14 @@ static int Jim_RangeCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
         return JIM_ERR;
     }
     if (argc == 2) {
-        if (Jim_GetWide(interp, argv[1], &end) != JIM_OK)
+        if (Jim_GetWideExpr(interp, argv[1], &end) != JIM_OK)
             return JIM_ERR;
     }
     else {
-        if (Jim_GetWide(interp, argv[1], &start) != JIM_OK ||
-            Jim_GetWide(interp, argv[2], &end) != JIM_OK)
+        if (Jim_GetWideExpr(interp, argv[1], &start) != JIM_OK ||
+            Jim_GetWideExpr(interp, argv[2], &end) != JIM_OK)
             return JIM_ERR;
-        if (argc == 4 && Jim_GetWide(interp, argv[3], &step) != JIM_OK)
+        if (argc == 4 && Jim_GetWideExpr(interp, argv[3], &step) != JIM_OK)
             return JIM_ERR;
     }
     if ((len = JimRangeLen(start, end, step)) == -1) {
@@ -15602,11 +15624,11 @@ static int Jim_RandCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     if (argc == 1) {
         max = JIM_WIDE_MAX;
     } else if (argc == 2) {
-        if (Jim_GetWide(interp, argv[1], &max) != JIM_OK)
+        if (Jim_GetWideExpr(interp, argv[1], &max) != JIM_OK)
             return JIM_ERR;
     } else if (argc == 3) {
-        if (Jim_GetWide(interp, argv[1], &min) != JIM_OK ||
-            Jim_GetWide(interp, argv[2], &max) != JIM_OK)
+        if (Jim_GetWideExpr(interp, argv[1], &min) != JIM_OK ||
+            Jim_GetWideExpr(interp, argv[2], &max) != JIM_OK)
             return JIM_ERR;
     }
     len = max-min;

--- a/jim.c
+++ b/jim.c
@@ -6082,7 +6082,7 @@ int Jim_GetWideExpr(Jim_Interp *interp, Jim_Obj *objPtr, jim_wide * widePtr)
         if (ret == JIM_OK) {
             ret = Jim_GetWide(interp, Jim_GetResult(interp), widePtr);
         }
-        else {
+        if (ret != JIM_OK) {
             /* XXX By doing this we throw away any more detailed message,
              * but typical integer expressions won't be very complex
              */
@@ -7822,9 +7822,12 @@ static void UpdateStringOfIndex(struct Jim_Obj *objPtr)
 
 static int SetIndexFromAny(Jim_Interp *interp, Jim_Obj *objPtr)
 {
-    int idx, end = 0;
+    jim_wide idx;
+    int end = 0;
     const char *str;
-    char *endptr;
+    Jim_Obj *exprObj = objPtr;
+
+    JimPanic((objPtr->refCount == 0, "SetIndexFromAny() called with zero refcount object"));
 
     /* Get the string representation */
     str = Jim_String(objPtr);
@@ -7834,34 +7837,33 @@ static int SetIndexFromAny(Jim_Interp *interp, Jim_Obj *objPtr)
         end = 1;
         str += 3;
         idx = 0;
-    }
-    else {
-        idx = jim_strtol(str, &endptr);
+        switch (*str) {
+            case '\0':
+                exprObj = NULL;
+                break;
 
-        if (endptr == str) {
+            case '-':
+            case '+':
+                /* Create a temp object here for evaluation, but this only happens
+                 * once unless the index object shimmers since the result is kept
+                 */
+                exprObj = Jim_NewStringObj(interp, str, -1);
+                break;
+
+            default:
+                goto badindex;
+        }
+    }
+    if (exprObj) {
+        int ret;
+        Jim_IncrRefCount(exprObj);
+        ret = Jim_GetWideExpr(interp, exprObj, &idx);
+        Jim_DecrRefCount(interp, exprObj);
+        if (ret != JIM_OK) {
             goto badindex;
         }
-        str = endptr;
     }
 
-    /* Now str may include any number of +<num> or -<num> */
-    while (*str == '+' || *str == '-') {
-        int sign = (*str == '+' ? 1 : -1);
-
-        idx += sign * jim_strtol(++str, &endptr);
-        if (endptr == str) {
-            goto badindex;
-        }
-        str = endptr;
-    }
-
-    /* The only thing left should be spaces */
-    while (isspace(UCHAR(*str))) {
-        str++;
-    }
-    if (*str) {
-        goto badindex;
-    }
     if (end) {
         if (idx > 0) {
             idx = INT_MAX;
@@ -7883,7 +7885,7 @@ static int SetIndexFromAny(Jim_Interp *interp, Jim_Obj *objPtr)
 
   badindex:
     Jim_SetResultFormatted(interp,
-        "bad index \"%#s\": must be integer?[+-]integer? or end?[+-]integer?", objPtr);
+        "bad index \"%#s\": must be intexpr or end?[+-]intexpr?", objPtr);
     return JIM_ERR;
 }
 

--- a/jim.c
+++ b/jim.c
@@ -4729,6 +4729,9 @@ int Jim_SetVariableLink(Jim_Interp *interp, Jim_Obj *nameObjPtr,
  */
 Jim_Obj *Jim_GetVariable(Jim_Interp *interp, Jim_Obj *nameObjPtr, int flags)
 {
+    if (interp->safeexpr) {
+        return nameObjPtr;
+    }
     switch (SetVariableFromAny(interp, nameObjPtr)) {
         case JIM_OK:{
                 Jim_Var *varPtr = nameObjPtr->internalRep.varValue.varPtr;
@@ -5019,6 +5022,10 @@ static Jim_Obj *JimExpandDictSugar(Jim_Interp *interp, Jim_Obj *objPtr)
 {
     Jim_Obj *resObjPtr = NULL;
     Jim_Obj *substKeyObjPtr = NULL;
+
+    if (interp->safeexpr) {
+        return objPtr;
+    }
 
     SetDictSubstFromAny(interp, objPtr);
 
@@ -6064,7 +6071,14 @@ int Jim_GetWideExpr(Jim_Interp *interp, Jim_Obj *objPtr, jim_wide * widePtr)
         *widePtr = JimWideValue(objPtr);
     }
     else {
+        /* safeexpr can never be set here, because evaluating an expression
+         * safely can never cause a script to be run
+         */
+        JimPanic((interp->safeexpr, "interp->safeexpr is set"));
+        interp->safeexpr++;
         ret = Jim_EvalExpression(interp, objPtr);
+        interp->safeexpr--;
+
         if (ret == JIM_OK) {
             ret = Jim_GetWide(interp, Jim_GetResult(interp), widePtr);
         }
@@ -9184,8 +9198,7 @@ static void JimShowExprNode(struct JimExprNode *node, int level)
  *
  * 'exp_numterms' indicates how many terms are expected. Normally this is 1, but may be more for EXPR_FUNC_ARGS and EXPR_TERNARY.
  */
-static int ExprTreeBuildTree(Jim_Interp *interp, struct ExprBuilder *builder, int precedence, int flags, int exp_numterms)
-{
+static int ExprTreeBuildTree(Jim_Interp *interp, struct ExprBuilder *builder, int precedence, int flags, int exp_numterms) {
     int rc;
     struct JimExprNode *node;
     /* Calculate the stack length expected after pushing the number of expected terms */
@@ -9637,6 +9650,9 @@ static int JimExprEvalTermNode(Jim_Interp *interp, struct JimExprNode *node)
                 return JIM_ERR;
 
             case JIM_TT_ESC:
+                if (interp->safeexpr) {
+                    return JIM_ERR;
+                }
                 if (Jim_SubstObj(interp, node->objPtr, &objPtr, JIM_NONE) == JIM_OK) {
                     Jim_SetResult(interp, objPtr);
                     return JIM_OK;
@@ -9644,6 +9660,9 @@ static int JimExprEvalTermNode(Jim_Interp *interp, struct JimExprNode *node)
                 return JIM_ERR;
 
             case JIM_TT_CMD:
+                if (interp->safeexpr) {
+                    return JIM_ERR;
+                }
                 return Jim_EvalObj(interp, node->objPtr);
 
             default:
@@ -9696,7 +9715,7 @@ int Jim_EvalExpression(Jim_Interp *interp, Jim_Obj *exprObjPtr)
      *   $a != CONST, $a != $b
      *   $a == CONST, $a == $b
      */
-    {
+    if (!interp->safeexpr) {
         Jim_Obj *objPtr;
 
         /* STEP 1 -- Check if there are the conditions to run the specialized

--- a/jim.h
+++ b/jim.h
@@ -547,6 +547,7 @@ typedef struct Jim_Interp {
                 structure. */
     int local; /* If 'local' is in effect, newly defined procs keep a reference to the old defn */
     int quitting; /* Set to 1 during Jim_FreeInterp() */
+    int safeexpr; /* Set when evaluating a "safe" expression, no var subst or command eval */
     Jim_Obj *liveList; /* Linked list of all the live objects. */
     Jim_Obj *freeList; /* Linked list of all the unused objects. */
     Jim_Obj *currentScriptObj; /* Script currently in execution. */

--- a/jim.h
+++ b/jim.h
@@ -849,6 +849,8 @@ JIM_EXPORT int Jim_GetBoolean(Jim_Interp *interp, Jim_Obj *objPtr,
 /* integer object */
 JIM_EXPORT int Jim_GetWide (Jim_Interp *interp, Jim_Obj *objPtr,
         jim_wide *widePtr);
+JIM_EXPORT int Jim_GetWideExpr(Jim_Interp *interp, Jim_Obj *objPtr,
+        jim_wide *widePtr);
 JIM_EXPORT int Jim_GetLong (Jim_Interp *interp, Jim_Obj *objPtr,
         long *longPtr);
 #define Jim_NewWideObj  Jim_NewIntObj

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -55,9 +55,9 @@ RECENT CHANGES
 Changes since 0.80
 ~~~~~~~~~~~~~~~~~~
 1. TIP 582, comments allowed in expressions
-2. Indexes may contain any number of +n, -n
-3. Many commands now accept integer expressions rather than simple integers:
+2. Many commands now accept "safe" integer expressions rather than simple integers:
    `loop`, `range`, `incr`, `string repeat`, `lrepeat`, `pack`, `unpack`, `rand`
+3. String and list indexes now accept integer expressions (<<_string_and_list_index_specifications,STRING AND LIST INDEX SPECIFICATIONS>>)
 
 Changes between 0.79 and 0.80
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -655,21 +655,32 @@ specify a position in the string relative to the start or end of the string/list
 The index may be one of the following forms:
 
 +integer+::
-    A simple integer, where '0' refers to the first element of the string
+    A simple integer, where +0+ refers to the first element of the string
     or list.
 
-+integer+integer?...?+ or::
-+integer-integer?...?+::
-    The sum or difference of the two or more integers. e.g. +2+3-1+ refers to the 4th element.
-    This is useful when used with (e.g.) +$i+1+ rather than the more verbose
-    +[expr {$i+1\}]+
++integerexpression+::
+    Any "safe" expression that evaluates to an integer. A "safe" expression does not perform
+    variable or command subsitution, but is otherwise like a normal expression
+    (see <<_expressions,EXPRESSIONS>>).
 
-+end+::
+ ::
+    For example +1+2*3+ is valid integer expression, but +{$x*2-1}+ is not.
+    But note that it is possible to use an unbraced expression to allow the Tcl interpreter
+    to expand variables and commands before being parsed as an integer expression.
+
+ ::
+    e.g. +string repeat a $x*2-1+
+
++*end*+::
     The last element of the string or list.
 
-+end-integer?...?+::
-    The 'nth-from-last' element of the string or list. Again, one or more integers may
-    be added or subtracted. e.g. +end-3+1+
++*end*-integer+::
++*end*-integerexpression+::
++*end*+integerexpression+::
+    The 'nth-from-last' element of the string or list. Again, a "safe" integer expression
+    may be used in place of a simple integer. +end-3+ or  +end-3+2*$n+. Normally it only makes
+    sense to use the +*end*-+ form, but if the integer expression is negative, the +*end*++ form
+    may be used.
 
 COMMAND SUMMARY
 ---------------

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -56,6 +56,8 @@ Changes since 0.80
 ~~~~~~~~~~~~~~~~~~
 1. TIP 582, comments allowed in expressions
 2. Indexes may contain any number of +n, -n
+3. Many commands now accept integer expressions rather than simple integers:
+   `loop`, `range`, `incr`, `string repeat`, `lrepeat`, `pack`, `unpack`, `rand`
 
 Changes between 0.79 and 0.80
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2771,7 +2773,7 @@ Increment the value stored in the variable whose name is +'varName'+.
 The value of the variable must be integral.
 
 If +'increment'+ is supplied then its value (which must be an
-integer) is added to the value of variable +'varName'+;  otherwise
+integer expression) is added to the value of variable +'varName'+;  otherwise
 1 is added to +'varName'+.
 
 The new value is stored as a decimal string in variable +'varName'+
@@ -3069,6 +3071,8 @@ While if +'incr'+ is negative, the count is downwards.
 If +'incr'+ is not specified, 1 is used.
 Note that setting the loop variable inside the loop does not
 affect the loop count.
+
+Integer parameters may be any integer expression.
 
 lindex
 ~~~~~~
@@ -3593,6 +3597,8 @@ and ranging up to but not including +'end'+ in steps of +'step'+ defaults to 1).
     . range 7 4 -2
     7 5
 ----
+
+Integer parameters may be any integer expression.
 
 read
 ~~~~

--- a/tcltest.tcl
+++ b/tcltest.tcl
@@ -152,7 +152,7 @@ if {![exists -proc puts]} {
 proc script_source {script} {
 	lassign [info source $script] f l
 	if {$f ne ""} {
-		puts "At      : $f:$l"
+		puts "$f:$l:Error test failure"
 		return \t$f:$l
 	}
 }
@@ -160,7 +160,7 @@ proc script_source {script} {
 proc error_source {} {
 	lassign [info stacktrace] p f l
 	if {$f ne ""} {
-		puts "At      : $f:$l"
+		puts "$f:$l:Error test failure"
 		return \t$f:$l
 	}
 }

--- a/tests/binary.test
+++ b/tests/binary.test
@@ -251,7 +251,7 @@ test binary-8.9 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 test binary-8.10 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     set a {0x50 0x51}
     binary format c $a
-} -result "expected integer but got \"0x50 0x51\""
+} -match glob -result "expected integer *but got \"0x50 0x51\""
 test binary-8.11 {Tcl_BinaryObjCmd: format} {
     set a {0x50 0x51}
     binary format c1 $a
@@ -262,7 +262,7 @@ test binary-9.1 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 } -result {not enough arguments for all format specifiers}
 test binary-9.2 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     binary format s blat
-} -result {expected integer but got "blat"}
+} -match glob -result {expected integer *but got "blat"}
 test binary-9.3 {Tcl_BinaryObjCmd: format} {
     binary format s0 0x50
 } {}
@@ -290,7 +290,7 @@ test binary-9.10 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 test binary-9.11 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     set a {0x50 0x51}
     binary format s $a
-} -result "expected integer but got \"0x50 0x51\""
+} -match glob -result "expected integer *but got \"0x50 0x51\""
 test binary-9.12 {Tcl_BinaryObjCmd: format} {
     set a {0x50 0x51}
     binary format s1 $a
@@ -301,7 +301,7 @@ test binary-10.1 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 } -result {not enough arguments for all format specifiers}
 test binary-10.2 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     binary format S blat
-} -result {expected integer but got "blat"}
+} -match glob -result {expected integer *but got "blat"}
 test binary-10.3 {Tcl_BinaryObjCmd: format} {
     binary format S0 0x50
 } {}
@@ -329,7 +329,7 @@ test binary-10.10 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 test binary-10.11 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     set a {0x50 0x51}
     binary format S $a
-} -result "expected integer but got \"0x50 0x51\""
+} -match glob -result "expected integer *but got \"0x50 0x51\""
 test binary-10.12 {Tcl_BinaryObjCmd: format} {
     set a {0x50 0x51}
     binary format S1 $a
@@ -340,7 +340,7 @@ test binary-11.1 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 } -result {not enough arguments for all format specifiers}
 test binary-11.2 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     binary format i blat
-} -result {expected integer but got "blat"}
+} -match glob -result {expected integer *but got "blat"}
 test binary-11.3 {Tcl_BinaryObjCmd: format} {
     binary format i0 0x50
 } {}
@@ -371,7 +371,7 @@ test binary-11.11 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 test binary-11.12 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     set a {0x50 0x51}
     binary format i $a
-} -result "expected integer but got \"0x50 0x51\""
+} -match glob -result "expected integer *but got \"0x50 0x51\""
 test binary-11.13 {Tcl_BinaryObjCmd: format} {
     set a {0x50 0x51}
     binary format i1 $a
@@ -382,7 +382,7 @@ test binary-12.1 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 } -result {not enough arguments for all format specifiers}
 test binary-12.2 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     binary format I blat
-} -result {expected integer but got "blat"}
+} -match glob -result {expected integer *but got "blat"}
 test binary-12.3 {Tcl_BinaryObjCmd: format} {
     binary format I0 0x50
 } {}
@@ -413,7 +413,7 @@ test binary-12.11 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 test binary-12.12 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     set a {0x50 0x51}
     binary format I $a
-} -result "expected integer but got \"0x50 0x51\""
+} -match glob -result "expected integer *but got \"0x50 0x51\""
 test binary-12.13 {Tcl_BinaryObjCmd: format} {
     set a {0x50 0x51}
     binary format I1 $a
@@ -1664,7 +1664,7 @@ test binary-48.1 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 } -result {not enough arguments for all format specifiers}
 test binary-48.2 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     binary format t blat
-} -result {expected integer but got "blat"}
+} -match glob -result {expected integer *but got "blat"}
 test binary-48.3 {Tcl_BinaryObjCmd: format} {
     binary format S0 0x50
 } {}
@@ -1710,7 +1710,7 @@ test binary-48.16 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 test binary-48.17 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     set a {0x50 0x51}
     binary format t $a
-} -result "expected integer but got \"0x50 0x51\""
+} -match glob -result "expected integer *but got \"0x50 0x51\""
 test binary-48.18 {Tcl_BinaryObjCmd: format} bigEndian {
     set a {0x50 0x51}
     binary format t1 $a
@@ -1726,7 +1726,7 @@ test binary-49.1 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 } -result {not enough arguments for all format specifiers}
 test binary-49.2 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     binary format n blat
-} -result {expected integer but got "blat"}
+} -match glob -result {expected integer *but got "blat"}
 test binary-49.3 {Tcl_BinaryObjCmd: format} {
     binary format n0 0x50
 } {}
@@ -1757,7 +1757,7 @@ test binary-49.11 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
 test binary-49.12 {Tcl_BinaryObjCmd: format} -returnCodes error -body {
     set a {0x50 0x51}
     binary format n $a
-} -result "expected integer but got \"0x50 0x51\""
+} -match glob -result "expected integer *but got \"0x50 0x51\""
 test binary-49.13 {Tcl_BinaryObjCmd: format} littleEndian {
     set a {0x50 0x51}
     binary format n1 $a

--- a/tests/coverage.test
+++ b/tests/coverage.test
@@ -182,11 +182,11 @@ test rand-1 {rand} -constraints rand -body {
 
 test rand-2 {rand} -constraints rand -body {
 	rand foo
-} -returnCodes error -result {expected integer but got "foo"}
+} -returnCodes error -match glob -result {expected integer *but got "foo"}
 
 test rand-3 {rand} -constraints rand -body {
 	rand 2 bar
-} -returnCodes error -result {expected integer but got "bar"}
+} -returnCodes error -match glob -result {expected integer *but got "bar"}
 
 test rand-4 {rand} rand {
 	string is integer [rand]

--- a/tests/dict2.test
+++ b/tests/dict2.test
@@ -316,14 +316,14 @@ test dict-11.9 {dict incr command} -returnCodes error -body {
 	dict-sort $dictv
 } -cleanup {
     unset dictv
-} -result {expected integer but got "dummy"}
+} -match glob -result {expected integer *but got "dummy"}
 test dict-11.10 {dict incr command} -returnCodes error -body {
     set dictv {a 1}
     dict incr dictv a dummy
 	dict-sort $dictv
 } -cleanup {
     unset dictv
-} -result {expected integer but got "dummy"}
+} -match glob -result {expected integer *but got "dummy"}
 test dict-11.11 {dict incr command} -setup {
     unset -nocomplain dictv
 } -body {

--- a/tests/intexpr.test
+++ b/tests/intexpr.test
@@ -1,0 +1,133 @@
+source [file dirname [info script]]/testing.tcl
+
+needs constraint jim
+
+# There are two kinds of commands that use (safe) integer expressions:
+# direct: loop, range, incr, string repeat, lrepeat, pack, unpack, rand
+# index: lindex, linsert, lreplace, lset, lrange, lsort, regexp, regsub, string index,first,last,range
+#
+# Since they are all identical under the covers, we only test one from each group here,
+# string repeat and string index
+
+test intexpr-1.1 {string repeat} {
+	string repeat a 2+1
+} {aaa}
+
+test intexpr-1.2 {string repeat} {
+	string repeat a 2-1
+} {a}
+
+test intexpr-1.3 {string repeat} {
+	string repeat a 2*3
+} {aaaaaa}
+
+test intexpr-1.4 {string repeat - function calls} {
+	string repeat a int(abs(-2))
+} {aa}
+
+test intexpr-1.4 {string repeat - expanded var} {
+	set n 3
+	string repeat a $n+1
+} {aaaa}
+
+test intexpr-1.5 {string repeat - no subst var} -body {
+	set n 3
+	string repeat a {$n+1}
+} -returnCodes error -result {expected integer expression but got "$n+1"}
+
+test intexpr-1.6 {string repeat - no subst cmd} -body {
+	string repeat a {[string length xy]+1}
+} -returnCodes error -result {expected integer expression but got "[string length xy]+1"}
+
+test intexpr-1.6 {string repeat - no subst dictvar} -body {
+	set b(3) 4
+	string repeat a {$b(4)}
+} -returnCodes error -result {expected integer expression but got "$b(4)"}
+
+test intexpr-1.7 {string repeat - no subst dictvar} -body {
+	set b(3) 4
+	string repeat a {$b(4)+2}
+} -returnCodes error -result {expected integer expression but got "$b(4)+2"}
+
+set str abcdefghi
+test intexpr-2.1 {string index} {
+	string index $str 2+1
+} {d}
+
+test intexpr-2.2 {string index} {
+	string index $str 2-1
+} {b}
+
+test intexpr-2.3 {string index} {
+	string index $str 2*3
+} {g}
+
+test intexpr-2.4 {string index - function calls} {
+	string index $str int(abs(-2))
+} {c}
+
+test intexpr-2.4 {string index - expanded var} {
+	set n 3
+	string index $str $n+1
+} {e}
+
+test intexpr-2.5 {string index - no subst var} -body {
+	set n 3
+	string index $str {$n+1}
+} -returnCodes error -result {bad index "$n+1": must be intexpr or end?[+-]intexpr?}
+
+test intexpr-2.6 {string index - no subst cmd} -body {
+	string index $str {[string length xy]+1}
+} -returnCodes error -result {bad index "[string length xy]+1": must be intexpr or end?[+-]intexpr?}
+
+test intexpr-2.6 {string index - no subst dictvar} -body {
+	set b(3) 4
+	string index $str {$b(4)}
+} -returnCodes error -result {bad index "$b(4)": must be intexpr or end?[+-]intexpr?}
+
+test intexpr-2.7 {string index - no subst dictvar} -body {
+	set b(3) 4
+	string index $str {$b(4)+2}
+} -returnCodes error -result {bad index "$b(4)+2": must be intexpr or end?[+-]intexpr?}
+
+test intexpr-3.1 {string index} {
+	string index $str end-2+1
+} {h}
+
+test intexpr-3.2 {string index} {
+	string index $str end-2-1
+} {f}
+
+test intexpr-3.3 {string index} {
+	string index $str end-2*3
+} {c}
+
+test intexpr-3.4 {string index - function calls} {
+	string index $str end+int(-2)
+} {g}
+
+test intexpr-3.4 {string index - expanded var} {
+	set n 3
+	string index $str end-($n+1)
+} {e}
+
+test intexpr-3.5 {string index - no subst var} -body {
+	set n 3
+	string index $str {end-($n+1)}
+} -returnCodes error -result {bad index "end-($n+1)": must be intexpr or end?[+-]intexpr?}
+
+test intexpr-3.6 {string index - no subst cmd} -body {
+	string index $str {end-[string length xy]+1}
+} -returnCodes error -result {bad index "end-[string length xy]+1": must be intexpr or end?[+-]intexpr?}
+
+test intexpr-3.6 {string index - no subst dictvar} -body {
+	set b(3) 4
+	string index $str {end-$b(4)}
+} -returnCodes error -result {bad index "end-$b(4)": must be intexpr or end?[+-]intexpr?}
+
+test intexpr-3.7 {string index - no subst dictvar} -body {
+	set b(3) -4
+	string index $str {end+$b(4)-2}
+} -returnCodes error -result {bad index "end+$b(4)-2": must be intexpr or end?[+-]intexpr?}
+
+testreport

--- a/tests/jim.test
+++ b/tests/jim.test
@@ -371,7 +371,7 @@ test lset-4.2 {lset, not compiled, 3 args, bad index} {
     list [catch {
 	eval [list $lset a [list 2a2] w]
     } msg] $msg
-} {1 {bad index "2a2": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "2a2": must be intexpr or end?[+-]intexpr?}}
 
 test lset-4.3 {lset, not compiled, 3 args, index out of range} {
     set a {x y z}
@@ -406,7 +406,7 @@ test lset-4.8 {lset, not compiled, 3 args, bad index} {
     list [catch {
 	eval [list $lset a 2a2 w]
     } msg] $msg
-} {1 {bad index "2a2": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "2a2": must be intexpr or end?[+-]intexpr?}}
 
 test lset-4.9 {lset, not compiled, 3 args, index out of range} {
     set a {x y z}
@@ -542,7 +542,7 @@ test lset-7.10 {lset, not compiled, data sharing} {
 test lset-8.3 {lset, not compiled, bad second index} {
     set a {{b c} {d e}}
     list [catch {eval [list $lset a 0 2a2 f]} msg] $msg
-} {1 {bad index "2a2": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "2a2": must be intexpr or end?[+-]intexpr?}}
 
 test lset-8.5 {lset, not compiled, second index out of range} {
     set a {{b c} {d e} {f g}}
@@ -1555,7 +1555,7 @@ test lindex-2.2 {singleton index list} {
 test lindex-2.4 {malformed index list} {
     set x \{
     list [catch { eval [list $lindex {a b c} $x] } result] $result
-} {1 bad\ index\ \"\{\":\ must\ be\ integer?\[+-\]integer?\ or\ end?\[+-\]integer?}
+} {1 bad\ index\ \"\{\":\ must\ be\ intexpr\ or\ end?\[+-\]intexpr?}
 
 # Indices that are integers or convertible to integers
 
@@ -1614,7 +1614,7 @@ test lindex-4.5 {index = end-3} {
 test lindex-4.8 {bad integer, not octal} {
     set x end-0a2
     list [catch { eval [list $lindex {a b c} $x] } result] $result
-} {1 {bad index "end-0a2": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "end-0a2": must be intexpr or end?[+-]intexpr?}}
 
 #test lindex-4.9 {incomplete end} {
 #    set x en
@@ -1624,11 +1624,11 @@ test lindex-4.8 {bad integer, not octal} {
 test lindex-4.10 {incomplete end-} {
     set x end-
     list [catch { eval [list $lindex {a b c} $x] } result] $result
-} {1 {bad index "end-": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "end-": must be intexpr or end?[+-]intexpr?}}
 
 test lindex-5.1 {bad second index} {
     list [catch { eval [list $lindex {a b c} 0 0a2] } result] $result
-} {1 {bad index "0a2": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "0a2": must be intexpr or end?[+-]intexpr?}}
 
 test lindex-5.2 {good second index} {
     eval [list $lindex {{a b c} {d e f} {g h i}} 1 2]
@@ -1678,7 +1678,7 @@ test lindex-10.2 {singleton index list} {
 test lindex-10.4 {malformed index list} {
     set x \{
     list [catch { lindex {a b c} $x } result] $result
-} {1 bad\ index\ \"\{\":\ must\ be\ integer?\[+-\]integer?\ or\ end?\[+-\]integer?}
+} {1 bad\ index\ \"\{\":\ must\ be\ intexpr\ or\ end?\[+-\]intexpr?}
 
 # Indices that are integers or convertible to integers
 
@@ -1758,16 +1758,16 @@ test lindex-12.5 {index = end-3} {
 test lindex-12.8 {bad integer, not octal} {
     set x end-0a2
     list [catch { lindex {a b c} $x } result] $result
-} {1 {bad index "end-0a2": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "end-0a2": must be intexpr or end?[+-]intexpr?}}
 
 test lindex-12.10 {incomplete end-} {
     set x end-
     list [catch { lindex {a b c} $x } result] $result
-} {1 {bad index "end-": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "end-": must be intexpr or end?[+-]intexpr?}}
 
 test lindex-13.1 {bad second index} {
     list [catch { lindex {a b c} 0 0a2 } result] $result
-} {1 {bad index "0a2": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "0a2": must be intexpr or end?[+-]intexpr?}}
 
 test lindex-13.2 {good second index} {
     catch {
@@ -2050,7 +2050,7 @@ test string-7.1 {string last, too few args} {
 } {1 {wrong # args: should be "string last subString string ?index?"}}
 test string-7.2 {string last, bad args} {
     list [catch {string last a b c} msg] $msg
-} {1 {bad index "c": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "c": must be intexpr or end?[+-]intexpr?}}
 test string-7.3 {string last, too many args} {
     list [catch {string last a b c d} msg] $msg
 } {1 {wrong # args: should be "string last subString string ?index?"}}

--- a/tests/jim.test
+++ b/tests/jim.test
@@ -1269,11 +1269,10 @@ test incr-1.23 {TclCompileIncrCmd: increment given, formatted int != int} {
     set i 25
     incr i 000012345     ;# a decimal literal
 } 12370
-test incr-1.24 {TclCompileIncrCmd: increment given, formatted int != int} {
+test incr-1.24 {TclCompileIncrCmd: increment given, formatted int != int} -body {
     set i 25
-    catch {incr i 1a} msg
-    set msg
-} {expected integer but got "1a"}
+    incr i 1a
+} -returnCodes error -match glob -result {expected integer *but got "1a"}
 
 test incr-1.25 {TclCompileIncrCmd: too many arguments} {
     set i 10
@@ -1282,10 +1281,10 @@ test incr-1.25 {TclCompileIncrCmd: too many arguments} {
 } {wrong # args: should be "incr varName ?increment?"}
 
 
-test incr-1.29 {TclCompileIncrCmd: runtime error, bad variable value} {
+test incr-1.29 {TclCompileIncrCmd: runtime error, bad variable value} -body {
     set x "  -  "
-    list [catch {incr x 1} msg] $msg
-} {1 {expected integer but got "  -  "}}
+    incr x 1
+} -returnCodes error -match glob -result {expected integer *but got "  -  "}
 
 test incr-1.30 {TclCompileIncrCmd: array var, braced (no subs)} {
     catch {unset array}
@@ -1488,12 +1487,11 @@ test incr-2.23 {incr command (not compiled): increment given, formatted int != i
     set i 25
     $z i 000012345     ;# an octal literal
 } 12370
-test incr-2.24 {incr command (not compiled): increment given, formatted int != int} {
+test incr-2.24 {incr command (not compiled): increment given, formatted int != int} -body {
     set z incr
     set i 25
-    catch {$z i 1a} msg
-    set msg
-} {expected integer but got "1a"}
+    $z i 1a
+} -returnCodes error -match glob -result {expected integer *but got "1a"}
 
 test incr-2.25 {incr command (not compiled): too many arguments} {
     set z incr
@@ -1502,11 +1500,11 @@ test incr-2.25 {incr command (not compiled): too many arguments} {
     set msg
 } {wrong # args: should be "incr varName ?increment?"}
 
-test incr-2.29 {incr command (not compiled): runtime error, bad variable value} {
+test incr-2.29 {incr command (not compiled): runtime error, bad variable value} -body {
     set z incr
     set x "  -  "
-    list [catch {$z x 1} msg] $msg
-} {1 {expected integer but got "  -  "}}
+    $z x 1
+} -returnCodes error -match glob -result {expected integer *but got "  -  "}
 
 ################################################################################
 # LLENGTH
@@ -3433,15 +3431,15 @@ test range-6.1 {range} -body {
 
 test range-6.2 {range} -body {
     range foo
-} -returnCodes error -result {expected integer but got "foo"}
+} -returnCodes error -match glob -result {expected integer *but got "foo"}
 
 test range-6.3 {range} -body {
     range 2 bar
-} -returnCodes error -result {expected integer but got "bar"}
+} -returnCodes error -match glob -result {expected integer *but got "bar"}
 
 test range-6.4 {range} -body {
     range 2 4 foo
-} -returnCodes error -result {expected integer but got "foo"}
+} -returnCodes error -match glob -result {expected integer *but got "foo"}
 
 test range-6.5 {range} -body {
     range 10 0

--- a/tests/linsert.test
+++ b/tests/linsert.test
@@ -82,10 +82,10 @@ test linsert-2.1 {linsert errors} {
 } {1 {wrong # args: should be "linsert list index ?element ...?"}}
 test linsert-2.2 {linsert errors} {
     list [catch {linsert a b} msg] $msg
-} {1 {bad index "b": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "b": must be intexpr or end?[+-]intexpr?}}
 test linsert-2.3 {linsert errors} {
     list [catch {linsert a 12x 2} msg] $msg
-} {1 {bad index "12x": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "12x": must be intexpr or end?[+-]intexpr?}}
 test linsert-2.4 {linsert errors} tcl {
     list [catch {linsert \{ 12 2} msg] $msg
 } {1 {unmatched open brace in list}}

--- a/tests/lrange.test
+++ b/tests/lrange.test
@@ -69,10 +69,10 @@ test lrange-2.2 {error conditions} {
 } {1 {wrong # args: should be "lrange list first last"}}
 test lrange-2.3 {error conditions} {
     list [catch {lrange a b 6} msg] $msg
-} {1 {bad index "b": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "b": must be intexpr or end?[+-]intexpr?}}
 test lrange-2.4 {error conditions} {
     list [catch {lrange a 0 enigma} msg] $msg
-} {1 {bad index "enigma": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "enigma": must be intexpr or end?[+-]intexpr?}}
 test lrange-2.5 {error conditions} tcl {
     list [catch {lrange "a \{b c" 3 4} msg] $msg
 } {1 {unmatched open brace in list}}

--- a/tests/lreplace.test
+++ b/tests/lreplace.test
@@ -116,13 +116,13 @@ test lreplace-2.2 {lreplace errors} {
 } {1 {wrong # args: should be "lreplace list first last ?element ...?"}}
 test lreplace-2.3 {lreplace errors} {
     list [catch {lreplace x a 10} msg] $msg
-} {1 {bad index "a": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "a": must be intexpr or end?[+-]intexpr?}}
 test lreplace-2.4 {lreplace errors} {
     list [catch {lreplace x 10 x} msg] $msg
-} {1 {bad index "x": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "x": must be intexpr or end?[+-]intexpr?}}
 test lreplace-2.5 {lreplace errors} {
     list [catch {lreplace x 10 1x} msg] $msg
-} {1 {bad index "1x": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "1x": must be intexpr or end?[+-]intexpr?}}
 test lreplace-2.6 {lreplace errors} {
     list [catch {lreplace x 3 2} msg] $msg
 } {0 x}

--- a/tests/lsort.test
+++ b/tests/lsort.test
@@ -51,7 +51,7 @@ test lsort-1.11 {Tcl_LsortObjCmd procedure, -index option} {
 } {1 {"-index" option must be followed by list index}}
 test lsort-1.12 {Tcl_LsortObjCmd procedure, -index option} {
     list [catch {lsort -index foo {1 3 2 5}} msg] $msg
-} {1 {bad index "foo": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "foo": must be intexpr or end?[+-]intexpr?}}
 test lsort-1.13 {Tcl_LsortObjCmd procedure, -index option} {
     lsort -index end -integer {{2 25} {10 20 50 100} {3 16 42} 1}
 } {1 {2 25} {3 16 42} {10 20 50 100}}

--- a/tests/pack.test
+++ b/tests/pack.test
@@ -12,7 +12,7 @@ test pack-1.2 {pack invalid type} -body {
 
 test pack-1.3 {pack bad width} -body {
 	pack a 1 -intbe badint
-} -returnCodes error -result {expected integer but got "badint"}
+} -returnCodes error -match glob -result {expected integer *but got "badint"}
 
 test pack-1.4 {pack bad width} -body {
 	pack a 1 -intbe -5
@@ -20,7 +20,7 @@ test pack-1.4 {pack bad width} -body {
 
 test pack-1.5 {pack bad offset} -body {
 	pack a 1 -intbe 5 badint
-} -returnCodes error -result {expected integer but got "badint"}
+} -returnCodes error -match glob -result {expected integer *but got "badint"}
 
 test pack-1.6 {pack bad offset} -body {
 	pack a 1 -intbe 5 -6
@@ -78,7 +78,7 @@ test unpack-1.2 {unpack invalid type} -body {
 
 test unpack-1.3 {unpack bad width} -body {
 	unpack abc -intle 0 badint
-} -returnCodes error -result {expected integer but got "badint"}
+} -returnCodes error -match glob -result {expected integer *but got "badint"}
 
 test unpack-1.4 {unpack bad width} -body {
 	unpack abc -intle 0 -5
@@ -86,7 +86,7 @@ test unpack-1.4 {unpack bad width} -body {
 
 test unpack-1.5 {unpack bad offset} -body {
 	unpack abc -intle badint 8
-} -returnCodes error -result {expected integer but got "badint"}
+} -returnCodes error -match glob -result {expected integer *but got "badint"}
 
 test unpack-1.6 {unpack bad offset} -body {
 	unpack abc -intle -6 8

--- a/tests/regexp.test
+++ b/tests/regexp.test
@@ -221,7 +221,7 @@ test regexp-6.8 {regexp errors} jim {
 } {1 {can't set "f1(f2)": variable isn't array}}
 test regexp-6.9 {regexp errors, -start bad int check} {
     list [catch {regexp -start bogus {^$} {}} msg] $msg
-} {1 {bad index "bogus": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "bogus": must be intexpr or end?[+-]intexpr?}}
 test regexp-6.10 {regexp errors, -start too few args} {
     list [catch {regexp -all -start} msg] $msg
 } {1 {wrong # args: should be "regexp ?-switch ...? exp string ?matchVar? ?subMatchVar ...?"}}
@@ -378,7 +378,7 @@ test regexp-11.7 {regsub errors} jim {
 } {1 {can't set "f1(f2)": variable isn't array}}
 test regexp-11.8 {regsub errors, -start bad int check} {
     list [catch {regsub -start bogus pattern string rep var} msg] $msg
-} {1 {bad index "bogus": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "bogus": must be intexpr or end?[+-]intexpr?}}
 test regexp-11.9 {regsub without final variable name returns value} {
     regsub b abaca X
 } {aXaca}

--- a/tests/regexp2.test
+++ b/tests/regexp2.test
@@ -287,7 +287,7 @@ test regexpComp-6.9 {regexp errors, -start bad int check} {
     evalInProc {
 	list [catch {regexp -start bogus {^$} {}} msg] $msg
     }
-} {1 {bad index "bogus": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "bogus": must be intexpr or end?[+-]intexpr?}}
 
 test regexpComp-7.1 {basic regsub operation} {
     evalInProc {
@@ -545,7 +545,7 @@ test regexpComp-11.8 {regsub errors, -start bad int check} {
     evalInProc {
 	list [catch {regsub -start bogus pattern string rep var} msg] $msg
     }
-} {1 {bad index "bogus": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "bogus": must be intexpr or end?[+-]intexpr?}}
 
 # This test crashes on the Mac unless you increase the Stack Space to about 1
 # Meg.  This is probably bigger than most users want... 

--- a/tests/string.test
+++ b/tests/string.test
@@ -837,10 +837,10 @@ test string-14.12 {string replace} {
 } {}
 test string-14.13 {string replace} {
     list [catch {string replace abc abc 1} msg] $msg
-} {1 {bad index "abc": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "abc": must be intexpr or end?[+-]intexpr?}}
 test string-14.14 {string replace} {
     list [catch {string replace abc 1 eof} msg] $msg
-} {1 {bad index "eof": must be integer?[+-]integer? or end?[+-]integer?}}
+} {1 {bad index "eof": must be intexpr or end?[+-]intexpr?}}
 test string-14.15 {string replace} {
     string replace abcdefghijklmnop end-10 end-2 NEW
 } {abcdeNEWop}
@@ -1029,6 +1029,6 @@ test string-24.12 {string byterange, full range} {
 } abcdef
 test string-24.13 {string byterange, invalid range} -body {
     string byterange abcdef foo bar
-} -returnCodes error -result {bad index "foo": must be integer?[+-]integer? or end?[+-]integer?}
+} -returnCodes error -result {bad index "foo": must be intexpr or end?[+-]intexpr?}
 
 testreport


### PR DESCRIPTION
For convenience, many commands now accept integer expressions
rather than only simple integers.

These are:

    loop, range, incr, string repeat, lrepeat, pack, unpack, rand

This simplifies many cases where previously expr {} or $() was required.
e.g.

    foreach i [range 4+1 2*$b] { ... }
    string repeat 2**$n a

Signed-off-by: Steve Bennett <steveb@workware.net.au>