### PR TITLE
info script: recurse up until the innermost fileObj is found, if any

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -15655,7 +15655,15 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
             return JIM_OK;
 
         case INFO_SCRIPT:
-            Jim_SetResult(interp, JimGetScript(interp, interp->evalFrame->scriptObj)->fileNameObj);
+			Jim_EvalFrame *f = interp->evalFrame;
+			ScriptObj *s;
+			while (1) {
+				s = JimGetScript(interp, f->scriptObj);
+				if (s->fileNameObj != interp->emptyObj) break;
+				if (f->parent == &interp->topEvalFrame) break;
+				f = f->parent;
+			}
+			Jim_SetResult(interp, s->fileNameObj);
             return JIM_OK;
 
         case INFO_SOURCE:{


### PR DESCRIPTION
If `info script` is wrapped into a `proc`, and the `proc` is then called from inside a `source`d script, the `fileObj` for the script is not found.

Reproduce:
```
rename info jimsh::info
proc info {command args} {jimsh::info $command {*}$args}
source test.tcl
```
`test.tc`l:
```
puts [jimsh::info script]
puts [info script]
```
Expected result is:
```
test.tcl
test.tcl
```
Result is:
```
test.tcl

```
This PR tries to solve the problem by going up the `evalFrame` until either finding a `fileObj` or reaching the `topEvalFrame` and works for the test. However I'm unfamiliar with the jimsh code base and just guessing. Please apologize any style flaws.
