### PR TITLE
expr: TIP 526, only support a single arg

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -13388,26 +13388,11 @@ static int Jim_UplevelCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
 /* [expr] */
 static int Jim_ExprCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    int retcode;
-
     if (argc == 2) {
-        retcode = Jim_EvalExpression(interp, argv[1]);
+        return Jim_EvalExpression(interp, argv[1]);
     }
-    else if (argc > 2) {
-        Jim_Obj *objPtr;
-
-        objPtr = Jim_ConcatObj(interp, argc - 1, argv + 1);
-        Jim_IncrRefCount(objPtr);
-        retcode = Jim_EvalExpression(interp, objPtr);
-        Jim_DecrRefCount(interp, objPtr);
-    }
-    else {
-        Jim_WrongNumArgs(interp, 1, argv, "expression ?...?");
-        return JIM_ERR;
-    }
-    if (retcode != JIM_OK)
-        return retcode;
-    return JIM_OK;
+    Jim_WrongNumArgs(interp, 1, argv, "expression");
+    return JIM_ERR;
 }
 
 /* [break] */

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -59,6 +59,7 @@ Changes since 0.80
    `loop`, `range`, `incr`, `string repeat`, `lrepeat`, `pack`, `unpack`, `rand`
 3. String and list indexes now accept integer expressions (<<_string_and_list_index_specifications,STRING AND LIST INDEX SPECIFICATIONS>>)
 4. `loop` can now omit start value
+5. TIP 526, `expr` now only allows a single argument
 
 Changes between 0.79 and 0.80
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/expr-new.test
+++ b/tests/expr-new.test
@@ -70,10 +70,10 @@ test expr-1.2 {TclCompileExprCmd: one expression word} {
     expr -25
 } -25
 test expr-1.3 {TclCompileExprCmd: two expression words} {
-    expr -8.2   -6
+    expr {-8.2   -6}
 } -14.2
 test expr-1.4 {TclCompileExprCmd: five expression words} {
-    expr 20 - 5 +10 -7
+    expr {20 - 5 +10 -7}
 } 18
 test expr-1.5 {TclCompileExprCmd: quoted expression word} {
     expr "0005"
@@ -111,7 +111,7 @@ test expr-1.13 {TclCompileExprCmd: second level of substitutions in expr not in 
 } foo
 test expr-1.14 {TclCompileExprCmd: second level of substitutions in expr with comparison as top-level operator} {
     set a xxx
-    set x 2;  set b {$x};  set a [expr $b == 2]
+    set x 2;  set b {$x};  set a [expr "$b == 2"]
     set a
 } 1
 

--- a/tests/expr-old.test
+++ b/tests/expr-old.test
@@ -128,7 +128,7 @@ test expr-old-2.35 {floating-point operators} {expr 3.3||0.0} 1
 test expr-old-2.36 {floating-point operators} {expr 3.3>2.3?44.3:66.3} 44.3
 test expr-old-2.37 {floating-point operators} {expr 2.3>3.3?44.3:66.3} 66.3
 test expr-old-2.38 {floating-point operators} {
-    list [catch {expr 028.1 + 09.2} msg] $msg
+    list [catch {expr {028.1 + 09.2}} msg] $msg
 } {0 37.3}
 
 # Operators that aren't legal on floating-point numbers
@@ -553,7 +553,7 @@ test expr-old-30.2 {long values} {
 # Expressions spanning multiple arguments
 
 test expr-old-31.1 {multiple arguments to expr command} {
-    expr 4 + ( 6 *12) -3
+    expr {4 + ( 6 *12) -3}
 } 73
 test expr-old-31.2 {multiple arguments to expr command} {
     list [catch {expr 2 + (3 + 4} msg]
@@ -577,7 +577,7 @@ test expr-old-32.3 {math functions in expressions} mathfunc {
     format %.6g [expr atan(1.0)]
 } {0.785398}
 test expr-old-32.4 {math functions in expressions} mathfunc {
-    format %.6g [expr atan2(2.0, 2.0)]
+    format %.6g [expr {atan2(2.0, 2.0)}]
 } {0.785398}
 test expr-old-32.5 {math functions in expressions} mathfunc {
     format %.6g [expr ceil(1.999)]
@@ -598,10 +598,10 @@ test expr-old-32.10 {math functions in expressions} mathfunc {
     format %.6g [expr floor(2.001)]
 } {2}
 test expr-old-32.11 {math functions in expressions} expr_fmod {
-    format %.6g [expr fmod(7.3, 3.2)]
+    format %.6g [expr {fmod(7.3, 3.2)}]
 } {0.9}
 test expr-old-32.12 {math functions in expressions} expr_hypot {
-    format %.6g [expr hypot(3.0, 4.0)]
+    format %.6g [expr {hypot(3.0, 4.0)}]
 } {5}
 test expr-old-32.13 {math functions in expressions} mathfunc {
     format %.6g [expr log(2.8)]
@@ -610,7 +610,7 @@ test expr-old-32.14 {math functions in expressions} mathfunc {
     format %.6g [expr log10(2.8)]
 } {0.447158}
 test expr-old-32.15 {math functions in expressions} mathfunc {
-    format %.6g [expr pow(2.1, 3.1)]
+    format %.6g [expr {pow(2.1, 3.1)}]
 } {9.97424}
 test expr-old-32.16 {math functions in expressions} mathfunc {
     format %.6g [expr sin(.1)]
@@ -692,7 +692,7 @@ test expr-old-32.38 {math functions in expressions} {
 #    list [catch {expr round(-1e60)} msg] $msg
 #} {1 {integer value too large to represent}}
 test expr-old-32.41 {math functions in expressions} mathfunc {
-    list [catch {expr pow(1.0 + 3.0 - 2, .8 * 5)} msg] $msg
+    list [catch {expr {pow(1.0 + 3.0 - 2, .8 * 5)}} msg] $msg
 } {0 16.0}
 if {1} {
 test expr-old-32.42 {math functions in expressions} expr_hypot {
@@ -702,7 +702,7 @@ test expr-old-32.43 {math functions in expressions} mathfunc {
     expr {pow(1.0 + 3.0, -2)}
 } {0.0625}
 test expr-old-32.45 {math functions in expressions} {
-    expr (0 <= rand()) && (rand() < 1)
+    expr {(0 <= rand()) && (rand() < 1)}
 } {1}
 test expr-old-32.46 {math functions in expressions} -body {
     expr rand(24)
@@ -719,7 +719,7 @@ test expr-old-32.49 {math functions in expressions} -body {
 } -returnCodes error -match glob -result *
 test expr-old-32.50 {math functions in expressions} mathfunc {
     for {set i 0} {$i < 10} {incr i} {
-	lappend result [expr round(sin($i) * 1000)]
+	lappend result [expr {round(sin($i) * 1000)}]
     }
     set result
 } {0 841 909 141 -757 -959 -279 657 989 412}
@@ -728,13 +728,13 @@ test expr-old-32.51 {math functions in expressions} -body {
 } -returnCodes error -match glob -result *
 
 test expr-old-33.1 {conversions and fancy args to math functions} expr_hypot {
-    expr hypot ( 3 , 4 )
+    expr {hypot ( 3 , 4 )}
 } 5.0
 test expr-old-33.2 {conversions and fancy args to math functions} expr_hypot {
-    expr hypot ( (2.0+1.0) , 4 )
+    expr {hypot ( (2.0+1.0) , 4 )}
 } 5.0
 test expr-old-33.3 {conversions and fancy args to math functions} expr_hypot {
-    expr hypot ( 3 , (3.0 + 1.0) )
+    expr {hypot ( 3 , (3.0 + 1.0) )}
 } 5.0
 test expr-old-33.4 {conversions and fancy args to math functions} mathfunc {
     format %.6g [expr cos(acos(0.1))]

--- a/tests/expr.test
+++ b/tests/expr.test
@@ -11,7 +11,7 @@ test expr-1.2 "Compare strings with embedded nulls" {
 } {1}
 
 test expr-1.3 "Hex values" {
-	set mask1 [expr 0x4050 & 0x0CCC]
+	set mask1 [expr {0x4050 & 0x0CCC}]
 } {64}
 
 test expr-1.4 "Ternary operator - true" {

--- a/tests/format.test
+++ b/tests/format.test
@@ -419,7 +419,7 @@ test format-13.1 {tcl_precision fuzzy comparison} {
     set a 0.0000000000001
     set b 0.00000000000001
     set c 0.00000000000000001
-    set d [expr $a + $b + $c]
+    set d [expr {$a + $b + $c}]
     format {%0.10f %0.12f %0.15f %0.17f} $d $d $d $d
 } {0.0000000000 0.000000000000 0.000000000000110 0.00000000000011001}
 test format-13.2 {tcl_precision fuzzy comparison} {
@@ -430,7 +430,7 @@ test format-13.2 {tcl_precision fuzzy comparison} {
     set a 0.000000000001
     set b 0.000000000000005
     set c 0.0000000000000008
-    set d [expr $a + $b + $c]
+    set d [expr {$a + $b + $c}]
     format {%0.10f %0.12f %0.15f %0.17f} $d $d $d $d
 } {0.0000000000 0.000000000001 0.000000000001006 0.00000000000100580}
 test format-13.3 {tcl_precision fuzzy comparison} {
@@ -439,7 +439,7 @@ test format-13.3 {tcl_precision fuzzy comparison} {
     catch {unset c}
     set a 0.00000000000099
     set b 0.000000000000011
-    set c [expr $a + $b]
+    set c [expr {$a + $b}]
     format {%0.10f %0.12f %0.15f %0.17f} $c $c $c $c
 } {0.0000000000 0.000000000001 0.000000000001001 0.00000000000100100}
 test format-13.4 {tcl_precision fuzzy comparison} {
@@ -448,7 +448,7 @@ test format-13.4 {tcl_precision fuzzy comparison} {
     catch {unset c}
     set a 0.444444444444
     set b 0.33333333333333
-    set c [expr $a + $b]
+    set c [expr {$a + $b}]
     format {%0.10f %0.12f %0.15f %0.16f} $c $c $c $c
 } {0.7777777778 0.777777777777 0.777777777777330 0.7777777777773300}
 test format-13.5 {tcl_precision fuzzy comparison} {
@@ -457,7 +457,7 @@ test format-13.5 {tcl_precision fuzzy comparison} {
     catch {unset c}
     set a 0.444444444444
     set b 0.99999999999999
-    set c [expr $a + $b]
+    set c [expr {$a + $b}]
     format {%0.10f %0.12f %0.15f} $c $c $c
 } {1.4444444444 1.444444444444 1.444444444443990}
 test format-14.1 {testing MAX_FLOAT_SIZE for 0 and 1} {
@@ -486,7 +486,7 @@ for {set i 0} {$i < 290} {incr i} {
     append b $a
 }
 for {set i 290} {$i < 400} {incr i} {
-    test format-15.[expr $i -290] {testing MAX_FLOAT_SIZE} {
+    test format-15.[expr {$i -290}] {testing MAX_FLOAT_SIZE} {
         format {%s} $b    
     } $b
     append b "x"

--- a/tests/jim.test
+++ b/tests/jim.test
@@ -1976,7 +1976,7 @@ test foreach-6.1 {noncompiled foreach and shared variable or value list objects 
   catch {unset x}
   foreach {12.0} {a b c} {
     set x 12.0  
-    set x [expr $x + 1]
+    set x [expr {$x + 1}]
   }
   set x
 } 13.0

--- a/tests/list.test
+++ b/tests/list.test
@@ -83,9 +83,9 @@ concat {}
 
 proc slowsort list {
     set result {}
-    set last [expr [llength $list] - 1]
+    set last [expr {[llength $list] - 1}]
     while {$last > 0} {
-	set minIndex [expr [llength $list] - 1]
+	set minIndex [expr {[llength $list] - 1}]
 	set min [lindex $list $last]
 	set i [expr $minIndex-1]
 	while {$i >= 0} {


### PR DESCRIPTION
Avoid unexpected issues by concatenating multiple arguments.
This does create an incompatibility with early versions, but
it is generally trivial to convert existing code that to one of two forms:

1. expr {$a + $b}    -- usually correct
2. expr "$a + $b"    -- usually incorrect

Signed-off-by: Steve Bennett <steveb@workware.net.au>