### PR TITLE
core: fix memory leak while replacing existing commands

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -4033,7 +4033,10 @@ static int JimCreateCommand(Jim_Interp *interp, Jim_Obj *nameObjPtr, Jim_Cmd *cm
      * existing command that is replace will be held as a negative cache entry
      * until the next time the proc epoch is incremented.
      */
-    return Jim_ReplaceHashEntry(&interp->commands, nameObjPtr, cmd);
+    Jim_IncrRefCount(nameObjPtr);
+    Jim_ReplaceHashEntry(&interp->commands, nameObjPtr, cmd);
+    Jim_DecrRefCount(interp, nameObjPtr);
+    return JIM_OK;
 }
 
 int Jim_CreateCommandObj(Jim_Interp *interp, Jim_Obj *cmdNameObj,


### PR DESCRIPTION
Hi Steve,
I'm not sure why 'nameObjPtr' causes a leak here.
In OpenOCD I only call Jim_CreateCommand() and after the commit specified below I get the leak.

Commit a712f98d210b ("core: tidy up command creation/replacement")
replaces the sequence
    Jim_DeleteHashEntry(&interp->commands, nameObjPtr);
    Jim_AddHashEntry(&interp->commands, nameObjPtr, cmd);
with
    Jim_ReplaceHashEntry(&interp->commands, nameObjPtr, cmd);
while replacing an existing command.
This cause as side effect a memory leak due to 'nameObjPtr' never
being referenced.

Add Jim_IncrRefCount/Jim_DecrRefCount on 'nameObjPtr'.

While there, fix also the returned value of JimCreateCommand(). In
fact Jim_ReplaceHashEntry() does not return JIM_OK/JIM_ERR but the
flag 1/0 for "key existed"/"key did not existed".

Signed-off-by: Antonio Borneo <borneo.antonio@gmail.com>
Fixes: a712f98d210b ("core: tidy up command creation/replacement")