### PR TITLE
core: add support for proc static variables by reference

### DIFF
--- a/jim.h
+++ b/jim.h
@@ -308,7 +308,7 @@ typedef struct Jim_Obj {
         } ptrIntValue;
         /* Variable object */
         struct {
-            struct Jim_Var *varPtr;
+            struct Jim_VarVal *vv;
             unsigned long callFrameId; /* for caching */
             int global; /* If the variable name is globally scoped with :: */
         } varValue;
@@ -458,17 +458,18 @@ typedef struct Jim_EvalFrame {
     Jim_Obj *scriptObj;
 } Jim_EvalFrame;
 
-/* The var structure. It just holds the pointer of the referenced
- * object. If linkFramePtr is not NULL the variable is a link
+/* The var structure. It holds the pointer of the referenced
+ * object and a reference count. If linkFramePtr is not NULL the variable is a link
  * to a variable of name stored in objPtr living in the given callframe
  * (this happens when the [global] or [upvar] command is used).
- * The interp in order to always know how to free the Jim_Obj associated
- * with a given variable because in Jim objects memory management is
+ * refCount is normally 1, but may be more than 1 if this has additional references
+ * (e.g. from proc static &var)
  * bound to interpreters. */
-typedef struct Jim_Var {
+typedef struct Jim_VarVal {
     Jim_Obj *objPtr;
     struct Jim_CallFrame *linkFramePtr;
-} Jim_Var;
+    int refCount;
+} Jim_VarVal;
 
 /* The cmd structure. */
 typedef int Jim_CmdProc(struct Jim_Interp *interp, int argc,

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -61,6 +61,7 @@ Changes since 0.82
 5. Improvements with `aio`, related to eventloop and buffering. Add `aio timeout`.
 6. `socket` , `open` and `aio accept` now support '-noclose'
 7. Add support for hinting with `history hints`
+8. Support for `proc` statics by reference (lexical closure) rather than by value
 
 Changes between 0.81 and 0.82
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1368,6 +1369,25 @@ has an initialiser, so it is initialised to 2.
 
 Unlike a local variable, the value of a static variable is retained across
 invocations of the procedure.
+
+In addition to static variables by value, static variables may also be
+defined by "reference" by using a leading "&" character. In this case,
+the statics point to the original variable and when one changes, they
+both change.  For example, here 'a' changes changes the value of the
+original 'x'.
+
+----
+    . set x 1
+    . proc a {} {&x} {
+        incr x
+    }
+    . a
+    2
+    . a
+    3
+    . puts $x
+    3
+----
 
 See the `proc` command for information on how to define procedures
 and what happens when they are invoked. See also <<_namespaces,NAMESPACES>>.

--- a/tests/procstatic.test
+++ b/tests/procstatic.test
@@ -1,0 +1,168 @@
+source [file dirname [info script]]/testing.tcl
+
+needs constraint jim
+
+test procstatic-1.1 "Simple statics by value with initialiser" {
+	proc a {} {{b 1} {c "two"}} {
+		incr b
+		append c -three
+		list $b $c
+	}
+	a
+} {2 two-three}
+
+test procstatic-1.2 "static by value from local scope" {
+	set b 1
+	set c two
+	proc a {} {b c} {
+		incr b
+		append c -three
+		list $b $c
+	}
+	list [a] $b $c
+} {{2 two-three} 1 two}
+
+test procstatic-1.3 "static by reference from local scope" {
+	set b 1
+	set c two
+	proc a {} {&b &c} {
+		incr b
+		append c -three
+		list $b $c
+	}
+	list [a] $b $c
+} {{2 two-three} 2 two-three}
+
+test procstatic-1.4 "static by reference shared between procs" {
+	set c 0
+	proc a {} {&c} {
+		incr c
+	}
+	proc b {} {&c} {
+		incr c 10
+	}
+	list [a] [b] [a] [b] $c
+} {1 11 12 22 22}
+
+test procstatic-1.5 "static by reference that goes out of scope" {
+	proc p {c} {
+		proc a {} {&c} {
+			incr c
+		}
+		proc b {} {&c} {
+			incr c 10
+		}
+	}
+	p 100
+	# Now c no longer exists but the reference is maintained by a and b
+	list [a] [b] [a] [b]
+} {101 111 112 122}
+
+test procstatic-1.5 "static by reference to upvar" {
+	set cc 5
+	proc p {&c} {
+		proc a {} {&c} {
+			incr c
+		}
+		proc b {} {&c} {
+			incr c 10
+		}
+	}
+	p cc
+	# a and b maintain a reference to cc by upvar. When we unset cc the link
+	# is dangling so the first incr will start with 0
+	unset cc
+	list [a] [b] [a] [b]
+} {1 11 12 22}
+
+test procstatic-1.6 "static by reference to upvar to array element" {
+	set cc {d 5}
+	proc p {} {
+		upvar cc(d) c
+		proc a {} {&c} {
+			incr c
+		}
+		proc b {} {&c} {
+			incr c 10
+		}
+	}
+	p
+	list [a] [b] [a] [b]
+} {6 16 17 27}
+
+# This test doesn't work yet because upvar simply keeps the name of the target
+# variable, not a reference to the variable so when it goes out of scope
+# the link is lost.
+# test procstatic-1.7 "static by reference to upvar that goes out of scope" {
+# 	proc q {} {
+# 		set cc 5
+# 		proc p {&c} {
+# 			proc a {} {&c} {
+# 				incr c
+# 			}
+# 			proc b {} {&c} {
+# 				incr c 10
+# 			}
+# 		}
+# 		p cc
+# 	}
+# 	q
+# 	# Now cc is out of scope. The stack frame the c points to is gone.
+# 	list [a] [b] [a] [b]
+# } {1 11 12 22}
+
+test procstatic-1.8 {lambda with reference} {
+	# Returns a lambda that appends to the given variable
+	proc a {&b sep} {
+		lambda {c} {&b sep} {
+			append b $sep$c
+		}
+	}
+	# Invoke the function with the arg.
+	# The updated variable will be in the original scope
+	proc p {f add} {
+		$f $add
+	}
+	set bb 5
+	# Create our two functions that both modify bb
+	set f [a bb -]
+	set f2 [a bb +]
+	# Call them a few times
+	p $f test
+	p $f2 again
+	p $f first
+} {5-test+again-first}
+
+test procstatic-2.1 {invalid static - array element} -body {
+    set b {1 2}
+    proc a {} {b(1)} {
+        return $b(1)
+    }
+    a
+} -returnCodes error -result {Can't initialise array element "b(1)"}
+
+test procstatic-2.2 {invalid static - array element by ref} -body {
+    set b {1 2}
+    proc a {} {&b(1)} {
+        return $b(1)
+    }
+    a
+} -returnCodes error -result {Can't link to array element "b(1)"}
+
+test procstatic-2.3 {invalid static - missing} -body {
+    unset -nocomplain b
+    proc a {} {b} {
+        return $b
+    }
+    a
+} -returnCodes error -result {variable for initialization of static "b" not found in the local context}
+
+test procstatic-2.4 {invalid static - missing, by ref} -body {
+    unset -nocomplain b
+    proc a {} {&b} {
+        return $b
+    }
+    a
+} -returnCodes error -result {variable for initialization of static "b" not found in the local context}
+
+testreport


### PR DESCRIPTION
This is an experimental feature that allows for lexical closures in Jim Tcl by allowing procs (and lambdas) to capture variables by reference rather than by value. e.g.

```
set a 5

proc b {} {&a} {
	incr a
}

b
```
Now a is 6 because b captured a by reference instead of by value