### PR TITLE
build: win32: Fix build with tdm-gcc10.3

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -285,6 +285,8 @@ switch -glob -- $host_os {
         define TCL_PLATFORM_OS $host_os
         define TCL_PLATFORM_PLATFORM windows
         define TCL_PLATFORM_PATH_SEPARATOR {;}
+        # Target WinXP or later. Should this be configurable?
+        define-append CCOPTS -D_WIN32_WINNT=0x501 -Wno-deprecated-declarations
     }
     default {
         # Note that cygwin is considered a unix platform

--- a/jimiocompat.h
+++ b/jimiocompat.h
@@ -65,8 +65,8 @@ int Jim_OpenForRead(const char *filename);
     #define HAVE_PIPE
     #define pipe(P) _pipe((P), 0, O_NOINHERIT)
 
-    typedef struct _stat64 jim_stat_t;
-    #define Jim_Stat __stat64
+    typedef struct __stat64 jim_stat_t;
+    #define Jim_Stat _stat64
     #define Jim_FileStat _fstat64
 
 #else


### PR DESCRIPTION
Mostly we need to specifically target WinXP.
Also silence deprecation warnings.
And fix the confusion about _stat64 vs __stat64

Fixes #219

Signed-off-by: Steve Bennett <steveb@workware.net.au>