### PR TITLE
build: win32: fix install of `build-jim-ext`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -118,7 +118,9 @@ install: all @TCL_EXTS@ install-exec install-docs
 		@srcdir@/jim-subcmd.h @srcdir@/jim-win32compat.h $(DESTDIR)@includedir@
 	$(INSTALL_DATA) jim-config.h $(DESTDIR)@includedir@
 	$(INSTALL_DATA_DIR) $(DESTDIR)@bindir@
+@if BUILD_JIM_EXT
 	$(INSTALL_DATA) build-jim-ext $(DESTDIR)@bindir@
+@endif
 	$(INSTALL_DATA_DIR) $(DESTDIR)@libdir@/pkgconfig
 	$(INSTALL_DATA) jimtcl.pc $(DESTDIR)@libdir@/pkgconfig
 

--- a/auto.def
+++ b/auto.def
@@ -549,7 +549,7 @@ if {$withinfo(without) eq "default"} {
 # Now go check everything - see autosetup/local.tcl
 array set extinfo [check-extensions [opt-bool allextmod]]
 
-set buildjimext 1
+define BUILD_JIM_EXT 1
 
 # Now special checks
 if {[have-feature windows]} {
@@ -560,7 +560,7 @@ if {[have-feature windows]} {
             user-error "cygwin/mingw require --shared for dynamic modules"
         } else {
             user-notice "Building static library, so build-jim-ext will not work on cygwin/mingw"
-            set buildjimext 0
+            define BUILD_JIM_EXT 0
         }
     }
 } else {
@@ -668,7 +668,7 @@ make-config-header jimautoconf.h -auto {jim_ext_* TCL_PLATFORM_* TCL_LIBRARY USE
 make-template Makefile.in
 make-template tests/Makefile.in
 make-template examples.api/Makefile.in
-if {$buildjimext} {
+if {[get-define BUILD_JIM_EXT]} {
     make-template build-jim-ext.in
     catch {exec chmod +x build-jim-ext}
 }


### PR DESCRIPTION
When building for Windows like:
```
> ./configure \
	--host=x86_64-w64-mingw32 \
	--build=x86_64-linux-gnu \
	--disable-ssl \
	--minimal
> make -j install DESTDIR=${PWD}/install
```
The following error is encountered:
```
cp build-jim-ext <PWD>/install/usr/local/bin
cp: cannot stat 'build-jim-ext': No such file or directory
```

The suggested fix changes `buildjimext` variable in `auto.def` to a define and copies `build-jim-ext` only if the define is set.