### PR TITLE
Proposal for a new 'leval' command

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -11136,16 +11136,16 @@ static Jim_Obj *JimInterpolateTokens(Jim_Interp *interp, const ScriptToken * tok
     return objPtr;
 }
 
-#define JIM_LEVAL_LINE 0x0001
+#define JIM_LSUBST_LINE 0x0001
 
-/* Parse a string as an 'leval' argument and sets the interp result.
+/* Parse a string as an 'lsubst' argument and sets the interp result.
  * Return JIM_OK if ok, or JIM_ERR on error.
  *
  * Modelled on Jim_EvalObj()
  * 
- * If flags contains JIM_LEVAL_LINE, each "statement" is returned as list of {command arg...}
+ * If flags contains JIM_LSUBST_LINE, each "statement" is returned as list of {command arg...}
  */
-static int JimListEvalObj(Jim_Interp *interp, struct Jim_Obj *objPtr, unsigned flags)
+static int JimListSubstObj(Jim_Interp *interp, struct Jim_Obj *objPtr, unsigned flags)
 {
     int i;
     ScriptObj *script;
@@ -11181,7 +11181,7 @@ static int JimListEvalObj(Jim_Interp *interp, struct Jim_Obj *objPtr, unsigned f
         /* Skip the JIM_TT_LINE token */
         i++;
 
-        if (flags & JIM_LEVAL_LINE) {
+        if (flags & JIM_LSUBST_LINE) {
             lineListObj = Jim_NewListObj(interp, NULL, 0);
         }
 
@@ -11225,7 +11225,7 @@ static int JimListEvalObj(Jim_Interp *interp, struct Jim_Obj *objPtr, unsigned f
             Jim_DecrRefCount(interp, wordObjPtr);
         }
 
-        if (flags & JIM_LEVAL_LINE) {
+        if (flags & JIM_LSUBST_LINE) {
             Jim_ListAppendElement(interp, resultListObj, lineListObj);
         }
     }
@@ -15701,14 +15701,14 @@ static int Jim_SubstCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
     return JIM_OK;
 }
 
-/* [leval] */
-static int Jim_LevalCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+/* [lsubst] */
+static int Jim_LsubstCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     if (argc == 2) {
-        return JimListEvalObj(interp, argv[1], 0);
+        return JimListSubstObj(interp, argv[1], 0);
     }
     if (argc == 3 && Jim_CompareStringImmediate(interp, argv[1], "-line")) {
-        return JimListEvalObj(interp, argv[2], JIM_LEVAL_LINE);
+        return JimListSubstObj(interp, argv[2], JIM_LSUBST_LINE);
     }
     Jim_WrongNumArgs(interp, 1, argv, "?-line? string");
     return JIM_ERR;
@@ -16620,7 +16620,7 @@ static const struct {
     {"rename", Jim_RenameCoreCommand},
     {"dict", Jim_DictCoreCommand},
     {"subst", Jim_SubstCoreCommand},
-    {"leval", Jim_LevalCoreCommand},
+    {"lsubst", Jim_LsubstCoreCommand},
     {"info", Jim_InfoCoreCommand},
     {"exists", Jim_ExistsCoreCommand},
     {"split", Jim_SplitCoreCommand},

--- a/jim.c
+++ b/jim.c
@@ -11045,6 +11045,7 @@ static Jim_Obj *JimInterpolateTokens(Jim_Interp *interp, const ScriptToken * tok
     Jim_Obj *sintv[JIM_EVAL_SINTV_LEN];
     Jim_Obj *objPtr;
     char *s;
+    const char *error_action = NULL;
 
     if (tokens <= JIM_EVAL_SINTV_LEN)
         intv = sintv;
@@ -11064,14 +11065,16 @@ static Jim_Obj *JimInterpolateTokens(Jim_Interp *interp, const ScriptToken * tok
                     tokens = i;
                     continue;
                 }
-                /* XXX: Should probably set an error about break outside loop */
+                error_action = "break";
                 /* fall through to error */
             case JIM_CONTINUE:
                 if (flags & JIM_SUBST_FLAG) {
                     intv[i] = NULL;
                     continue;
                 }
-                /* XXX: Ditto continue outside loop */
+                if (!error_action) {
+                    error_action = "continue";
+                }
                 /* fall through to error */
             default:
                 while (i--) {
@@ -11079,6 +11082,9 @@ static Jim_Obj *JimInterpolateTokens(Jim_Interp *interp, const ScriptToken * tok
                 }
                 if (intv != sintv) {
                     Jim_Free(intv);
+                }
+                if (error_action) {
+                    Jim_SetResultFormatted(interp, "invoked \"%s\" outside of a loop", error_action);
                 }
                 return NULL;
         }

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -3124,7 +3124,7 @@ than variables, a list of unassigned elements is returned.
 leval
 ~~~~
 
-+*leval* 'string'+
++*leval ?-line?* 'string'+
 
 This command is similar to `list` in that it creates a list, but uses
 the same rules as scripts when constructing the elements of the list.
@@ -3158,6 +3158,26 @@ The result of `leval` is the following list with 7 elements.
 This is particularly useful when constructing a list (or dict)
 as a data structure as it easily allows for comments and variable and command
 substitution.
+
+Sometimes it is useful to return each "command" as a separate list rather than
+simply running all the words together. This can be accomplished with `leval -line`.
+
+Consider the following example.
+
+---
+    leval -line {
+        # two "lines" because of the semicolon
+        one a; two b
+        # one line with three elements
+        {*}{a b c}
+    }
+---
+
+The result of `leval -line` is the following list with 3 elements, one for each "command".
+
+---
+{one a} {two b} {a b c}
+---
 
 local
 ~~~~~

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -63,7 +63,7 @@ Changes since 0.82
 7. Add support for hinting with `history hints`
 8. Support for `proc` statics by reference (lexical closure) rather than by value
 9. `regsub` now supports '-command' (per Tcl 8.7)
-10. New `leval` command to create lists using subst-style substitution
+10. New `lsubst` command to create lists using subst-style substitution
 
 Changes between 0.81 and 0.82
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3121,10 +3121,10 @@ than variables, a list of unassigned elements is returned.
     a=1,b=2
 ----
 
-leval
+lsubst
 ~~~~
 
-+*leval ?-line?* 'string'+
++*lsubst ?-line?* 'string'+
 
 This command is similar to `list` in that it creates a list, but uses
 the same rules as scripts when constructing the elements of the list.
@@ -3139,7 +3139,7 @@ Consider the following example.
     set x 1
     set y {2 3}
     set z 3
-    leval {
+    lsubst {
         # This is a list with interpolation
         $x; # The x variable
         {*}$y; # The y variable expanded
@@ -3149,7 +3149,7 @@ Consider the following example.
     }
 ---
 
-The result of `leval` is the following list with 7 elements.
+The result of `lsubst` is the following list with 7 elements.
 
 ---
     1 2 3 abc 4 5 33
@@ -3160,12 +3160,12 @@ as a data structure as it easily allows for comments and variable and command
 substitution.
 
 Sometimes it is useful to return each "command" as a separate list rather than
-simply running all the words together. This can be accomplished with `leval -line`.
+simply running all the words together. This can be accomplished with `lsubst -line`.
 
 Consider the following example.
 
 ---
-    leval -line {
+    lsubst -line {
         # two "lines" because of the semicolon
         one a; two b
         # one line with three elements
@@ -3173,7 +3173,7 @@ Consider the following example.
     }
 ---
 
-The result of `leval -line` is the following list with 3 elements, one for each "command".
+The result of `lsubst -line` is the following list with 3 elements, one for each "command".
 
 ---
 {one a} {two b} {a b c}

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -63,6 +63,7 @@ Changes since 0.82
 7. Add support for hinting with `history hints`
 8. Support for `proc` statics by reference (lexical closure) rather than by value
 9. `regsub` now supports '-command' (per Tcl 8.7)
+10. New `leval` command to create lists using subst-style substitution
 
 Changes between 0.81 and 0.82
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3119,6 +3120,44 @@ than variables, a list of unassigned elements is returned.
     3
     a=1,b=2
 ----
+
+leval
+~~~~
+
++*leval* 'string'+
+
+This command is similar to `list` in that it creates a list, but uses
+the same rules as scripts when constructing the elements of the list.
+It is somewhat similar to `subst` except it produces a list instead of a string.
+
+This means that variables are substituted, commands are evaluated, backslashes are
+interpreted, the expansion operator is applied and comments are skipped.
+
+Consider the following example.
+
+---
+    set x 1
+    set y {2 3}
+    set z 3
+    leval {
+        # This is a list with interpolation
+        $x; # The x variable
+        {*}$y; # The y variable expanded
+        [string cat a b c]; # A command
+        {*}[list 4 5]; # A list expanded into multiple elements
+        "$z$z"; # A string with interpolation
+    }
+---
+
+The result of `leval` is the following list with 7 elements.
+
+---
+    1 2 3 abc 4 5 33
+---
+
+This is particularly useful when constructing a list (or dict)
+as a data structure as it easily allows for comments and variable and command
+substitution.
 
 local
 ~~~~~

--- a/tests/exec2.test
+++ b/tests/exec2.test
@@ -70,8 +70,9 @@ test exec2-3.2 "close pipeline return value" -constraints {pipe signal nomingw32
 	signal ignore SIGPIPE
 	# Write more than 64KB which is maximum size of the pipe buffers
 	# on all systems we have seen
-	set bigstring [string repeat a 100000]
-	set f [open [list |cat << $bigstring]]
+	set bigstring [string repeat a 100]
+	set f [open [list |dd bs=512 << $bigstring]]
+	puts pid=[$f pid]
 	set rc [catch {close $f} msg opts]
 	lassign [dict get $opts -errorcode] status pid exitcode
 	list $rc $msg $status $exitcode
@@ -81,7 +82,7 @@ test exec2-3.3 "close pipeline with SIGPIPE blocked" -constraints {pipe signal n
 	signal block SIGPIPE
 	# Write more than 64KB which is maximum size of the pipe buffers
 	# on all systems we have seen
-	set bigstring [string repeat a 100000]
+	set bigstring [string repeat a 100]
 	set f [open [list |cat << $bigstring 2>/dev/null]]
 	set rc [catch {close $f} msg opts]
 	lassign [dict get $opts -errorcode] status pid exitcode

--- a/tests/leval.test
+++ b/tests/leval.test
@@ -1,0 +1,59 @@
+source [file dirname [info script]]/testing.tcl
+
+needs cmd leval
+
+test leval-1.1 {no args} -body {
+    leval
+} -returnCodes error -result {wrong # args: should be "leval string"}
+
+test leval-1.2 {too many args} -body {
+    leval
+} -returnCodes error -result {wrong # args: should be "leval string"}
+
+test leval-1.3 {basic, no subst} -body {
+    leval {a b c}
+} -result {a b c}
+
+test leval-1.4 {basics, vars} -body {
+    set a 1
+    set b "2 3"
+    set c "4 5 6"
+    set d ".1"
+    leval {$a $b $c$d}
+} -result {1 {2 3} {4 5 6.1}}
+
+test leval-1.5 {comments} -body {
+    # It is helpful to be able to include comments in a list definition
+    # just like in a script
+    leval {
+        # comment line
+        1
+        2 3
+        # comment line with continuation \
+        this is also a comments
+        4 ;# comment at end of line
+        5
+    }
+} -result {1 2 3 4 5}
+
+test leval-1.6 {commands} -body {
+    set a 0
+    leval {
+        [incr a]
+        [incr a]
+        [list d e]
+        [string cat f g][string cat h i]
+    }
+} -result {1 2 {d e} fghi}
+
+test leval-1.7 {expand} -body {
+    set a {1 2}
+	set space " "
+    set b {3 4 5}
+    leval {
+        {*}$a
+        {*}$a$space$b$space[list 6 7]
+    }
+} -result {1 2 1 2 3 4 5 6 7}
+
+testreport

--- a/tests/leval.test
+++ b/tests/leval.test
@@ -4,11 +4,11 @@ needs cmd leval
 
 test leval-1.1 {no args} -body {
     leval
-} -returnCodes error -result {wrong # args: should be "leval string"}
+} -returnCodes error -result {wrong # args: should be "leval ?-line? string"}
 
 test leval-1.2 {too many args} -body {
-    leval
-} -returnCodes error -result {wrong # args: should be "leval string"}
+    leval a b c
+} -returnCodes error -result {wrong # args: should be "leval ?-line? string"}
 
 test leval-1.3 {basic, no subst} -body {
     leval {a b c}
@@ -48,7 +48,7 @@ test leval-1.6 {commands} -body {
 
 test leval-1.7 {expand} -body {
     set a {1 2}
-	set space " "
+    set space " "
     set b {3 4 5}
     leval {
         {*}$a
@@ -57,72 +57,83 @@ test leval-1.7 {expand} -body {
 } -result {1 2 1 2 3 4 5 6 7}
 
 test leval-1.8 {empty case} -body {
-	leval {
-		# Nothing
-	}
+    leval {
+        # Nothing
+    }
 } -result {}
 
 test leval-1.9 {backslash escapes} -body {
-	leval {
-		# char escapes
-		\r\n\t
-		# unicode escapes
-		\u00b5
-		# hex escapes
-		\x41\x42
-	}
+    leval {
+        # char escapes
+        \r\n\t
+        # unicode escapes
+        \u00b5
+        # hex escapes
+        \x41\x42
+    }
 } -result [list \r\n\t \u00b5 AB]
 
+test leval-1.10 {simple -line} -body {
+    set a {1 2}
+    set b {3 4 5}
+    leval -line {
+        # This line won't produce a list, but the next will produce a list with two elements
+        {*}$a
+        # And this one will have three elements
+        one two $b
+    }
+} -result {{1 2} {one two {3 4 5}}}
+
 test leval-2.1 {error, missing [} -body {
-	leval {
-		# Missing bracket
-		[string cat
-	}
+    leval {
+        # Missing bracket
+        [string cat
+    }
 } -returnCodes error -result {unmatched "["}
 
 test leval-2.2 {error, invalid command} -body {
-	leval {
-		a
-		[dummy]
-		b
-	}
+    leval {
+        a
+        [dummy]
+        b
+    }
 } -returnCodes error -result {invalid command name "dummy"}
 
 test leval-2.3 {error, unset variable} -body {
-	leval {
-		a
-		$doesnotexist
-		b
-	}
+    leval {
+        a
+        $doesnotexist
+        b
+    }
 } -returnCodes error -result {can't read "doesnotexist": no such variable}
 
 test leval-2.4 {break} -body {
-	leval {
-		a
-		[break]
-		b
-	}
+    leval {
+        a
+        [break]
+        b
+    }
 } -returnCodes error -result {invoked "break" outside of a loop}
 
 test leval-2.5 {continue} -body {
-	leval {
-		a
-		[continue]
-		b
-	}
+    leval {
+        a
+        [continue]
+        b
+    }
 } -returnCodes error -result {invoked "continue" outside of a loop}
 
 test leval-3.1 {preservation of line numbers} -body {
-	set x abc
-	set src1 [info source $x]
-	set list [leval {
-		a
-		$x
-		b
-	}]
-	if {[info source [lindex $list 1]] ne [info source $x]} {
-		error "source does not match
-	}
+    set x abc
+    set src1 [info source $x]
+    set list [leval {
+        a
+        $x
+        b
+    }]
+    if {[info source [lindex $list 1]] ne [info source $x]} {
+        error "source does not match
+    }
 } -result {}
 
 testreport

--- a/tests/leval.test
+++ b/tests/leval.test
@@ -56,4 +56,73 @@ test leval-1.7 {expand} -body {
     }
 } -result {1 2 1 2 3 4 5 6 7}
 
+test leval-1.8 {empty case} -body {
+	leval {
+		# Nothing
+	}
+} -result {}
+
+test leval-1.9 {backslash escapes} -body {
+	leval {
+		# char escapes
+		\r\n\t
+		# unicode escapes
+		\u00b5
+		# hex escapes
+		\x41\x42
+	}
+} -result [list \r\n\t \u00b5 AB]
+
+test leval-2.1 {error, missing [} -body {
+	leval {
+		# Missing bracket
+		[string cat
+	}
+} -returnCodes error -result {unmatched "["}
+
+test leval-2.2 {error, invalid command} -body {
+	leval {
+		a
+		[dummy]
+		b
+	}
+} -returnCodes error -result {invalid command name "dummy"}
+
+test leval-2.3 {error, unset variable} -body {
+	leval {
+		a
+		$doesnotexist
+		b
+	}
+} -returnCodes error -result {can't read "doesnotexist": no such variable}
+
+test leval-2.4 {break} -body {
+	leval {
+		a
+		[break]
+		b
+	}
+} -returnCodes error -result {invoked "break" outside of a loop}
+
+test leval-2.5 {continue} -body {
+	leval {
+		a
+		[continue]
+		b
+	}
+} -returnCodes error -result {invoked "continue" outside of a loop}
+
+test leval-3.1 {preservation of line numbers} -body {
+	set x abc
+	set src1 [info source $x]
+	set list [leval {
+		a
+		$x
+		b
+	}]
+	if {[info source [lindex $list 1]] ne [info source $x]} {
+		error "source does not match
+	}
+} -result {}
+
 testreport

--- a/tests/lsubst.test
+++ b/tests/lsubst.test
@@ -1,31 +1,31 @@
 source [file dirname [info script]]/testing.tcl
 
-needs cmd leval
+needs cmd lsubst
 
-test leval-1.1 {no args} -body {
-    leval
-} -returnCodes error -result {wrong # args: should be "leval ?-line? string"}
+test lsubst-1.1 {no args} -body {
+    lsubst
+} -returnCodes error -result {wrong # args: should be "lsubst ?-line? string"}
 
-test leval-1.2 {too many args} -body {
-    leval a b c
-} -returnCodes error -result {wrong # args: should be "leval ?-line? string"}
+test lsubst-1.2 {too many args} -body {
+    lsubst a b c
+} -returnCodes error -result {wrong # args: should be "lsubst ?-line? string"}
 
-test leval-1.3 {basic, no subst} -body {
-    leval {a b c}
+test lsubst-1.3 {basic, no subst} -body {
+    lsubst {a b c}
 } -result {a b c}
 
-test leval-1.4 {basics, vars} -body {
+test lsubst-1.4 {basics, vars} -body {
     set a 1
     set b "2 3"
     set c "4 5 6"
     set d ".1"
-    leval {$a $b $c$d}
+    lsubst {$a $b $c$d}
 } -result {1 {2 3} {4 5 6.1}}
 
-test leval-1.5 {comments} -body {
+test lsubst-1.5 {comments} -body {
     # It is helpful to be able to include comments in a list definition
     # just like in a script
-    leval {
+    lsubst {
         # comment line
         1
         2 3
@@ -36,9 +36,9 @@ test leval-1.5 {comments} -body {
     }
 } -result {1 2 3 4 5}
 
-test leval-1.6 {commands} -body {
+test lsubst-1.6 {commands} -body {
     set a 0
-    leval {
+    lsubst {
         [incr a]
         [incr a]
         [list d e]
@@ -46,24 +46,24 @@ test leval-1.6 {commands} -body {
     }
 } -result {1 2 {d e} fghi}
 
-test leval-1.7 {expand} -body {
+test lsubst-1.7 {expand} -body {
     set a {1 2}
     set space " "
     set b {3 4 5}
-    leval {
+    lsubst {
         {*}$a
         {*}$a$space$b$space[list 6 7]
     }
 } -result {1 2 1 2 3 4 5 6 7}
 
-test leval-1.8 {empty case} -body {
-    leval {
+test lsubst-1.8 {empty case} -body {
+    lsubst {
         # Nothing
     }
 } -result {}
 
-test leval-1.9 {backslash escapes} -body {
-    leval {
+test lsubst-1.9 {backslash escapes} -body {
+    lsubst {
         # char escapes
         \r\n\t
         # unicode escapes
@@ -73,10 +73,10 @@ test leval-1.9 {backslash escapes} -body {
     }
 } -result [list \r\n\t \u00b5 AB]
 
-test leval-1.10 {simple -line} -body {
+test lsubst-1.10 {simple -line} -body {
     set a {1 2}
     set b {3 4 5}
-    leval -line {
+    lsubst -line {
         # This line won't produce a list, but the next will produce a list with two elements
         {*}$a
         # And this one will have three elements
@@ -84,49 +84,49 @@ test leval-1.10 {simple -line} -body {
     }
 } -result {{1 2} {one two {3 4 5}}}
 
-test leval-2.1 {error, missing [} -body {
-    leval {
+test lsubst-2.1 {error, missing [} -body {
+    lsubst {
         # Missing bracket
         [string cat
     }
 } -returnCodes error -result {unmatched "["}
 
-test leval-2.2 {error, invalid command} -body {
-    leval {
+test lsubst-2.2 {error, invalid command} -body {
+    lsubst {
         a
         [dummy]
         b
     }
 } -returnCodes error -result {invalid command name "dummy"}
 
-test leval-2.3 {error, unset variable} -body {
-    leval {
+test lsubst-2.3 {error, unset variable} -body {
+    lsubst {
         a
         $doesnotexist
         b
     }
 } -returnCodes error -result {can't read "doesnotexist": no such variable}
 
-test leval-2.4 {break} -body {
-    leval {
+test lsubst-2.4 {break} -body {
+    lsubst {
         a
         [break]
         b
     }
 } -returnCodes error -result {invoked "break" outside of a loop}
 
-test leval-2.5 {continue} -body {
-    leval {
+test lsubst-2.5 {continue} -body {
+    lsubst {
         a
         [continue]
         b
     }
 } -returnCodes error -result {invoked "continue" outside of a loop}
 
-test leval-3.1 {preservation of line numbers} -body {
+test lsubst-3.1 {preservation of line numbers} -body {
     set x abc
     set src1 [info source $x]
-    set list [leval {
+    set list [lsubst {
         a
         $x
         b


### PR DESCRIPTION
This is a proposal. Feedback is welcome, including alternative names (such as lsubst).
From the docs:

This command is similar to `list` in that it creates a list, but uses
the same rules as scripts when constructing the elements of the list.
It is somewhat similar to `subst` except it produces a list instead of a string.

This means that variables are substituted, commands are evaluated, backslashes are
interpreted, the expansion operator is applied and comments are skipped.

Consider the following example.

```
    set x 1
    set y {2 3}
    set z 3
    leval {
        # This is a list with interpolation
        $x; # The x variable
        {*}$y; # The y variable expanded
        [string cat a b c]; # A command
        {*}[list 4 5]; # A list expanded into multiple elements
        "$z$z"; # A string with interpolation
    }

```
The result of `leval` is the following list with 7 elements.

`    1 2 3 abc 4 5 33`

This is particularly useful when constructing a list (or dict)
as a data structure as it easily allows for comments and variable and command
substitution.