### PR TITLE
Add support for vwait -signal

### DIFF
--- a/examples/vwaitsignal.tcl
+++ b/examples/vwaitsignal.tcl
@@ -1,0 +1,26 @@
+# In lieu of some proper unit tests, this example
+# checks that vwait can be interrupted by handled signals
+
+set f [open "/dev/urandom" r]
+
+set count 0
+
+$f ndelay 1
+
+signal handle SIGALRM
+
+$f readable {
+	incr count [string bytelength [read $f 100]]
+}
+
+
+set start [clock millis]
+
+# Even though nothing sets 'done', vwait will return on the signal
+alarm 0.5
+vwait -signal done
+
+set end [clock millis]
+puts "Read $count bytes and received [signal check -clear] after $($end - $start)ms"
+
+$f close

--- a/jim-eventloop.c
+++ b/jim-eventloop.c
@@ -620,8 +620,12 @@ static int JimELVwaitCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         if (signal && interp->sigmask) {
             /* vwait -signal and handled signals were received, so transfer them
              * to ignored signals so that 'signal check -clear' will return them.
+             * It's possible that if signals aren't supported we shouldn't even
+             * allow the -signal option.
              */
+#ifdef jim_ext_signal
             Jim_SignalSetIgnored(interp->sigmask);
+#endif
             interp->sigmask = 0;
             break;
         }

--- a/jim-signal.c
+++ b/jim-signal.c
@@ -46,6 +46,11 @@ static void signal_ignorer(int sig)
     sigsignored |= sig_to_bit(sig);
 }
 
+void Jim_SignalSetIgnored(jim_wide mask)
+{
+    sigsignored |= mask;
+}
+
 static void signal_init_names(void)
 {
 #define SET_SIG_NAME(SIG) siginfo[SIG].name = #SIG

--- a/jim.h
+++ b/jim.h
@@ -932,6 +932,7 @@ JIM_EXPORT int Jim_IsBigEndian(void);
  * in a catch -signal {} clause.
  */
 #define Jim_CheckSignal(i) ((i)->signal_level && (i)->sigmask)
+JIM_EXPORT void Jim_SignalSetIgnored(jim_wide mask);
 
 /* jim-load.c */
 JIM_EXPORT int Jim_LoadLibrary(Jim_Interp *interp, const char *pathName);

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -58,6 +58,7 @@ Changes between 0.81 and 0.82
 2. TIP 603, `aio stat` is now supported to stat a file handle
 3. Add support for `socket -async`
 4. The handles created by `socket pty` now make the replica name available via 'filename'
+5. `vwait -signal` is now supported
 
 Changes between 0.80 and 0.81
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -5103,12 +5104,14 @@ Time-based execution is also available via the eventloop API.
     the type of the event. An error occurs if +'id'+ does not
     match an event.
 
-+*vwait* 'variable'+::
++*vwait ?-signal?* 'variable'+::
     A call to `vwait` enters the eventloop. `vwait` processes
     events until the named (global) variable changes or all
     event handlers are removed. The variable need not exist
     beforehand.  If there are no event handlers defined, `vwait`
-    returns immediately.
+    returns immediately. If +'-signal'+ is specified, `vwait` will
+    also quit if a handled signal occurs. In this case, `signal check -clear`
+    can be used to check for the signal that occurred.
 
 +*update ?idletasks?*+::
     A call to `update` enters the eventloop to process expired events, but

--- a/tests/event.test
+++ b/tests/event.test
@@ -104,12 +104,12 @@ test event-10.1 {Tcl_Exit procedure} exec {
         [lindex $errorCode 2]
 } {1 CHILDSTATUS 3}
 
-test event-11.1 {Tcl_VwaitCmd procedure} {
-    list [catch {vwait} msg] $msg
-} {1 {wrong # args: should be "vwait name"}}
-test event-11.2 {Tcl_VwaitCmd procedure} {
-    list [catch {vwait a b} msg] $msg
-} {1 {wrong # args: should be "vwait name"}}
+test event-11.1 {Tcl_VwaitCmd procedure} -body {
+    vwait
+} -returnCodes error -match glob -result {wrong # args: should be "vwait* name"}
+test event-11.2 {Tcl_VwaitCmd procedure} -body {
+    vwait a b
+} -returnCodes error -match glob -result {wrong # args: should be "vwait* name"}
 test event-11.3 {Tcl_VwaitCmd procedure} jim {
     catch {unset x}
     set x 1


### PR DESCRIPTION
To improve the integration of scripts that use both signals and the eventloop. Otherwise signals could break an eventloop script and it would never run again (because it returned with an error). Best if signals are handled back outside the eventloop scripts.