### PR TITLE
Tcl compatible info frame

### DIFF
--- a/jim.h
+++ b/jim.h
@@ -126,7 +126,7 @@ extern "C" {
  * ---------------------------------------------------------------------------*/
 
 /* Increment this every time the public ABI changes */
-#define JIM_ABI_VERSION 100
+#define JIM_ABI_VERSION 101
 
 #define JIM_OK 0
 #define JIM_ERR 1

--- a/jim.h
+++ b/jim.h
@@ -446,6 +446,18 @@ typedef struct Jim_CallFrame {
     struct Jim_Cmd *tailcallCmd;  /* Resolved command for pending tailcall invocation */
 } Jim_CallFrame;
 
+/* Evaluation frame */
+typedef struct Jim_EvalFrame {
+    const char *type;           /* "cmd", "source", etc. */
+    int level; /* Level of this evaluation frame. 0 = global */
+    int callFrameLevel;         /* corresponding call frame level */
+    struct Jim_Cmd *cmd;        /* The currently executing command */
+    struct Jim_EvalFrame *parent; /* The parent frame or NULL if at top */
+    Jim_Obj *const *argv; /* object vector of the current command . */
+    int argc; /* number of args */
+    Jim_Obj *scriptObj;
+} Jim_EvalFrame;
+
 /* The var structure. It just holds the pointer of the referenced
  * object. If linkFramePtr is not NULL the variable is a link
  * to a variable of name stored in objPtr living in the given callframe
@@ -488,6 +500,7 @@ typedef struct Jim_Cmd {
     int inUse;           /* Reference count */
     int isproc;          /* Is this a procedure? */
     struct Jim_Cmd *prevCmd;    /* Previous command defn if cmd created 'local' */
+    Jim_Obj *cmdNameObj;       /* The fully resolved command name - just a pointer, not a reference */
     union {
         struct {
             /* native (C) command */
@@ -555,6 +568,10 @@ typedef struct Jim_Interp {
     Jim_Obj *liveList; /* Linked list of all the live objects. */
     Jim_Obj *freeList; /* Linked list of all the unused objects. */
     Jim_Obj *currentScriptObj; /* Script currently in execution. */
+    Jim_EvalFrame topEvalFrame;  /* dummy top evaluation frame */
+    Jim_EvalFrame *evalFrame;  /* evaluation stack */
+    int argc;
+    Jim_Obj * const *argv;
     Jim_Obj *nullScriptObj; /* script representation of an empty string */
     Jim_Obj *emptyObj; /* Shared empty string object. */
     Jim_Obj *trueObj; /* Shared true int object. */

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -2877,16 +2877,28 @@ The legal +'option'+'s (which may be abbreviated) are:
     otherwise.
 
 +*info frame* ?'number'?+::
-    TBD: Update for new Tcl-compatible dictionary format - type, line, file, cmd, proc, level.
+    *Note*: This command has changed as of Jim version 0.82 to be more Tcl-compatible.
+  ::
     If +'number'+ is not specified, this command returns a number
-    which is the same result as `info level` - the current stack frame level.
-    If +'number'+ is specified, then the result is a list consisting of the procedure,
-    filename and line number for the procedure call at level +'number'+ on the stack.
-    If +'number'+ is positive then it selects a particular stack level (1 refers
-    to the top-most active procedure, 2 to the procedure it called, and
-    so on); otherwise it gives a level relative to the current level
-    (0 refers to the current procedure, -1 to its caller, and so on).
-    The level has an identical meaning to `info level`.
+    giving the evaluation level of the invoking command (1 when invoked a the top level).
+  ::
+    If +'number'+ is positive then it selects a particular evaluation level (1 refers
+    to the top-most evaluation level, 2 to the command it called, and
+    so on); otherwise it gives a level relative to the current evaluation level
+    (0 refers to the current command (info frame), -1 to its caller, and so on).
+    In this case, the command returns a dictionary containing the folllowing keys:
+  ::
+    'type' - always +'"source"'+
+  ::
+    'file' - file name where the command was invoked (may be empty if not known)
+  ::
+    'line' - line number where the command was invoked (may be 0 if not known)
+  ::
+    'cmd' - the command (as a list) executing at the given level
+  ::
+    'proc' - if within a proc, the name of the proc (omitted if not within a proc)
+  ::
+    'level' - the evaluation level
 
 +*info globals* ?'pattern'?+::
     If +'pattern'+ isn't specified, returns a list of all the names

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -58,6 +58,7 @@ Changes between 0.81 and 0.82
 2. TIP 603, `aio stat` is now supported to stat a file handle
 3. Add support for `socket -async`
 4. The handles created by `socket pty` now make the replica name available via 'filename'
+5. `info frame` now returns a (largely) Tcl-compatible dictionary, and supports 'info frame 0'
 
 Changes between 0.80 and 0.81
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2876,6 +2877,7 @@ The legal +'option'+'s (which may be abbreviated) are:
     otherwise.
 
 +*info frame* ?'number'?+::
+    TBD: Update for new Tcl-compatible dictionary format - type, line, file, cmd, proc, level.
     If +'number'+ is not specified, this command returns a number
     which is the same result as `info level` - the current stack frame level.
     If +'number'+ is specified, then the result is a list consisting of the procedure,

--- a/jimdb
+++ b/jimdb
@@ -378,7 +378,9 @@ proc debugger::_db {type file line result name arglist} {
             # Build the active stacktrace
             set s(stacktrace) {}
             foreach level [range 1 [info level]] {
-                lassign [info frame $level] p f l
+                set frame [info frame $level]
+                set f [dict get $frame file]
+                set l [dict get $frame line]
                 lassign [info level $level] p pargs
                 lappend s(stacktrace) [list $f $l $p $pargs]
             }

--- a/stdlib.tcl
+++ b/stdlib.tcl
@@ -38,9 +38,29 @@ proc function {value} {
 # (deepest level first)
 proc stacktrace {{skip 0}} {
 	set trace {}
-	incr skip
-	foreach level [range $skip [info level]] {
-		lappend trace {*}[info frame -$level]
+	# Need to skip info frame 0 and this (stacktrace) level
+	incr skip 2
+	loop level $skip [info level]+1 {
+		set frame [info frame -$level]
+		lappend trace [lindex [dict get $frame cmd] 0] [dict get $frame file] [dict get $frame line]
+	}
+	return $trace
+}
+proc stacktrace {{skip 0}} {
+	set trace {}
+	# skip the internal frames
+	incr skip 1
+	set last 0
+	loop level $skip [info frame]+1 {
+		set frame [info frame -$level]
+		set file [dict get $frame file]
+		set line [dict get $frame line]
+		set lev [dict get $frame level]
+		if {$lev != $last && $lev > $skip} {
+			set proc [lindex [dict get $frame cmd] 0]
+			lappend trace $proc $file $line
+		}
+		set last $lev
 	}
 	return $trace
 }

--- a/tests/apply.test
+++ b/tests/apply.test
@@ -128,11 +128,11 @@ test apply-8.10 {default values} {
 } {{args {}} {x 1} {y 3}}
 
 test apply-9.1 {tailcall within apply} {
-    proc p {y frame} {
-        list [expr {$y * 2}] [expr {$frame - [info frame]}]
+    proc p {y level} {
+        list [expr {$y * 2}] [expr {$level - [info level]}]
     }
     apply {{x} {
-        tailcall p $x [info frame]
+        tailcall p $x [info level]
         notreached
     }} {4}
 } {8 0}

--- a/tests/infoframe.test
+++ b/tests/infoframe.test
@@ -2,10 +2,10 @@ source [file dirname [info script]]/testing.tcl
 needs constraint jim
 proc a {n} {
 	if {$n eq "trace"} {
-		basename-stacktrace [stacktrace]
-	} else {
-		basename-stacktrace [info frame $n]
+		# strip the frame levels for test and uplevel
+		return [basename-stacktrace [lrange [stacktrace] 0 end-6]]
 	}
+	set frame [info frame $n]; list [dict getdef $frame proc {}] [file tail [dict get $frame file]] [dict get $frame line]
 }
 
 proc b {n} {
@@ -18,20 +18,24 @@ proc c {n} {
 
 # --- Don't change line numbers above
 
-test info-frame-1.1 "Current proc" {
+test info-frame-1.1 "Current command" {
 	c 0
-} {a infoframe.test 12}
+} {a infoframe.test 8}
 
-test info-frame-1.2 "Caller" {
+test info-frame-1.2 "Current Proc" {
 	c -1
-} {b infoframe.test 16}
+} {b infoframe.test 12}
 
-test info-frame-1.3 "Caller of Caller" {
+test info-frame-1.3 "Caller" {
 	c -2
-} {c infoframe.test 30}
+} {c infoframe.test 16}
+
+test info-frame-1.4 "Caller of Caller" {
+	c -3
+} {test infoframe.test 34}
 
 test stacktrace-1.1 "Full stack trace" {
 	c trace
-} {a infoframe.test 12 b infoframe.test 16 c infoframe.test 34}
+} {a infoframe.test 12 b infoframe.test 16 c infoframe.test 38}
 
 testreport


### PR DESCRIPTION
Currently in Jim, info frame returns a list of {proc file line} and can only examine proc call frames, not evaluation frames. It is useful to make info frame more Tcl-compatible (return a dict) and also allow access to evaluation frames that are not proc call frames.

As we can see here, info frame now acts much more like Tcl (example from TIP 280):

```
$ tclsh tip280.tcl
type source line 1 file /Volumes/src/jimtcl/tip280.tcl cmd {info frame 0} level 0
type source line 4 file /Volumes/src/jimtcl/tip280.tcl cmd {info frame 0} proc ::foo level 0
type eval line 2 cmd {info frame 0} level 0
type source line 14 file /Volumes/src/jimtcl/tip280.tcl cmd {info frame 0} level 0
type eval line 2 cmd {info frame 0} proc ::fox level 0
type source line 24 file /Volumes/src/jimtcl/tip280.tcl cmd {info frame 0} proc ::squirrel level 0
...
```

```
$ ./jimsh tip280.tcl
type source line 1 file tip280.tcl cmd {info frame 0} level 0
type source line 4 file tip280.tcl cmd {info frame 0} proc foo level 0
type source line 9 file tip280.tcl cmd {info frame 0} level 0
type source line 14 file tip280.tcl cmd {info frame 0} level 0
type source line 9 file tip280.tcl cmd {info frame 0} proc fox level 0
type source line 24 file tip280.tcl cmd {info frame 0} proc squirrel level 0
...
```
