### PR TITLE
build: remove jsmn/*.o on clean

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -217,6 +217,7 @@ coverage:
 
 clean:
 	rm -f *.o *.so *.dll *.exe lib*.a $(JIMSH) $(LIBJIM) Tcl.html _*.c libjim@SH_SOEXT@
+	rm -f jsmn/*.o
 @if COVERAGE
 	rm -f *.gcno *.gcov *.gcda */*.gcno */*.gcda */*.gcov coverage*.html
 	rm -rf coverage_html lcov.txt genhtml_output.txt


### PR DESCRIPTION
json decoder is available since jimtcl 0.79, but the Makefile does not remove the related object files during 'make clean'.

Add jsmn/*.o in the list of files to remove during 'make clean'.