### PR TITLE
Info frame stacktrace improvements

### DIFF
--- a/jim-package.c
+++ b/jim-package.c
@@ -181,9 +181,6 @@ static int package_cmd_provide(Jim_Interp *interp, int argc, Jim_Obj *const *arg
  */
 static int package_cmd_require(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    /* package require failing is important enough to add to the stack */
-    interp->addStackTrace++;
-
     return Jim_PackageRequire(interp, Jim_String(argv[0]), JIM_ERRMSG);
 }
 

--- a/jim.c
+++ b/jim.c
@@ -5700,6 +5700,7 @@ Jim_Interp *Jim_CreateInterp(void)
     Jim_SetVariableStrWithStr(i, "tcl_platform(bootstrap)", "0");
     Jim_SetVariableStr(i, "tcl_platform(pointerSize)", Jim_NewIntObj(i, sizeof(void *)));
     Jim_SetVariableStr(i, "tcl_platform(wordSize)", Jim_NewIntObj(i, sizeof(jim_wide)));
+    Jim_SetVariableStr(i, "tcl_platform(stackFormat)", Jim_NewIntObj(i, 4));
 
     return i;
 }

--- a/jim.c
+++ b/jim.c
@@ -5958,12 +5958,12 @@ static void JimSetStackTrace(Jim_Interp *interp, Jim_Obj *stackTraceObj)
     Jim_IncrRefCount(stackTraceObj);
     Jim_DecrRefCount(interp, interp->stackTrace);
     interp->stackTrace = stackTraceObj;
-    interp->errorFlag = 1;
+    interp->hasErrorStackTrace = 1;
 }
 
 static void JimSetErrorStack(Jim_Interp *interp)
 {
-    if (!interp->errorFlag) {
+    if (!interp->hasErrorStackTrace) {
         int i;
         Jim_Obj *stackTrace = Jim_NewListObj(interp, NULL, 0);
 
@@ -11106,7 +11106,7 @@ int Jim_EvalObj(Jim_Interp *interp, Jim_Obj *scriptObjPtr)
     JimPushEvalFrame(interp, &frame, scriptObjPtr);
 
     /* Collect a new error stack trace if an error occurs */
-    interp->errorFlag = 0;
+    interp->hasErrorStackTrace = 0;
     argv = sargv;
 
     /* Execute every command sequentially until the end of the script
@@ -13720,7 +13720,7 @@ static int Jim_ContinueCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const 
 /* [stacktrace] */
 static int Jim_StacktraceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    Jim_Obj *listObj = Jim_NewListObj(interp, NULL, 0);
+    Jim_Obj *listObj;
     long skip = 0;
     int i;
 
@@ -13730,6 +13730,7 @@ static int Jim_StacktraceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *cons
         }
     }
 
+    listObj = Jim_NewListObj(interp, NULL, 0);
     for (i = skip; i <= interp->procLevel; i++) {
         Jim_EvalFrame *frame = JimGetEvalFrameByProcLevel(interp, -i);
         if (frame) {
@@ -14748,7 +14749,7 @@ wrongargs:
     else {
         exitCode = Jim_EvalObj(interp, argv[idx]);
         /* Once caught, a new error will set a stack trace again */
-        interp->errorFlag = 0;
+        interp->hasErrorStackTrace = 0;
     }
     interp->signal_level -= sig;
 

--- a/jim.c
+++ b/jim.c
@@ -13721,11 +13721,17 @@ static int Jim_ContinueCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const 
 static int Jim_StacktraceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     Jim_Obj *listObj;
-    long skip = 0;
     int i;
+    jim_wide skip = 0;
+    jim_wide last = 0;
 
     if (argc > 1) {
-        if (Jim_GetLong(interp, argv[1], &skip) != JIM_OK) {
+        if (Jim_GetWideExpr(interp, argv[1], &skip) != JIM_OK) {
+            return JIM_ERR;
+        }
+    }
+    if (argc > 2) {
+        if (Jim_GetWideExpr(interp, argv[2], &last) != JIM_OK) {
             return JIM_ERR;
         }
     }
@@ -13733,9 +13739,10 @@ static int Jim_StacktraceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *cons
     listObj = Jim_NewListObj(interp, NULL, 0);
     for (i = skip; i <= interp->procLevel; i++) {
         Jim_EvalFrame *frame = JimGetEvalFrameByProcLevel(interp, -i);
-        if (frame) {
-            JimAddStackFrame(interp, frame, listObj);
+        if (frame->procLevel < last) {
+            break;
         }
+        JimAddStackFrame(interp, frame, listObj);
     }
     Jim_SetResult(interp, listObj);
     return JIM_OK;

--- a/jim.h
+++ b/jim.h
@@ -126,7 +126,7 @@ extern "C" {
  * ---------------------------------------------------------------------------*/
 
 /* Increment this every time the public ABI changes */
-#define JIM_ABI_VERSION 101
+#define JIM_ABI_VERSION 102
 
 #define JIM_OK 0
 #define JIM_ERR 1
@@ -440,8 +440,6 @@ typedef struct Jim_CallFrame {
     Jim_Obj *procBodyObjPtr; /* body object of the running procedure */
     struct Jim_CallFrame *next; /* Callframes are in a linked list */
     Jim_Obj *nsObj;             /* Namespace for this proc call frame */
-    Jim_Obj *unused_fileNameObj;
-    int unused_line;
     Jim_Stack *localCommands; /* commands to be destroyed when the call frame is destroyed */
     struct Jim_Obj *tailcallObj;  /* Pending tailcall invocation */
     struct Jim_Cmd *tailcallCmd;  /* Resolved command for pending tailcall invocation */
@@ -540,14 +538,12 @@ typedef struct Jim_PrngState {
  * ---------------------------------------------------------------------------*/
 typedef struct Jim_Interp {
     Jim_Obj *result; /* object returned by the last command called. */
-    int unused_errorLine; /* Error line where an error occurred. */
-    Jim_Obj *unused_errorFileNameObj; /* Error file where an error occurred. */
-    int unused_addStackTrace;
     int maxCallFrameDepth; /* Used for infinite loop detection. */
     int maxEvalDepth; /* Used for infinite loop detection. */
     int evalDepth;  /* Current eval depth */
     int returnCode; /* Completion code to return on JIM_RETURN. */
     int returnLevel; /* Current level of 'return -level' */
+    int procLevel;   /* Total depth of proc stack, including uplevel calls */
     int exitCode; /* Code to return to the OS on JIM_EXIT. */
     long id; /* Hold unique id for various purposes */
     int signal_level; /* A nesting level of catch -signal */
@@ -568,11 +564,8 @@ typedef struct Jim_Interp {
     int safeexpr; /* Set when evaluating a "safe" expression, no var subst or command eval */
     Jim_Obj *liveList; /* Linked list of all the live objects. */
     Jim_Obj *freeList; /* Linked list of all the unused objects. */
-    Jim_Obj *unused_currentScriptObj; /* Script currently in execution. */
     Jim_EvalFrame topEvalFrame;  /* dummy top evaluation frame */
     Jim_EvalFrame *evalFrame;  /* evaluation stack */
-    int procLevel;
-    Jim_Obj * const *unused_argv;
     Jim_Obj *nullScriptObj; /* script representation of an empty string */
     Jim_Obj *emptyObj; /* Shared empty string object. */
     Jim_Obj *trueObj; /* Shared true int object. */
@@ -591,7 +584,7 @@ typedef struct Jim_Interp {
     Jim_Obj *defer; /* "jim::defer" */
     Jim_Obj *traceCmdObj; /* If non-null, execution trace command to invoke */
     int unknown_called; /* The unknown command has been invoked */
-    int errorFlag; /* Set if an error occurred during execution. */
+    int hasErrorStackTrace; /* If a stack trace has been set due to an error during execution. */
     void *cmdPrivData; /* Used to pass the private data pointer to
                   a command. It is set to what the user specified
                   via Jim_CreateCommand(). */

--- a/jim.h
+++ b/jim.h
@@ -440,8 +440,8 @@ typedef struct Jim_CallFrame {
     Jim_Obj *procBodyObjPtr; /* body object of the running procedure */
     struct Jim_CallFrame *next; /* Callframes are in a linked list */
     Jim_Obj *nsObj;             /* Namespace for this proc call frame */
-    Jim_Obj *fileNameObj;       /* file and line of caller of this proc (if available) */
-    int line;
+    Jim_Obj *unused_fileNameObj;
+    int unused_line;
     Jim_Stack *localCommands; /* commands to be destroyed when the call frame is destroyed */
     struct Jim_Obj *tailcallObj;  /* Pending tailcall invocation */
     struct Jim_Cmd *tailcallCmd;  /* Resolved command for pending tailcall invocation */
@@ -449,11 +449,11 @@ typedef struct Jim_CallFrame {
 
 /* Evaluation frame */
 typedef struct Jim_EvalFrame {
-    const char *type;           /* "cmd", "source", etc. */
-    int level; /* Level of this evaluation frame. 0 = global */
-    int callFrameLevel;         /* corresponding call frame level */
+    Jim_CallFrame *framePtr;    /* Pointer to corresponding proc call frame */
+    int level;                  /* Level of this evaluation frame. 0 = global */
+    int procLevel;              /* Total proc depth */
     struct Jim_Cmd *cmd;        /* The currently executing command */
-    struct Jim_EvalFrame *parent; /* The parent frame or NULL if at top */
+    struct Jim_EvalFrame *parent; /* The parent eval frame or NULL if at top */
     Jim_Obj *const *argv; /* object vector of the current command . */
     int argc; /* number of args */
     Jim_Obj *scriptObj;
@@ -568,11 +568,11 @@ typedef struct Jim_Interp {
     int safeexpr; /* Set when evaluating a "safe" expression, no var subst or command eval */
     Jim_Obj *liveList; /* Linked list of all the live objects. */
     Jim_Obj *freeList; /* Linked list of all the unused objects. */
-    Jim_Obj *currentScriptObj; /* Script currently in execution. */
+    Jim_Obj *unused_currentScriptObj; /* Script currently in execution. */
     Jim_EvalFrame topEvalFrame;  /* dummy top evaluation frame */
     Jim_EvalFrame *evalFrame;  /* evaluation stack */
-    int argc;
-    Jim_Obj * const *argv;
+    int procLevel;
+    Jim_Obj * const *unused_argv;
     Jim_Obj *nullScriptObj; /* script representation of an empty string */
     Jim_Obj *emptyObj; /* Shared empty string object. */
     Jim_Obj *trueObj; /* Shared true int object. */

--- a/jim.h
+++ b/jim.h
@@ -540,9 +540,9 @@ typedef struct Jim_PrngState {
  * ---------------------------------------------------------------------------*/
 typedef struct Jim_Interp {
     Jim_Obj *result; /* object returned by the last command called. */
-    int errorLine; /* Error line where an error occurred. */
-    Jim_Obj *errorFileNameObj; /* Error file where an error occurred. */
-    int addStackTrace; /* > 0 if a level should be added to the stack trace */
+    int unused_errorLine; /* Error line where an error occurred. */
+    Jim_Obj *unused_errorFileNameObj; /* Error file where an error occurred. */
+    int unused_addStackTrace;
     int maxCallFrameDepth; /* Used for infinite loop detection. */
     int maxEvalDepth; /* Used for infinite loop detection. */
     int evalDepth;  /* Current eval depth */

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -3,7 +3,7 @@ Jim Tcl(n)
 
 NAME
 ----
-Jim Tcl v0.82 - reference manual for the Jim Tcl scripting language
+Jim Tcl v0.82+ - reference manual for the Jim Tcl scripting language
 
 SYNOPSIS
 --------
@@ -52,6 +52,12 @@ Some notable differences with Tcl 8.5/8.6/8.7 are:
 
 RECENT CHANGES
 --------------
+Changes since 0.82
+~~~~~~~~~~~~~~~~~~
+1. `info frame` now only returns 'proc' levels
+2. `stacktrace` is now a builtin command
+3. The stack trace on error now includes the full stack trace, not just back to where it was caught
+
 Changes between 0.81 and 0.82
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1. `try` now supports trap to match on errorcode
@@ -2989,7 +2995,7 @@ The legal +'option'+'s (which may be abbreviated) are:
 
 +*info stacktrace*+::
     After an error is caught with `catch`, returns the stack trace as a list
-    of +{procedure filename line \...}+.
+    of +{procedure filename line cmd \...}+.
 
 +*info statics* 'procname'+::
     Returns a dictionary of the static variables of procedure
@@ -4230,8 +4236,8 @@ stacktrace
 
 +*stacktrace*+
 
-Returns a live stack trace as a list of +proc file line proc file line \...+.
-Iteratively uses `info frame` to create the stack trace. This stack trace is in the
+Returns a live stack trace as a list of +proc file line cmd proc file line cmd \...+.
+uses the same information as `info frame` to create the stack trace. This stack trace is in the
 same form as produced by `catch` and `info stacktrace`
 
 See also `stackdump`.

--- a/jimdb
+++ b/jimdb
@@ -375,13 +375,13 @@ proc debugger::_db {type file line result name arglist} {
             set s(laststop) $file:$line
             set s(prevname) $name
 
-            # Build the active stacktrace
+            # Build the active stacktrace, omitting internal frames
             set s(stacktrace) {}
-            foreach level [range 1 [info level]] {
-                set frame [info frame $level]
-                set f [dict get $frame file]
-                set l [dict get $frame line]
-                lassign [info level $level] p pargs
+            foreach {p f l cmd} [stacktrace 1] {
+                if {[lindex $cmd 0] eq "debugger::_db"} {
+                    continue
+                }
+                lassign $cmd p pargs
                 lappend s(stacktrace) [list $f $l $p $pargs]
             }
             lappend s(stacktrace) $s(active)

--- a/stdlib.tcl
+++ b/stdlib.tcl
@@ -38,9 +38,9 @@ proc function {value} {
 # (deepest level first)
 proc stacktrace {{skip 0}} {
 	set frames {}
-	loop level 2 [info frame]+1 {
+	loop level $skip+1 [info frame] {
 		set frame [info frame -$level]
-		if {$frame(level) > $skip && [dict exists $frame proc]} {
+		if {[dict exists $frame proc]} {
 			lappend frames $frame(proc) $frame(file) $frame(line)
 		}
 	}

--- a/tcltest.tcl
+++ b/tcltest.tcl
@@ -110,11 +110,12 @@ if {[catch {info version}]} {
 	proc testreport {} {
 		::tcltest::cleanupTests
 	}
-	proc stacktrace {{skip 0}} {
+	proc stacktrace {{skip 0} {last 0}} {
 		set frames {}
 		incr skip
-		for {set level $skip} {$level < [info frame]} {incr level} {
+		for {set level $skip} {$level < [info frame] - $last} {incr level} {
 			set frame [info frame -$level]
+			puts $frame
 			if {[dict get $frame type] ne "source"} {
 				continue
 			}

--- a/tcltest.tcl
+++ b/tcltest.tcl
@@ -78,11 +78,20 @@ proc skiptest {{msg {}}} {
 # Also convert proc name ::a into a for compatibility between Tcl and Jim
 proc basename-stacktrace {stacktrace} {
 	set result {}
-	foreach {p f l} $stacktrace {
-		if {[string match ::* $p]} {
+	foreach {p f l cmd} $stacktrace {
+		if {[string match *tcltest-* $f]} {
+			#break
+		}
+		if {$p eq "::tcltest::RunTest"} {
+			set p test
+		} elseif {[string match ::* $p]} {
 			set p [string range $p 2 end]
 		}
-		lappend result $p [file tail $f] $l
+		set cmd [string map [list \n \\n] $cmd]
+		if {[string length $cmd] > 20} {
+			set cmd [string range $cmd 0 20]...
+		}
+		lappend result $p [file tail $f] $l $cmd
 	}
 	return $result
 }
@@ -102,27 +111,21 @@ if {[catch {info version}]} {
 		::tcltest::cleanupTests
 	}
 	proc stacktrace {{skip 0}} {
-		set trace {}
-		# Need to skip info frame 0 and this (stacktrace) level
-		incr skip 1
-		set maxlevel [info frame]
-		for {set level $skip} {$level < $maxlevel} {incr level} {
+		set frames {}
+		incr skip
+		for {set level $skip} {$level < [info frame]} {incr level} {
 			set frame [info frame -$level]
-			if {[dict get $frame type] eq "source" && [dict exists $frame proc]} {
-				set proc [dict get $frame proc]
-				# make it look like it is running under Jim tcltest
-				if {$proc eq "::tcltest::RunTest"} {
-					set proc test
-				} else {
-					set proc [string range $proc 2 end]
-				}
-				lappend trace $proc [dict get $frame file] [dict get $frame line]
-				if {$proc eq "test"} {
-					break
-				}
+			if {[dict get $frame type] ne "source"} {
+				continue
 			}
+			if {[dict exists $frame proc]} {
+				set proc [dict get $frame proc]
+			} else {
+				set proc ""
+			}
+			lappend frames $proc [dict get $frame file] [dict get $frame line] [dict get $frame cmd]
 		}
-		return $trace
+		return $frames
 	}
 	return
 }

--- a/tests/error.test
+++ b/tests/error.test
@@ -11,12 +11,12 @@ proc b {} {
 	}
 }
 
-test error-1.1 "Rethrow caught error" {
+test error-1.1 {Rethrow caught error} -body {
 	set rc [catch {b} msg]
 	#puts stderr "error-1.1\n[errorInfo $msg]\n"
 
 	list $rc $msg [basename-stacktrace [info stacktrace]]
-} {1 {error thrown from a} {{} error.test 4 a error.test 8 b error.test 15}}
+} -result {1 {error thrown from a} {a error.test 4 error\ \{error\ thrown\ f... b error.test 8 a test error.test 15 b {} error.test 14 test\ error-1.1\ \{Rethr...}}
 
 proc c {} {
 	a
@@ -30,22 +30,22 @@ proc e {} {
 	d
 }
 
-test error-1.2 "Modify stacktrace" {
+test error-1.2 {Modify stacktrace} -body {
 	set rc [catch {e} msg]
 	set st [info stacktrace]
 	# Now elide one entry from the stacktrace
 	#puts [errorInfo $msg]
 	set newst {}
-	foreach {p f l} $st {
+	foreach {p f l cmd} $st {
 		if {$p ne "d"} {
-			lappend newst $p $f $l
+			lappend newst $p $f $l $cmd
 		}
 	}
 	# Now rethrow with the new stack
 	set rc [catch {error $msg $newst} msg]
 	#puts [errorInfo $msg]
 	basename-stacktrace [info stacktrace]
-} {{} error.test 4 a error.test 22 c error.test 26 e error.test 34}
+} -result {a error.test 4 error\ \{error\ thrown\ f... c error.test 22 a e error.test 30 d test error.test 34 e {} error.test 33 test\ error-1.2\ \{Modif...}
 
 # Package should be able to invoke exit, which should exit if not caught
 test error-2.1 "Exit from package" {

--- a/tests/event.test
+++ b/tests/event.test
@@ -92,7 +92,11 @@ test event-7.4 {bgerror throws an error} -constraints jim -body {
         update
     }
 } -result {stdin:3: Error: inside bgerror
-at file "stdin", line 3}
+Traceback (most recent call last):
+  File "stdin", line 6
+    bgerror err1
+  File "stdin", line 3, in bgerror
+    error {inside bgerror}}
 
 # end of bgerror tests
 catch {rename bgerror {}}

--- a/tests/infoframe.test
+++ b/tests/infoframe.test
@@ -8,7 +8,7 @@ proc a {n} {
 	if {![dict exists $frame proc]} {
 		dict set frame proc {}
 	}
-	basename-stacktrace [list [dict get $frame proc] [file tail [dict get $frame file]] [dict get $frame line]]
+	basename-stacktrace [list [dict get $frame proc] [file tail [dict get $frame file]] [dict get $frame line] [dict get $frame cmd]]
 }
 
 proc b {n} {
@@ -23,22 +23,22 @@ proc c {n} {
 
 test info-frame-1.1 {Current command} -body {
 	c 0
-} -result {a infoframe.test 7}
+} -result {a infoframe.test 7 {info frame 0}}
 
 test info-frame-1.2 {Current Proc} -body {
 	c -1
-} -result {b infoframe.test 15}
+} -result {b infoframe.test 15 {a -1}}
 
 test info-frame-1.3 Caller -body {
 	c -2
-} -result {c infoframe.test 19}
+} -result {c infoframe.test 19 {b -2}}
 
 test info-frame-1.4 {Caller of Caller} -body {
 	c -3
-} -result {test infoframe.test 37}
+} -result {test infoframe.test 37 {c -3}}
 
 test stacktrace-1.1 {Full stack trace} -body {
 	c trace
-} -result {a infoframe.test 5 b infoframe.test 15 c infoframe.test 19 test infoframe.test 41}
+} -result {a infoframe.test 5 stacktrace b infoframe.test 15 {a trace} c infoframe.test 19 {b trace} test infoframe.test 41 {c trace} {} infoframe.test 40 test\ stacktrace-1.1\ \{...}
 
 testreport

--- a/tests/infoframe.test
+++ b/tests/infoframe.test
@@ -1,8 +1,8 @@
 source [file dirname [info script]]/testing.tcl
 
-proc a {n} {
+proc a {n args} {
 	if {$n eq "trace"} {
-		return [basename-stacktrace [stacktrace]]
+		return [basename-stacktrace [stacktrace {*}$args]]
 	}
 	set frame [info frame $n]
 	if {![dict exists $frame proc]} {
@@ -11,12 +11,12 @@ proc a {n} {
 	basename-stacktrace [list [dict get $frame proc] [file tail [dict get $frame file]] [dict get $frame line] [dict get $frame cmd]]
 }
 
-proc b {n} {
-	a $n
+proc b {args} {
+	a {*}$args
 }
 
-proc c {n} {
-	b $n
+proc c {args} {
+	b {*}$args
 }
 
 # --- Don't change line numbers above
@@ -40,5 +40,11 @@ test info-frame-1.4 {Caller of Caller} -body {
 test stacktrace-1.1 {Full stack trace} -body {
 	c trace
 } -result {a infoframe.test 5 stacktrace b infoframe.test 15 {a trace} c infoframe.test 19 {b trace} test infoframe.test 41 {c trace} {} infoframe.test 40 test\ stacktrace-1.1\ \{...}
+
+test stacktrace-1.2 {Stack trace with limited depth} -body {
+	# This will limit the stack trace to omit "this" level and below
+	c trace 0 [info frame]
+} -result {a infoframe.test 5 {stacktrace 0 2} b infoframe.test 15 {a trace 0 2} c infoframe.test 19 {b trace 0 2}}
+
 
 testreport

--- a/tests/misc.test
+++ b/tests/misc.test
@@ -301,25 +301,24 @@ test catch-1.9 "catch no error has no -errorinfo" {
 	list $rc [info exists opts(-errorinfo)]
 } {0 0}
 
-test return-1.1 "return can rethrow an error" {
+test return-1.1 {return can rethrow an error} -body {
 	proc a {} { error "from a" }
 	proc b {} { catch {a} msg opts; return {*}$opts $msg }
 	set rc [catch {b} msg opts]
-	list $rc $msg [llength $opts(-errorinfo)]
-} {1 {from a} 9}
+	list $rc $msg [basename-stacktrace $opts(-errorinfo)]
+} -result {1 {from a} {a misc.test 305 {error {from a}} b misc.test 306 a test misc.test 307 b {} misc.test 304 test\ return-1.1\ \{retu...}}
 
-test return-1.2 "error can rethrow an error" {
+test return-1.2 {error can rethrow an error} -body {
 	proc a {} { error "from a" }
 	proc b {} { catch {a} msg; error $msg [info stacktrace] }
 	set rc [catch {b} msg opts]
-	list $rc $msg [llength $opts(-errorinfo)]
-} {1 {from a} 9}
+	list $rc $msg [basename-stacktrace $opts(-errorinfo)]
+} -result {1 {from a} {a misc.test 312 {error {from a}} b misc.test 313 a test misc.test 314 b {} misc.test 311 test\ return-1.2\ \{erro...}}
 
 test return-1.3 "return can rethrow no error" {
 	proc a {} { return "from a" }
 	proc b {} { catch {a} msg opts; return {*}$opts $msg }
 	set rc [catch {b} msg opts]
-	#list $rc $msg [llength $opts(-errorinfo)]
 	list $rc $msg [info exists opts(-errorinfo)]
 } {0 {from a} 0}
 

--- a/tests/stacktrace.test
+++ b/tests/stacktrace.test
@@ -34,13 +34,13 @@ proc main {} {
 		error "from unknown"
 	}
 
-	test err-10.1 "Stacktrace on error from unknown (badcmd, call)" {
+	test err-10.1 {Stacktrace on error from unknown (badcmd, call)} -body {
 		set rc [catch {error_caller badcmd call} msg]
 		#puts stderr "err-10.1\n[errorInfo $msg]\n"
 		#puts stderr "\terr-10.1 {[list $rc $msg [basename-stacktrace [info stacktrace]]]}"
 
 		list $rc $msg [basename-stacktrace [info stacktrace]]
-	} {1 {from unknown} {{} stacktrace.test 34 {} errors.tcl 6 error_generator errors.tcl 44 error_caller stacktrace.test 38}}
+	} -result {1 {from unknown} {unknown stacktrace.test 34 {error {from unknown}} error_generator errors.tcl 6 {unknown bogus command...} error_caller errors.tcl 44 {error_generator badcm...} test stacktrace.test 38 {error_caller badcmd c...} main stacktrace.test 37 test\ err-10.1\ \{Stackt... {} stacktrace.test 127 main}}
 
 	rename unknown ""
 
@@ -74,50 +74,50 @@ proc main {} {
 }
 
 set expected {
-	err-1.1 {1 {invalid command name "bogus"} {{} errors.tcl 6 error_generator errors.tcl 44 error_caller stacktrace.test 25}}
-	err-1.2 {1 {invalid command name "bogus"} {{} errors.tcl 6 error_generator errors.tcl 47 error_caller stacktrace.test 25}}
-	err-1.3 {1 {invalid command name "bogus"} {{} errors.tcl 6 error_generator errors.tcl 50 error_caller stacktrace.test 25}}
-	err-1.4 {1 {invalid command name "bogus"} {{} errors.tcl 6 error_generator errors.tcl 53 error_caller stacktrace.test 25}}
-	err-2.1 {1 {can't read "bogus": no such variable} {{} errors.tcl 9 error_generator errors.tcl 44 error_caller stacktrace.test 25}}
-	err-2.2 {1 {can't read "bogus": no such variable} {{} errors.tcl 9 error_generator errors.tcl 47 error_caller stacktrace.test 25}}
-	err-2.3 {1 {can't read "bogus": no such variable} {{} errors.tcl 9 error_generator errors.tcl 50 error_caller stacktrace.test 25}}
-	err-2.4 {1 {can't read "bogus": no such variable} {{} errors.tcl 9 error_generator errors.tcl 53 error_caller stacktrace.test 25}}
-	err-3.1 {1 {unmatched "["} {{} errors.tcl 62 error_badproc errors.tcl 33 error_generator errors.tcl 44 error_caller stacktrace.test 25}}
-	err-3.2 {1 {unmatched "["} {{} errors.tcl 62 error_badproc errors.tcl 33 error_generator errors.tcl 47 error_caller stacktrace.test 25}}
-	err-3.3 {1 {unmatched "["} {{} errors.tcl 62 error_badproc errors.tcl 33 error_generator errors.tcl 50 error_caller stacktrace.test 25}}
-	err-3.4 {1 {unmatched "["} {{} errors.tcl 62 error_badproc errors.tcl 33 error_generator errors.tcl 53 error_caller stacktrace.test 25}}
-	err-4.1 {1 bogus {{} errors.tcl 12 error_generator errors.tcl 44 error_caller stacktrace.test 25}}
-	err-4.2 {1 bogus {{} errors.tcl 12 error_generator errors.tcl 47 error_caller stacktrace.test 25}}
-	err-4.3 {1 bogus {{} errors.tcl 12 error_generator errors.tcl 50 error_caller stacktrace.test 25}}
-	err-4.4 {1 bogus {{} errors.tcl 12 error_generator errors.tcl 53 error_caller stacktrace.test 25}}
-	err-5.1 {1 {can't read "bogus": no such variable} {{} errors.tcl 15 error_generator errors.tcl 44 error_caller stacktrace.test 25}}
-	err-5.2 {1 {can't read "bogus": no such variable} {{} errors.tcl 15 error_generator errors.tcl 47 error_caller stacktrace.test 25}}
-	err-5.3 {1 {can't read "bogus": no such variable} {{} errors.tcl 15 error_generator errors.tcl 50 error_caller stacktrace.test 25}}
-	err-5.4 {1 {can't read "bogus": no such variable} {{} errors.tcl 15 error_generator errors.tcl 53 error_caller stacktrace.test 25}}
-	err-6.1 {1 {can't read "bogus": no such variable} {{} errors.tcl 18 error_generator errors.tcl 44 error_caller stacktrace.test 25}}
-	err-6.2 {1 {can't read "bogus": no such variable} {{} errors.tcl 18 error_generator errors.tcl 47 error_caller stacktrace.test 25}}
-	err-6.3 {1 {can't read "bogus": no such variable} {{} errors.tcl 18 error_generator errors.tcl 50 error_caller stacktrace.test 25}}
-	err-6.4 {1 {can't read "bogus": no such variable} {{} errors.tcl 18 error_generator errors.tcl 53 error_caller stacktrace.test 25}}
+	err-1.1 {1 {invalid command name "bogus"} {error_generator errors.tcl 6 {} error_caller errors.tcl 44 {error_generator badcm...} test stacktrace.test 25 {error_caller badcmd c...} main stacktrace.test 24 test\ err-1.1\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-1.2 {1 {invalid command name "bogus"} {error_generator errors.tcl 6 {} error_caller errors.tcl 47 {error_generator badcm...} test stacktrace.test 25 {error_caller badcmd u...} main stacktrace.test 24 test\ err-1.2\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-1.3 {1 {invalid command name "bogus"} {error_generator errors.tcl 6 {} error_caller errors.tcl 50 {error_generator badcm...} test stacktrace.test 25 {error_caller badcmd e...} main stacktrace.test 24 test\ err-1.3\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-1.4 {1 {invalid command name "bogus"} {error_generator errors.tcl 6 {} error_caller {} 1 {error_generator badcm...} test stacktrace.test 25 {error_caller badcmd e...} main stacktrace.test 24 test\ err-1.4\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-2.1 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 9 {set bogus} error_caller errors.tcl 44 {error_generator badva...} test stacktrace.test 25 {error_caller badvar c...} main stacktrace.test 24 test\ err-2.1\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-2.2 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 9 {set bogus} error_caller errors.tcl 47 {error_generator badva...} test stacktrace.test 25 {error_caller badvar u...} main stacktrace.test 24 test\ err-2.2\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-2.3 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 9 {set bogus} error_caller errors.tcl 50 {error_generator badva...} test stacktrace.test 25 {error_caller badvar e...} main stacktrace.test 24 test\ err-2.3\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-2.4 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 9 {set bogus} error_caller {} 1 {error_generator badva...} test stacktrace.test 25 {error_caller badvar e...} main stacktrace.test 24 test\ err-2.4\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-3.1 {1 {unmatched "["} {error_generator errors.tcl 33 error_badproc error_generator errors.tcl 33 error_badproc error_caller errors.tcl 44 {error_generator badpr...} test stacktrace.test 25 {error_caller badproc ...} main stacktrace.test 24 test\ err-3.1\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-3.2 {1 {unmatched "["} {error_generator errors.tcl 33 error_badproc error_generator errors.tcl 33 error_badproc error_caller errors.tcl 47 {error_generator badpr...} test stacktrace.test 25 {error_caller badproc ...} main stacktrace.test 24 test\ err-3.2\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-3.3 {1 {unmatched "["} {error_generator errors.tcl 33 error_badproc error_generator errors.tcl 33 error_badproc error_caller errors.tcl 50 {error_generator badpr...} test stacktrace.test 25 {error_caller badproc ...} main stacktrace.test 24 test\ err-3.3\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-3.4 {1 {unmatched "["} {error_generator errors.tcl 33 error_badproc error_generator errors.tcl 33 error_badproc error_caller {} 1 {error_generator badpr...} test stacktrace.test 25 {error_caller badproc ...} main stacktrace.test 24 test\ err-3.4\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-4.1 {1 bogus {error_generator errors.tcl 12 {error bogus} error_caller errors.tcl 44 {error_generator error...} test stacktrace.test 25 {error_caller error ca...} main stacktrace.test 24 test\ err-4.1\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-4.2 {1 bogus {error_generator errors.tcl 12 {error bogus} error_caller errors.tcl 47 {error_generator error...} test stacktrace.test 25 {error_caller error up...} main stacktrace.test 24 test\ err-4.2\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-4.3 {1 bogus {error_generator errors.tcl 12 {error bogus} error_caller errors.tcl 50 {error_generator error...} test stacktrace.test 25 {error_caller error ev...} main stacktrace.test 24 test\ err-4.3\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-4.4 {1 bogus {error_generator errors.tcl 12 {error bogus} error_caller {} 1 {error_generator error...} test stacktrace.test 25 {error_caller error ev...} main stacktrace.test 24 test\ err-4.4\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-5.1 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 15 {} error_caller errors.tcl 44 {error_generator inter...} test stacktrace.test 25 {error_caller interpba...} main stacktrace.test 24 test\ err-5.1\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-5.2 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 15 {} error_caller errors.tcl 47 {error_generator inter...} test stacktrace.test 25 {error_caller interpba...} main stacktrace.test 24 test\ err-5.2\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-5.3 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 15 {} error_caller errors.tcl 50 {error_generator inter...} test stacktrace.test 25 {error_caller interpba...} main stacktrace.test 24 test\ err-5.3\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-5.4 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 15 {} error_caller {} 1 {error_generator inter...} test stacktrace.test 25 {error_caller interpba...} main stacktrace.test 24 test\ err-5.4\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-6.1 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 18 {} error_caller errors.tcl 44 {error_generator inter...} test stacktrace.test 25 {error_caller interpba...} main stacktrace.test 24 test\ err-6.1\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-6.2 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 18 {} error_caller errors.tcl 47 {error_generator inter...} test stacktrace.test 25 {error_caller interpba...} main stacktrace.test 24 test\ err-6.2\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-6.3 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 18 {} error_caller errors.tcl 50 {error_generator inter...} test stacktrace.test 25 {error_caller interpba...} main stacktrace.test 24 test\ err-6.3\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-6.4 {1 {can't read "bogus": no such variable} {error_generator errors.tcl 18 {} error_caller {} 1 {error_generator inter...} test stacktrace.test 25 {error_caller interpba...} main stacktrace.test 24 test\ err-6.4\ \{Stacktr... {} stacktrace.test 127 main}}
 	err-7.1 {1 {from dummyproc
-Can't load package dummy} {{} dummy.tcl 3 dummyproc dummy.tcl 6 {} errors.tcl 21 error_generator errors.tcl 44 error_caller stacktrace.test 25}}
+Can't load package dummy} {dummyproc dummy.tcl 3 error\ \{from\ dummyproc... error_generator dummy.tcl 6 dummyproc error_caller errors.tcl 44 {error_generator packa...} test stacktrace.test 25 {error_caller package ...} main stacktrace.test 24 test\ err-7.1\ \{Stacktr... {} stacktrace.test 127 main}}
 	err-7.2 {1 {from dummyproc
-Can't load package dummy} {{} dummy.tcl 3 dummyproc dummy.tcl 6 {} errors.tcl 21 error_generator errors.tcl 47 error_caller stacktrace.test 25}}
+Can't load package dummy} {dummyproc dummy.tcl 3 error\ \{from\ dummyproc... error_generator dummy.tcl 6 dummyproc error_caller errors.tcl 47 {error_generator packa...} test stacktrace.test 25 {error_caller package ...} main stacktrace.test 24 test\ err-7.2\ \{Stacktr... {} stacktrace.test 127 main}}
 	err-7.3 {1 {from dummyproc
-Can't load package dummy} {{} dummy.tcl 3 dummyproc dummy.tcl 6 {} errors.tcl 21 error_generator errors.tcl 50 error_caller stacktrace.test 25}}
+Can't load package dummy} {dummyproc dummy.tcl 3 error\ \{from\ dummyproc... error_generator dummy.tcl 6 dummyproc error_caller errors.tcl 50 {error_generator packa...} test stacktrace.test 25 {error_caller package ...} main stacktrace.test 24 test\ err-7.3\ \{Stacktr... {} stacktrace.test 127 main}}
 	err-7.4 {1 {from dummyproc
-Can't load package dummy} {{} dummy.tcl 3 dummyproc dummy.tcl 6 {} errors.tcl 21 error_generator errors.tcl 53 error_caller stacktrace.test 25}}
-	err-8.1 {1 {from dummyproc} {{} dummy.tcl 3 dummyproc dummy.tcl 6 {} errors.tcl 24 error_generator errors.tcl 44 error_caller stacktrace.test 25}}
-	err-8.2 {1 {from dummyproc} {{} dummy.tcl 3 dummyproc dummy.tcl 6 {} errors.tcl 24 error_generator errors.tcl 47 error_caller stacktrace.test 25}}
-	err-8.3 {1 {from dummyproc} {{} dummy.tcl 3 dummyproc dummy.tcl 6 {} errors.tcl 24 error_generator errors.tcl 50 error_caller stacktrace.test 25}}
-	err-8.4 {1 {from dummyproc} {{} dummy.tcl 3 dummyproc dummy.tcl 6 {} errors.tcl 24 error_generator errors.tcl 53 error_caller stacktrace.test 25}}
-	err-9.1 {1 {Can't load package bogus} {{} errors.tcl 27 error_generator errors.tcl 44 error_caller stacktrace.test 25}}
-	err-9.2 {1 {Can't load package bogus} {{} errors.tcl 27 error_generator errors.tcl 47 error_caller stacktrace.test 25}}
-	err-9.3 {1 {Can't load package bogus} {{} errors.tcl 27 error_generator errors.tcl 50 error_caller stacktrace.test 25}}
-	err-9.4 {1 {Can't load package bogus} {{} errors.tcl 27 error_generator errors.tcl 53 error_caller stacktrace.test 25}}
-	err-10.1 {1 failure {{} errors.tcl 44 error_caller stacktrace.test 25}}
-	err-10.2 {1 failure {{} errors.tcl 47 error_caller stacktrace.test 25}}
-	err-10.3 {1 failure {{} errors.tcl 50 error_caller stacktrace.test 25}}
-	err-10.4 {1 failure {{} errors.tcl 53 error_caller stacktrace.test 25}}
+Can't load package dummy} {dummyproc dummy.tcl 3 error\ \{from\ dummyproc... error_generator dummy.tcl 6 dummyproc error_caller {} 1 {error_generator packa...} test stacktrace.test 25 {error_caller package ...} main stacktrace.test 24 test\ err-7.4\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-8.1 {1 {from dummyproc} {dummyproc dummy.tcl 3 error\ \{from\ dummyproc... error_generator dummy.tcl 6 dummyproc error_caller errors.tcl 44 {error_generator sourc...} test stacktrace.test 25 {error_caller source c...} main stacktrace.test 24 test\ err-8.1\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-8.2 {1 {from dummyproc} {dummyproc dummy.tcl 3 error\ \{from\ dummyproc... error_generator dummy.tcl 6 dummyproc error_caller errors.tcl 47 {error_generator sourc...} test stacktrace.test 25 {error_caller source u...} main stacktrace.test 24 test\ err-8.2\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-8.3 {1 {from dummyproc} {dummyproc dummy.tcl 3 error\ \{from\ dummyproc... error_generator dummy.tcl 6 dummyproc error_caller errors.tcl 50 {error_generator sourc...} test stacktrace.test 25 {error_caller source e...} main stacktrace.test 24 test\ err-8.3\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-8.4 {1 {from dummyproc} {dummyproc dummy.tcl 3 error\ \{from\ dummyproc... error_generator dummy.tcl 6 dummyproc error_caller {} 1 {error_generator sourc...} test stacktrace.test 25 {error_caller source e...} main stacktrace.test 24 test\ err-8.4\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-9.1 {1 {Can't load package bogus} {error_generator errors.tcl 27 {package require bogus...} error_caller errors.tcl 44 {error_generator badpa...} test stacktrace.test 25 {error_caller badpacka...} main stacktrace.test 24 test\ err-9.1\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-9.2 {1 {Can't load package bogus} {error_generator errors.tcl 27 {package require bogus...} error_caller errors.tcl 47 {error_generator badpa...} test stacktrace.test 25 {error_caller badpacka...} main stacktrace.test 24 test\ err-9.2\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-9.3 {1 {Can't load package bogus} {error_generator errors.tcl 27 {package require bogus...} error_caller errors.tcl 50 {error_generator badpa...} test stacktrace.test 25 {error_caller badpacka...} main stacktrace.test 24 test\ err-9.3\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-9.4 {1 {Can't load package bogus} {error_generator errors.tcl 27 {package require bogus...} error_caller {} 1 {error_generator badpa...} test stacktrace.test 25 {error_caller badpacka...} main stacktrace.test 24 test\ err-9.4\ \{Stacktr... {} stacktrace.test 127 main}}
+	err-10.1 {1 failure {error_caller errors.tcl 44 {error_generator retur...} test stacktrace.test 25 {error_caller returnco...} main stacktrace.test 24 test\ err-10.1\ \{Stackt... {} stacktrace.test 127 main}}
+	err-10.2 {1 failure {error_caller errors.tcl 47 {error_generator retur...} test stacktrace.test 25 {error_caller returnco...} main stacktrace.test 24 test\ err-10.2\ \{Stackt... {} stacktrace.test 127 main}}
+	err-10.3 {1 failure {error_caller errors.tcl 50 {error_generator retur...} test stacktrace.test 25 {error_caller returnco...} main stacktrace.test 24 test\ err-10.3\ \{Stackt... {} stacktrace.test 127 main}}
+	err-10.4 {1 failure {error_caller {} 1 {error_generator retur...} test stacktrace.test 25 {error_caller returnco...} main stacktrace.test 24 test\ err-10.4\ \{Stackt... {} stacktrace.test 127 main}}
 }
 
 # Set this to output expected results to stderr


### PR DESCRIPTION
This is a proposal to improve error handling and stack traces. Comments are welcome.
This makes error messages generally more readable (natural order and includes command). e.g.:

```
        t4.tcl:2: Error: syntax error in expression: "blah"
        Traceback (most recent call last):
          File "t4.tcl", line 14
            c 1 2 3
          File "t4.tcl", line 10, in c
            b a c
          File "t4.tcl", line 6, in b
            a A14
          File "t4.tcl", line 2, in a
            expr blah
```

Also when an error is caught, the stacktrace includes the entire stacktrace (from the interp top level), not just back to where the error was caught.