### PR TITLE
examples.api: drop last JIM_EMBEDDED definitions

### DIFF
--- a/examples.api/jim_command.c
+++ b/examples.api/jim_command.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define JIM_EMBEDDED
 #include <jim.h>
 
 /*

--- a/examples.api/jim_list.c
+++ b/examples.api/jim_list.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define JIM_EMBEDDED
 #include <jim.h>
 
 /*

--- a/examples.api/jim_obj.c
+++ b/examples.api/jim_obj.c
@@ -30,7 +30,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define JIM_EMBEDDED
 #include <jim.h>
 
 #define	OBJ_DESC	"hello world"

--- a/examples.api/jim_return.c
+++ b/examples.api/jim_return.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define JIM_EMBEDDED
 #include <jim.h>
 
 /*


### PR DESCRIPTION
The macro JIM_EMBEDDED was required to be defined before including jim.h in applications that embed jimtcl.
This requirement has been dropped in 2010 with commit 2d8564100c86 ("Documentation updates") but it's use has remained for longer and it even re-appeared later in the examples.api.

Drop last instances of JIM_EMBEDDED.