### PR TITLE
Hide some more umask() calls behind HAVE_UMASK

### DIFF
--- a/jimiocompat.c
+++ b/jimiocompat.c
@@ -213,7 +213,9 @@ int Jim_MakeTempFile(Jim_Interp *interp, const char *filename_template, int unli
     }
 
     /* Update the template name directly with the filename */
+#ifdef HAVE_UMASK
     mask = umask(S_IXUSR | S_IRWXG | S_IRWXO);
+#endif
 #ifdef HAVE_MKSTEMP
     fd = mkstemp(filenameObj->bytes);
 #else
@@ -224,7 +226,9 @@ int Jim_MakeTempFile(Jim_Interp *interp, const char *filename_template, int unli
         fd = open(filenameObj->bytes, O_RDWR | O_CREAT | O_TRUNC);
     }
 #endif
+#ifdef HAVE_UMASK
     umask(mask);
+#endif
     if (fd < 0) {
         Jim_SetResultErrno(interp, Jim_String(filenameObj));
         Jim_FreeNewObj(interp, filenameObj);


### PR DESCRIPTION
I found this while trying to target jimtcl for Classic Mac OS with [Retro68](https://github.com/autc04/Retro68).