### PR TITLE
lsearch, lsort: support for -stride and -index

### DIFF
--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -61,6 +61,9 @@ Changes since 0.80
 4. `loop` can now omit the start value
 5. Add the `xtrace` command for execution trace support
 6. Add `history keep`
+7. Add support for `lsearch -index` and `lsearch -stride`, the latter per TIP 351
+8. `lsort -index` now supports multiple indices
+9. Add support for `lsort -stride`
 
 Changes between 0.79 and 0.80
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3371,35 +3374,80 @@ the list are to be matched against pattern and must have one of the values below
 +*-nocase*+::
     Causes comparisons to be handled in a case-insensitive manner.
 
++*-index* 'indexList'+::
+    This option is designed for use when searching within nested lists. The
+    'indexList' gives a path of indices (much as might be used with
+    the lindex or lset commands) within each element to allow the location
+    of the term being matched against.
+
++*-stride* 'strideLength'+::
+    If this option is specified, the list is treated as consisting of
+    groups of 'strideLength' elements and the groups are searched by
+    either their first element or, if the +-index+ option is used,
+    by the element within each group given by the first index passed to
+    +-index+ (which is then ignored by +-index+). The resulting
+    index always points to the first element in a group.
+ ::
+    The list length must be an integer multiple of 'strideLength', which
+    in turn must be at least 1. A 'strideLength' of 1 is the default and
+    indicates no grouping.
+
 lsort
 ~~~~~
-+*lsort* ?*-index* 'listindex'? ?*-nocase|-integer|-real|-command* 'cmdname'? ?*-unique*? ?*-decreasing*|*-increasing*? 'list'+
++*lsort* '?options? list'+
 
 Sort the elements of +'list'+, returning a new list in sorted order.
 By default, ASCII (or UTF-8) sorting is used, with the result in increasing order.
 
-If +-nocase+ is specified, comparisons are case-insensitive.
+Note that only one sort type may be selected with +-integer+, +-real+, +-nocase+ or +-command+
+with last option being used.
 
-If +-integer+ is specified, numeric sorting is used.
++*-integer*+::
+    Sort using numeric (integer) comparison.
 
-If +-real+ is specified, floating point number sorting is used.
++*-real*+::
+    Sort using floating point comparison.
 
-If +-command 'cmdname'+ is specified, +'cmdname'+ is treated as a command
-name. For each comparison, +'cmdname $value1 $value2+' is called which
-should compare the values and return an integer less than, equal
-to, or greater than zero if the +'$value1'+ is to be considered less
-than, equal to, or greater than +'$value2'+, respectively.
++*-nocase*+::
+    Sort using using string comparison without regard for case.
 
-If +-decreasing+ is specified, the resulting list is in the opposite
-order to what it would be otherwise. +-increasing+ is the default.
++*-command* 'cmdname'+::
+    +'cmdname'+ is treated as a command name. For each comparison,
+    +'cmdname $value1 $value2+' is called which
+    should compare the values and return an integer less than, equal
+    to, or greater than zero if the +'$value1'+ is to be considered less
+    than, equal to, or greater than +'$value2'+, respectively.
 
-If +-unique+ is specified, then only the last set of duplicate elements found in the list will be retained.
-Note that duplicates are determined relative to the comparison used in the sort. Thus if +-index 0+ is used,
-+{1 a}+ and +{1 b}+ would be considered duplicates and only the second element, +{1 b}+, would be retained.
++*-increasing*+::
+    The resulting list is in ascending order, from smallest/lowest to largest/highest.
+    This is the default and does not need to be specified.
 
-If +-index 'listindex'+ is specified, each element of the list is treated as a list and
-the given index is extracted from the list for comparison. The list index may
-be any valid list index, such as +1+, +end+ or +end-2+.
++*-decreasing*+::
+    The resulting list is in the opposite order to what it would be otherwise.
+
++*-unique*+::
+    Only the last set of duplicate elements found in the list will
+    be retained.  Note that duplicates are determined relative to the
+    comparison used in the sort. Thus if +-index 0+ is used, +{1 a}+ and
+    +{1 b}+ would be considered duplicates and only the second element,
+    +{1 b}+, would be retained.
+
++*-index* 'indexList'+::
+    This option is designed for use when sorting nested lists. The
+    'indexList' gives a path of indices (much as might be used with
+    the lindex or lset commands) within each element to specify the
+    value to be used for comparison.
+
++*-stride* 'strideLength'+::
+    If this option is specified, the list is treated as consisting of
+    groups of 'strideLength' elements and the groups are sorted by
+    either their first element or, if the +-index+ option is used,
+    by the element within each group given by the first index passed to
+    +-index+ (which is then ignored by +-index+). The resulting list
+    is once again a flat list.
+ ::
+    The list length must be an integer multiple of 'strideLength', which
+    in turn must be at least 2.
 
 defer
 ~~~~~

--- a/tests/lsearch.test
+++ b/tests/lsearch.test
@@ -187,4 +187,117 @@ test lsearch-6.10 {lsearch -not -bool -all -nocase} jim {
     lsearch -not -bool -glob -all -nocase {a1 a2 b1 b2 a3 b3} B*
 } {1 1 0 0 1 0}
 
+test lsearch-17.1 {lsearch -index option, basic functionality} {
+    lsearch -index 1 {{a c} {a b} {a a}} a
+} 2
+test lsearch-17.2 {lsearch -index option, basic functionality} {
+    lsearch -index 1 -exact {{a c} {a b} {a a}} a
+} 2
+test lsearch-17.3 {lsearch -index option, basic functionality} {
+    lsearch -index 1 -glob {{ab cb} {ab bb} {ab ab}} b*
+} 1
+test lsearch-17.4 {lsearch -index option, basic functionality} {
+    lsearch -index 1 -regexp {{ab cb} {ab bb} {ab ab}} {[cb]b}
+} 0
+test lsearch-17.5 {lsearch -index option, basic functionality} {
+    lsearch -all -index 0 -exact {{a c} {a b} {d a}} a
+} {0 1}
+test lsearch-17.6 {lsearch -index option, basic functionality} {
+    lsearch -all -index 1 -glob {{ab cb} {ab bb} {db bx}} b*
+} {1 2}
+test lsearch-17.7 {lsearch -index option, basic functionality} {
+    lsearch -all -index 1 -regexp {{ab cb} {ab bb} {ab ab}} {[cb]b}
+} {0 1}
+test lsearch-17.8 {lsearch -index option, empty argument} {
+    lsearch -index {} a a
+} 0
+test lsearch-17.9 {lsearch -index option, empty argument} {
+    lsearch -index {} a a
+} [lsearch a a]
+test lsearch-17.10 {lsearch -index option, empty argument} {
+    lsearch -index {} [list \{] \{
+} 0
+test lsearch-17.11 {lsearch -index option, empty argument} {
+    lsearch -index {} [list \{] \{
+} [lsearch [list \{] \{]
+test lsearch-17.12 {lsearch -index option, encoding aliasing} -body {
+    lsearch -index -2 a a
+} -returnCodes error -result {index "-2" out of range}
+test lsearch-17.13 {lsearch -index option, encoding aliasing} -body {
+    lsearch -index -1-1 a a
+} -returnCodes error -result {index "-1-1" out of range}
+test lsearch-17.14 {lsearch -index option, encoding aliasing} -body {
+    lsearch -index end--1 a a
+} -returnCodes error -result {index "end--1" out of range}
+test lsearch-17.15 {lsearch -index option, encoding aliasing} -body {
+    lsearch -index end+1 a a
+} -returnCodes error -result {index "end+1" out of range}
+test lsearch-17.16 {lsearch -index option, encoding aliasing} -body {
+    lsearch -index end+2 a a
+} -returnCodes error -result {index "end+2" out of range}
+
+test lsearch-20.1 {lsearch -index option, index larger than sublists} -body {
+    lsearch -index 2 {{a c} {a b} {a a}} a
+} -returnCodes error -result {element 2 missing from sublist "a c"}
+test lsearch-20.2 {lsearch -index option, malformed index} -body {
+    lsearch -index foo {{a c} {a b} {a a}} a
+} -returnCodes error -match glob -result {bad index *}
+
+test lsearch-23.1 {lsearch -stride option, errors} -body {
+    lsearch -stride {a b} a
+} -returnCodes error -match glob -result {*}
+test lsearch-23.2 {lsearch -stride option, errors} -body {
+    lsearch -stride 0 {a b} a
+} -returnCodes error -result {stride length must be at least 1}
+test lsearch-23.3 {lsearch -stride option, errors} -body {
+    lsearch -stride 2 {a b c} a
+} -returnCodes error -result {list size must be a multiple of the stride length}
+test lsearch-23.4 {lsearch -stride option, errors} -body {
+    lsearch -stride 5 {a b c} a
+} -returnCodes error -result {list size must be a multiple of the stride length}
+test lsearch-23.5 {lsearch -stride option, errors} -body {
+    # Stride equal to length is ok
+    lsearch -stride 3 {a b c} a
+} -result 0
+
+test lsearch-24.1 {lsearch -stride option} -body {
+    lsearch -stride 2 {a b c d e f g h} d
+} -result -1
+test lsearch-24.2 {lsearch -stride option} -body {
+    lsearch -stride 2 {a b c d e f g h} e
+} -result 4
+test lsearch-24.3 {lsearch -stride option} -body {
+    lsearch -stride 3 {a b c d e f g h i} e
+} -result -1
+test lsearch-24.4 {lsearch -stride option} -body {
+    # Result points first in group
+    lsearch -stride 3 -index 1 {a b c d e f g h i} e
+} -result 3
+test lsearch-24.5 {lsearch -stride option} -body {
+    lsearch -inline -stride 2 {a b c d e f g h} d
+} -result {}
+test lsearch-24.6 {lsearch -stride option} -body {
+    # Inline result is a "single element" strided list
+    lsearch -inline -stride 2 {a b c d e f g h} e
+} -result "e f"
+test lsearch-24.7 {lsearch -stride option} -body {
+    lsearch -inline -stride 3 {a b c d e f g h i} e
+} -result {}
+test lsearch-24.8 {lsearch -stride option} -body {
+    lsearch -inline -stride 3 -index 1 {a b c d e f g h i} e
+} -result "d e f"
+test lsearch-24.9 {lsearch -stride option} -body {
+    lsearch -all -inline -stride 3 -index 1 {a b c d e f g e i} e
+} -result "d e f g e i"
+test lsearch-24.10 {lsearch -stride option} -body {
+    lsearch -all -inline -stride 3 -index 0 {a b c d e f a e i} a
+} -result "a b c a e i"
+test lsearch-24.11 {lsearch -stride option} -body {
+    # Stride 1 is same as no stride
+    lsearch -stride 1 {a b c d e f g h} d
+} -result 3
+test lsearch-24.12 {lsearch -stride -index with missing elements} -body {
+    lsearch -stride 1 -index {1 1} {a b c} c
+} -returnCodes error -result {element 1 missing from sublist "a"}
+
 testreport

--- a/tests/lsort.test
+++ b/tests/lsort.test
@@ -17,7 +17,7 @@ test lsort-1.1 {Tcl_LsortObjCmd procedure} jim {
 } {1 {wrong # args: should be "lsort ?options? list"}}
 test lsort-1.2 {Tcl_LsortObjCmd procedure} jim {
     list [catch {lsort -foo {1 3 2 5}} msg] $msg
-} {1 {bad option "-foo": must be -ascii, -command, -decreasing, -increasing, -index, -integer, -nocase, -real, or -unique}}
+} {1 {bad option "-foo": must be -ascii, -command, -decreasing, -increasing, -index, -integer, -nocase, -real, -stride, or -unique}}
 test lsort-1.3 {Tcl_LsortObjCmd procedure, default options} {
     lsort {d e c b a \{ d35 d300}
 } {a b c d d300 d35 e \{}
@@ -131,12 +131,12 @@ test lsort-3.1 {SortCompare procedure, skip comparisons after error} {
 test lsort-3.2 {lsort -real, returning indices} {
     lsort -decreasing -real {1.2 34.5 34.5 5.6}
 } {34.5 34.5 5.6 1.2}
-test lsort-3.3 {SortCompare procedure, -index option} jim {
-    list [catch {lsort -integer -index 2 {{20 10} {15 30 40}}} msg] $msg
-} {1 {list index out of range}}
-test lsort-3.5 {SortCompare procedure, -index option} jim {
-    list [catch {lsort -integer -index 2 {{20 10 13} {15}}} msg] $msg
-} {1 {list index out of range}}
+test lsort-3.3 {SortCompare procedure, -index option} -body {
+    lsort -integer -index 2 {{20 10} {15 30 40}}
+} -returnCodes error -result {element 2 missing from sublist "20 10"}
+test lsort-3.5 {SortCompare procedure, -index option} -body {
+    lsort -integer -index 2 {{20 10 13} {15}}
+} -returnCodes error -result {index "2" out of range}
 test lsort-3.6 {SortCompare procedure, -index option} {
     lsort -integer -index 2 {{1 15 30} {2 5 25} {3 25 20}}
 } {{3 25 20} {2 5 25} {1 15 30}}
@@ -202,12 +202,40 @@ test lsort-3.22 {lsort, unique sort with index} {
 	set vallist
 } {0 4 5}
 
-test lsort-4.26 {DefaultCompare procedure, signed characters} utf8 {
-    lsort [list "abc\u80" "abc"]
-} [list "abc" "abc\u80"]
 
 test lsort-5.1 "Sort case insensitive" {
     lsort -nocase {ba aB aa ce}
 } {aa aB ba ce}
+
+test cmdIL-1.30 {Tcl_LsortObjCmd procedure, -stride option} {
+    lsort -stride 2 {f e d c b a}
+} {b a d c f e}
+test cmdIL-1.31 {Tcl_LsortObjCmd procedure, -stride option} {
+    lsort -stride 3 {f e d c b a}
+} {c b a f e d}
+test cmdIL-1.32 {lsort -stride errors} -returnCodes error -body {
+    lsort -stride foo bar
+} -result {expected integer but got "foo"}
+test cmdIL-1.33 {lsort -stride errors} -returnCodes error -body {
+    lsort -stride 1 bar
+} -result {stride length must be at least 2}
+test cmdIL-1.34 {lsort -stride errors} -returnCodes error -body {
+    lsort -stride 2 {a b c}
+} -result {list size must be a multiple of the stride length}
+test cmdIL-1.35 {lsort -stride errors} -returnCodes error -body {
+    lsort -stride 2 -index 3 {a b c d}
+} -match glob -result {*}
+test cmdIL-1.36 {lsort -stride and -index: Bug 2918962} {
+    lsort -stride 2 -index {0 1} {
+	{{c o d e} 54321} {{b l a h} 94729}
+	{{b i g} 12345} {{d e m o} 34512}
+    }
+} {{{b i g} 12345} {{d e m o} 34512} {{c o d e} 54321} {{b l a h} 94729}}
+test cmdIL-1.41 {lsort -stride and -index} -body {
+    lsort -stride 2 -index -2 {a 2 b 1}
+} -returnCodes error -result {index "-2" out of range}
+test cmdIL-1.42 {lsort -stride and-index} -body {
+    lsort -stride 2 -index -1-1 {a 2 b 1}
+} -returnCodes error -result {index "-1-1" out of range}
 
 testreport


### PR DESCRIPTION
Addresses some of the features mentioned in #170 

Add -stride support to both lsearch and lsort
Add -index support to lsearch
Improve -index for lsort to support multiple indices

Also harmonise some error messages with Tcl 8.7