### PR TITLE
Unicode ranges are closed intervals

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -167,7 +167,7 @@ struct casemap {
 
 struct utf8range {
     unsigned lower;     /* lower inclusive */
-    unsigned upper;     /* upper exclusive */
+    unsigned upper;     /* upper inclusive */
 };
 
 
@@ -202,7 +202,7 @@ static int cmp_range(const void *key, const void *cm)
     if (ch < range->lower) {
         return -1;
     }
-    if (ch >= range->upper) {
+    if (ch > range->upper) {
         return 1;
     }
     return 0;


### PR DESCRIPTION
E.g., see the hourglass character U+231B closing the range at line 1111 of the bundled EastAsianWidth.txt:
https://github.com/msteveb/jimtcl/blob/3bf391ebe1a87c1fd0fc064254ef40976dff06f9/EastAsianWidth.txt#L1111