### PR TITLE
Distribute JimTcl using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+ARG JIMTCL_DIR=/root/jimtcl
+ARG CONFIGURE_ARGS=""
+
+
+FROM alpine AS build
+ARG JIMTCL_DIR
+ARG CONFIGURE_ARGS
+
+RUN apk add --update build-base
+
+WORKDIR "$JIMTCL_DIR"
+COPY . .
+RUN ./configure $CONFIGURE_ARGS
+RUN make
+
+
+FROM alpine
+ARG JIMTCL_DIR
+
+RUN apk add --update make
+
+COPY --from=build "$JIMTCL_DIR" "$JIMTCL_DIR"
+RUN cd $JIMTCL_DIR && make install
+RUN rm -rf "$JIMTCL_DIR"
+
+ENTRYPOINT ["jimsh"]


### PR DESCRIPTION
This PR aims to start (automatized) distribution of JimTcl through Docker.

I'm submitting a working Dockerfile, but probably this PR should be followed by Travis changes to build the Docker image and push it to the hub.