### PR TITLE
configure.ac: fix autoreconf with autoconf >= 2.70

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,1 +1,3 @@
 # Dummy configure.ac to make automake happy
+AC_INIT([jimtcl], [0.80])
+AC_OUTPUT


### PR DESCRIPTION
Fix the following build failure raised with openocd and autoconf >= 2.70 due to http://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=commit;h=aba75f6d4a9c875a9d5d90a07c6b3678db66a4bf:

```
>>> openocd 0.11.0 Autoreconfiguring
autoreconf: error: configure.ac: AC_INIT not found; not an autoconf script?
```

Fixes:
 - http://autobuild.buildroot.org/results/5fb7aa28703aff61ba850eac11bd35c8804528ae

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>