### PR TITLE
Drop the dummy file configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,0 @@
-# Dummy configure.ac to make automake happy
-AC_INIT([jimtcl], [0.80])
-AC_OUTPUT


### PR DESCRIPTION
Jimtcl dropped the file configure.ac with commit 2ffa2eee88f3 ("Remove obsolete configure.ac") in 2011, but this caused a build failure when jimtcl is used as submodule by OpenOCD. Instead of fixing the obsoleted path in OpenOCD's configure.ac, a patch to add a dummy configure.ac was merged in jimtcl with commit 142edb4e35a90 ("Re-add a dummy configure.ac for automake").

The resulting setup still has issues, as running 'autoremake -f' in OpenOCD folder causes autoconf to replace jimtcl configure file with an incorrect file generated from the dummy configure.ac .

OpenOCD release v0.12.0 includes a fix that makes useless the dummy configure.ac in jimtcl: https://review.openocd.org/7437/ ("configure.ac: fix check for jimtcl submodule").

Drop the dummy configure.ac .

Signed-off-by: Antonio Borneo <borneo.antonio@gmail.com>