### PR TITLE
build: ignore command-line parameters while looking for tools

### DIFF
--- a/autosetup/autosetup
+++ b/autosetup/autosetup
@@ -878,7 +878,7 @@ proc list-non-empty {list} {
 # The full path to the executable if found, or "" if not found.
 # Returns 1 if found, or 0 if not.
 #
-proc find-executable-path {name} {
+proc find-executable-path {name args} {
 	# Ignore any parameters
 	set name [lindex $name 0]
 	# The empty string is never a valid executable
@@ -902,7 +902,7 @@ proc find-executable-path {name} {
 # in which case the parameters are ignored.
 # Returns 1 if found, or 0 if not.
 #
-proc find-executable {name} {
+proc find-executable {name args} {
 	if {[find-executable-path $name] eq {}} {
 		return 0
 	}


### PR DESCRIPTION
During configure, cc-check-tools looks for installed tools after
retrieving from environment the tool's name.

From Yocto Release 3.4 (honister) the variable RANLIB is set by
default as:
	RANLIB="ranlib -D"
The tool's parameter '-D' causes configure to fail with error
	Error: wrong # args: should be "find-executable name"

Let 'find-executable' and 'find-executable-path' to ignore any
parameter passed to the tool.

Signed-off-by: Antonio Borneo <borneo.antonio@gmail.com>