### PR TITLE
Update autosetup-find-tclsh

### DIFF
--- a/autosetup/autosetup-find-tclsh
+++ b/autosetup/autosetup-find-tclsh
@@ -10,7 +10,7 @@ done
 echo 1>&2 "No installed jimsh or tclsh, building local bootstrap jimsh0"
 for cc in ${CC_FOR_BUILD:-cc} gcc; do
 	{ $cc -o jimsh0 "$d/jimsh0.c"; } 2>/dev/null || continue
-	./jimsh0 "$d/${-autosetup-test-tclsh}" && exit 0
+	./jimsh0 "$d/${1-autosetup-test-tclsh}" && exit 0
 done
 echo 1>&2 "No working C compiler found. Tried ${CC_FOR_BUILD:-cc} and gcc."
 echo false


### PR DESCRIPTION
Fixes an apparent typo in d6edb1347713f002a8f1e61c585583b3b1c37394

This is the error from _configure_ which occurs otherwise:
```
No installed jimsh or tclsh, building local bootstrap jimsh0
./autosetup/autosetup-find-tclsh: 13: ./autosetup/autosetup-find-tclsh: Bad substitution
./configure: 4: exec: : Permission denied

```