### PR TITLE
Two small segfault fixes

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -15026,6 +15026,8 @@ wrongargs:
                     }
                     else if (errorCodeObj) {
                         int len = Jim_ListLength(interp, argv[idx + 1]);
+                        int errorCodeLen = Jim_ListLength(interp, errorCodeObj);
+                        if (errorCodeLen < len) len = errorCodeLen;
                         int i;
 
                         ret = JIM_OK;

--- a/jim.c
+++ b/jim.c
@@ -8452,6 +8452,16 @@ static int JimExprOpNumUnary(Jim_Interp *interp, struct JimExprNode *node)
             case JIM_EXPROP_NOT:
                 wC = !bA;
                 break;
+            case JIM_EXPROP_UNARYPLUS:
+                rc = JIM_ERR;
+                Jim_SetResultString(interp, 
+                    "can't use non-numeric string as operand of \"+\"", -1);
+                break;
+            case JIM_EXPROP_UNARYMINUS:
+                rc = JIM_ERR;
+                Jim_SetResultString(interp, 
+                    "can't use non-numeric string as operand of \"-\"", -1);
+                break;
             default:
                 abort();
         }

--- a/tests/expr.test
+++ b/tests/expr.test
@@ -154,5 +154,12 @@ test expr-5.3 {boolean in expression} {
 	expr {true ? 4 : 5}
 } {4}
 
+test expr-6.1 "Unary negation on boolean - should return error" -body {
+	expr {-true}
+} -returnCodes error -result {can't use non-numeric string as operand of "-"}
+
+test expr-6.2 "Unary plus on boolean - should return error" -body {
+	expr {+true}
+} -returnCodes error -result {can't use non-numeric string as operand of "+"}
 
 testreport

--- a/tests/try.test
+++ b/tests/try.test
@@ -140,6 +140,12 @@ test try-2.5 "trap match first but not second" -body {
 	}
 } -returnCodes error -result failed
 
+test try-2.6 "don't crash on empty errorcode" {
+	try {
+		return -code error -errorcode ""
+	} trap {COMPARED_AGAINST_ERRORCODE} {msg opts} {}
+} {}
+
 
 proc c {} {
 	try {


### PR DESCRIPTION
Hi! I've recently been fuzzing in another project, and I ran into these two corner cases.

The first bug happens with `expr {-true}` or similar. `-` is parsed as a unary operator, which then operates on the parsed boolean value. This currently aborts due to only expecting the `!` operator with boolean values.  I fixed this using tcl's error message.

The second bug is in [try]. Here's the code that causes the segfault:
```tcl
try {
	return -code error -errorcode ""
} trap {COMPARED_AGAINST_ERRORCODE} {msg opts} {}
```
[Line 15018](https://github.com/msteveb/jimtcl/blob/e0671d7c5396f6a5569792013e7e71121f42ce89/jim.c#L15018) gets the length of `match`, but it doesn't check the length of `errorCodeObj`. When the element pairs are compared, `Jim_ListGetIndex` ends up returning NULL when `i` is greater than `errorCodeObj`'s length. `Jim_StringCompareObj` segfaults since `objPtr` is NULL.

I fixed this by capping the length by `errorCodeObj`'s length.

Let me know if I should tweak the code style or error messages!