### PR TITLE
clock: Fix DST problem in [clock scan] using "-gmt 0"

### DIFF
--- a/jim-clock.c
+++ b/jim-clock.c
@@ -131,6 +131,7 @@ static int clock_cmd_scan(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     }
 
     /* Now convert into a time_t */
+    tm.tm_isdst = options.gmt ? 0 : -1;
     Jim_SetResultInt(interp, options.gmt ? jim_timegm(&tm) : mktime(&tm));
 
     return JIM_OK;


### PR DESCRIPTION
Currently (in the UK, pre-DST, with "now" set to 1711500000):
```
. clock scan {2024-03-31 00:00:00} -format {%F %T} -gmt 0	;# Correct
1711843200
. clock scan {2024-03-31 00:00:00} -format {%F %T} -gmt 1	;# Correct
1711843200

. clock scan {2024-04-01 00:00:00} -format {%F %T} -gmt 0	;# Wrong
1711929600
. clock scan {2024-04-01 00:00:00} -format {%F %T} -gmt 1	;# Correct
1711929600
```
Next week (post-DST, with "now" set to 1712000000):
```
. clock scan {2024-03-31 00:00:00} -format {%F %T} -gmt 0	;# Wrong
1711839600
. clock scan {2024-03-31 00:00:00} -format {%F %T} -gmt 1	;# Correct
1711843200

. clock scan {2024-04-01 00:00:00} -format {%F %T} -gmt 0	;# Correct
1711926000
. clock scan {2024-04-01 00:00:00} -format {%F %T} -gmt 1	;# Correct
1711929600
```
This because tm.tm_isdst is set by localtime_r() using "now" set by time(NULL).
It is nonsensical to specify a date to convert and have the DST flag used in the conversion set from another (i.e. the current) date.

With the patch (set tm.tm_isdst to -1 and leave mktime() to figure it out), it is correct under all circumstances:
```
. clock scan {2024-03-31 00:00:00} -format {%F %T} -gmt 0	;# Correct
1711843200
. clock scan {2024-03-31 00:00:00} -format {%F %T} -gmt 1	;# Correct
1711843200

. clock scan {2024-04-01 00:00:00} -format {%F %T} -gmt 0	;# Correct
1711926000
. clock scan {2024-04-01 00:00:00} -format {%F %T} -gmt 1	;# Correct
1711929600
```
For reference:
```
. clock format 1711839600 -format {%F %T %Z} -gmt 1
2024-03-30 23:00:00 GMT

. clock format 1711843200 -format {%F %T %Z} -gmt 1
2024-03-31 00:00:00 GMT

. clock format 1711926000 -format {%F %T %Z} -gmt 1
2024-03-31 23:00:00 GMT

. clock format 1711929600 -format {%F %T %Z} -gmt 1
2024-04-01 00:00:00 GMT
```
