### PR TITLE
Fixed when source dir and build dir not the same

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -187,7 +187,7 @@ install-docs: docs
 install-docs:
 	$(INSTALL_DATA_DIR) $(DESTDIR)$(docdir)
 	@echo "Warning: asciidoc not available - installing Tcl_shipped.html"
-	$(INSTALL_DATA) Tcl_shipped.html $(DESTDIR)$(docdir)/Tcl.html
+	$(INSTALL_DATA) @srcdir@/Tcl_shipped.html $(DESTDIR)$(docdir)/Tcl.html
 @endif
 
 Tcl.html: jim_tcl.txt @srcdir@/make-index

--- a/autosetup/autosetup
+++ b/autosetup/autosetup
@@ -652,7 +652,7 @@ proc options {optlist} {
 		if {[opt-bool option-checking]} {
 			foreach o [dict keys $::autosetup(getopt)] {
 				if {$o ni $::autosetup(options)} {
-					user-error "Unknown option --$o"
+					user-notice "Unknown option --$o"
 				}
 			}
 		}


### PR DESCRIPTION
When the build directory and the source directory do not match
some files are looked in the build directory. Fixed it.

Signed-off-by: Asier Llano <allano@hubbell.com>