### PR TITLE
reorder SDL text command help to match parsing

### DIFF
--- a/jim-sdl.c
+++ b/jim-sdl.c
@@ -446,7 +446,7 @@ static const jim_subcmd_type sdl_command_table[] = {
         2,
     },
     {   "text",
-        "x y string red green blue ?alpha?",
+        "string x y red green blue ?alpha?",
         jim_sdl_subcmd_text,
         6,
         7,


### PR DESCRIPTION
Here's a very small patch to fix the ordering of the SDL `text` subcommand help, which was not what was being parsed. The string to be drawn is in fact the first argument. 

In first looking at this, I thought it might make sense to change the _parsing_ to match the help text, but that's more complicated and is unlike any other SDL subcommand in that it features multiple numeric arguments _and_ a string. Due to the way that `JimSdlGetLongs()` is used, having the string argument be in the middle of the numeric arguments makes this a bit more wordy and error-prone. I could certainly submit it that way, but I think an argument is equally able to be made, since `text` is unique, that the string argument does in fact come first, followed by all the numeric arguments in the same order as several other subcommands. 

Lastly, this change doesn’t break any existing code which makes use of the extension. 