### PR TITLE
aio: add support for translation binary|text

### DIFF
--- a/jim-aio.c
+++ b/jim-aio.c
@@ -1666,6 +1666,28 @@ static int aio_cmd_buffering(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     return JIM_OK;
 }
 
+static int aio_cmd_translation(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    enum {OPT_BINARY, OPT_TEXT};
+    static const char * const options[] = {
+        "binary",
+        "text",
+        NULL
+    };
+    int opt;
+
+    if (Jim_GetEnum(interp, argv[0], options, &opt, NULL, JIM_ERRMSG) != JIM_OK) {
+            return JIM_ERR;
+    }
+#if defined(Jim_SetMode)
+    else {
+        AioFile *af = Jim_CmdPrivData(interp);
+        Jim_SetMode(af->fd, opt == OPT_BINARY ? O_BINARY : O_TEXT);
+    }
+#endif
+    return JIM_OK;
+}
+
 static int aio_cmd_readsize(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     AioFile *af = Jim_CmdPrivData(interp);
@@ -2181,6 +2203,13 @@ static const jim_subcmd_type aio_command_table[] = {
         0,
         2,
         /* Description: Sets or returns write buffering */
+    },
+    {   "translation",
+        "binary|text",
+        aio_cmd_translation,
+        1,
+        1,
+        /* Description: Sets output translation mode */
     },
     {   "readsize",
         "?size?",

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -56,6 +56,7 @@ Changes since 0.83
 ~~~~~~~~~~~~~~~~~~
 1. `aio` - support for configurable read and write buffering
 2. Add support for `package forget`
+3. Add `aio translation` support (and fconfigure -translation)
 
 Changes between 0.82 and 0.83
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -5166,6 +5167,12 @@ This command returns an empty string.
     See `aio read` and `aio gets` for command that use the timeout.
     Note that the timeout is only used if the channel is in blocking mode.
 
++$handle *translation binary|text*+::
+    This has no effect on Unix platforms, but on Windows it changes the mode of the file
+    handle to binary or text. In general, use "wb" as the open mode instead, but this
+    can be useful on existing filehandles such as +stdout+ and +stderr+. It is probably
+    a good idea to do this immediately before sending any output.
+
 +$handle *tty* ?settings?+::
     If no arguments are given, returns a dictionary containing the tty settings for the stream.
     If arguments are given, they must either be a dictionary, or +setting value \...+.
@@ -5277,7 +5284,7 @@ fconfigure
     command is supported.
     * `fconfigure ... -blocking` maps to `aio ndelay`
     * `fconfigure ... -buffering` maps to `aio buffering`
-    * `fconfigure ... -translation` is accepted but ignored
+    * `fconfigure ... -translation` maps to `aio translation` and suppports only +binary+ and +text+
 
 [[cmd_2]]
 eventloop: after, vwait, update

--- a/jimiocompat.h
+++ b/jimiocompat.h
@@ -70,6 +70,9 @@ int Jim_OpenForRead(const char *filename);
     #define Jim_FileStat _fstat64
     #define Jim_Lseek _lseeki64
     #define O_TEXT _O_TEXT
+    #ifndef STDIN_FILENO
+    #define STDIN_FILENO 0
+    #endif
 
 #else
     #if defined(HAVE_STAT64)

--- a/jimiocompat.h
+++ b/jimiocompat.h
@@ -70,6 +70,8 @@ int Jim_OpenForRead(const char *filename);
     #define Jim_FileStat _fstat64
     #define Jim_Lseek _lseeki64
     #define O_TEXT _O_TEXT
+    #define O_BINARY _O_BINARY
+    #define Jim_SetMode _setmode
     #ifndef STDIN_FILENO
     #define STDIN_FILENO 0
     #endif

--- a/jimsh.c
+++ b/jimsh.c
@@ -39,10 +39,7 @@
 
 #include "jimautoconf.h"
 #include "jim.h"
-
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
+#include "jimiocompat.h"
 
 /* From initjimsh.tcl */
 extern int Jim_initjimshInit(Jim_Interp *interp);

--- a/tclcompat.tcl
+++ b/tclcompat.tcl
@@ -48,7 +48,7 @@ if {[exists -command stdout]} {
 					$f buffering $v
 				}
 				-tr* {
-					# Just ignore -translation
+					$f translation $v
 				}
 				default {
 					return -code error "fconfigure: unknown option $n"

--- a/tcltest.tcl
+++ b/tcltest.tcl
@@ -168,8 +168,8 @@ proc basename-stacktrace {stacktrace} {
 
 # If tcl, just use tcltest
 if {[catch {info version}]} {
-	package require Tcl 8.5
-	package require tcltest 2.1
+	package require Tcl 8.5-
+	package require tcltest 2.1-
 	namespace import tcltest::*
 
 	if {$testinfo(verbose)} {

--- a/tests/io.test
+++ b/tests/io.test
@@ -1,0 +1,26 @@
+source [file dirname [info script]]/testing.tcl
+
+# This is a proxy for tcl || tclcompat
+constraint cmd fconfigure
+
+# The tests in this file are intended to test Tcl-compatible I/O features
+
+test io-1.1 {translation binary} -body {
+	# write a file via stdout in binary mode
+	# This will always work on Unix
+	set script {
+		fconfigure stdout -translation binary
+		puts line1
+		puts line2
+	}
+	exec [info nameofexecutable] << $script >binary.out
+	# Read it back in binary mode
+	set f [open binary.out rb]
+	set buf [read $f]
+	close $f
+	set buf
+} -cleanup {
+	file delete binary.out
+} -result "line1\nline2\n"
+
+testreport


### PR DESCRIPTION
This can be necessary on Windows to set stdout and/or stderr to binary output mode

Also adds fconfigure -translation

Note that we don't support all the modes that Tcl does (cr, crlf, lf, auto). Only `binary` and the new option `text` as that maps more directly to the underlying support and we really only have the goal of setting binary mode.