### PR TITLE
update master from master-next branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,8 @@
 name: "CodeQL"
 
 on:
-  # push:
-  #   branches: [ "main", "master" ]
+  push:
+     branches: [ "master" ]
   schedule:
     - cron: '0 0 * * *'
   pull_request:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,7 +66,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v2
+    #  uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -78,7 +78,7 @@ jobs:
         ./.github/workflows/codeql-buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
         upload: false
@@ -107,7 +107,7 @@ jobs:
         output: ${{ steps.step1.outputs.sarif-output }}/cpp.sarif
 
     - name: Upload CodeQL results to code scanning
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ steps.step1.outputs.sarif-output }}
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/fail_on_error.py
+++ b/.github/workflows/fail_on_error.py
@@ -11,7 +11,10 @@ def codeql_sarif_contain_error(filename):
     for run in s.get('runs', []):
         rules_metadata = run['tool']['driver']['rules']
         if not rules_metadata:
-            rules_metadata = run['tool']['extensions'][0]['rules']
+            for ext in run['tool']['extensions']:
+                if ext['name'] == 'codeql/cpp-queries':
+                    rules_metadata = ext['rules']
+                    break
 
         for res in run.get('results', []):
             if 'ruleIndex' in res:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,7 +2,7 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "master-next" ]
   pull_request:
     branches: [ "master" ]
 

--- a/README.taint
+++ b/README.taint
@@ -9,12 +9,12 @@ OVERVIEW
 Perl and Ruby support the concept of tainted data, taint sources
 and taint sinks. The idea is to improve security in situations
 where data may be coming from outside the program (e.g. input
-to a web application) should not inadvertently be output
+to a web application). This data should not inadvertently be output
 on a web page unescaped (to avoid XSS attacks), to a database
 (to avoid SQL injections attacks) or to execute system commands
 (to avoid system attacks).
 
-Standard Tcl does not support tainting. Instead it uses "safe"
+Standard Tcl does not support tainting, but uses "safe"
 interpreters for a similar purpose. For Jim Tcl, taint support is
 smaller and simpler.
 
@@ -31,7 +31,7 @@ Taint Sources
 Untrusted data may come from various sources in the system.
 In Jim Tcl, the sources of external data are:
 
-* Data read file a file or socket (aio read, gets, recvfrom)
+* Data read from a file or socket (aio read, gets, recvfrom)
 * Command line arguments ($argv)
 * Loaded code or scripts (source, package require, load)
 * Environment variables (env)
@@ -70,15 +70,15 @@ to taint propagation as follows:
 * Any value constructed in part from a tainted value is tainted
   (append, lappend, lset)
 * A tainted value added to a container (dict, list, array) remains tainted.
-  While the tainted value can be distinguished from other values
-  in the container, the container is not tainted. However if the container
-  needs to change representation (the entire container becomes tainted.
+  If the tainted value can be distinguished from other values
+  in the container, the container is not tainted. However, if the container
+  needs to change representation, the entire container becomes tainted.
 * Integer and floating point values are not tainted
 
 Taint types
 -----------
 It may be useful to distinguish between different types of taint.
-Each taint type is associate with a bit field. The standard taint
+Each taint type is assigned a bit in a taint bit field. The standard taint
 type is 1, but taint types 2, 4, etc. may also be used.  If a taint
 source is marked as taint type 2, it will not be flagged as invalid
 when consumed by a taint sink marked as taint type 4.
@@ -114,16 +114,16 @@ To mark a filehandle as a taint source or sink (or not):
 
 More Information
 ----------------
-In order to simplify taint propagation, the interpreter
-examines the arguments to every command (plus the command itself).
-If any argument is tainted, the command execution is considered tainted.
-Any new objects (except int and double) created during the execution of the command
-will be marked tainted.
+To simplify taint propagation, the interpreter examines the arguments
+to every command (plus the command itself).  If any argument is
+tainted, the command execution is considered tainted.  Any new
+objects (except int and double) created during the execution of the
+command will be marked tainted.
 
 The Rules
 ---------
-- The taint and untaint commands operate on variables and taint/untaint the contents of the variable
-- Adding/modifying a list/dict/array element taints that element plus the "container" but not
+- The taint and untaint commands operate on variables, and taint/untaint the contents of the variable
+- Adding/modifying a list/dict/array element taints that element plus the "container", but not
   the other elements in that container
 - Tainting a container element taints the container too
 - Untainting a container element does not untaint the container, even if it contains no more tainted elements
@@ -133,11 +133,11 @@ The Rules
 Specific Notes
 --------------
 In general, a conservative approach is used to tainting, so if
-a command creates a new object while any of it's arguments are tainted,
+a command creates a new object while any of its arguments are tainted,
 the new object is also tainted.
 
-However the list-related commands are more intelligent.
+However, the list-related commands are more intelligent.
 All list-related commands such as lindex, lrange, lassign and lreplace will
-maintain the taint of existing list elements, but will avoid tainting untainted elements.
+not change the taint of existing list elements, but will avoid tainting untainted elements.
 For example, if the list {a b t d} contains one tainted element, 't', then [lreverse $a]
 will produce a list with only one tainted element.

--- a/README.taint
+++ b/README.taint
@@ -1,0 +1,143 @@
+Taint Suport for Jim Tcl
+========================
+
+Author: Steve Bennett <steveb@workware.net.au>
+Date: 24 May 2011
+
+OVERVIEW
+--------
+Perl and Ruby support the concept of tainted data, taint sources
+and taint sinks. The idea is to improve security in situations
+where data may be coming from outside the program (e.g. input
+to a web application) should not inadvertently be output
+on a web page unescaped (to avoid XSS attacks), to a database
+(to avoid SQL injections attacks) or to execute system commands
+(to avoid system attacks).
+
+Standard Tcl does not support tainting. Instead it uses "safe"
+interpreters for a similar purpose. For Jim Tcl, taint support is
+smaller and simpler.
+
+HOW IT WORKS
+------------
+
+Any data read from a 'taint source' is considered tainted.
+As that data moves through the system, it retains its taint property.
+Tainted data should not be allowed to be consumed by a 'taint sink'.
+An error should be raised instead.
+
+Taint Sources
+~~~~~~~~~~~~~
+Untrusted data may come from various sources in the system.
+In Jim Tcl, the sources of external data are:
+
+* Data read file a file or socket (aio read, gets, recvfrom)
+* Command line arguments ($argv)
+* Loaded code or scripts (source, package require, load)
+* Environment variables (env)
+* Custom Tcl commands implemented as C code
+
+Any data from these sources may be considered "tainted".
+
+By default, sockets are considered taint sources while the other
+external data sources are not. Data read from a 'taint source'
+filehandle with read, recvfrom or gets is tainted.
+
+No filehandles are considered taint sinks by default.
+
+Client sockets produced by accept inherit the accept socket settings.
+
+Taint Sinks
+~~~~~~~~~~~
+In order for tainted data to cause security problems, the data
+need to be used in certain contexts. These *may* include:
+
+* Establishing network connections (socket)
+* Sending the data to certain file descriptors (aio puts, sendto)
+* Modifying the filesystem (open, file delete, rename, mkdir)
+* Running commands (exec)
+* Evaluating scripts (eval, uplevel, source)
+* Use in custom Tcl commands implemented as C code
+
+Taint Propagation
+~~~~~~~~~~~~~~~~~
+As tainted data is assigned, or manipulated, it should retain
+its taint property. This includes the creation of new values
+based on tainted data. Jim Tcl takes a conservative approach
+to taint propagation as follows:
+
+* Any copy of a tainted value is tainted (e.g. set, proc calls)
+* Any value constructed in part from a tainted value is tainted
+  (append, lappend, lset)
+* A tainted value added to a container (dict, list, array) remains tainted.
+  While the tainted value can be distinguished from other values
+  in the container, the container is not tainted. However if the container
+  needs to change representation (the entire container becomes tainted.
+* Integer and floating point values are not tainted
+
+Taint types
+-----------
+It may be useful to distinguish between different types of taint.
+Each taint type is associate with a bit field. The standard taint
+type is 1, but taint types 2, 4, etc. may also be used.  If a taint
+source is marked as taint type 2, it will not be flagged as invalid
+when consumed by a taint sink marked as taint type 4.
+
+The commands exec, source, etc. consider any taint to be invalid, however
+file descriptors may have specific taint source and sink types specified.
+
+Taint-aware Commands
+--------------------
+The following commands will fail if any argument is tainted:
+
+- source, exec, open, socket, load, file mkdir, file delete, file rename
+
+In addition, 'package require' will ignore any tainted paths in $auto_path
+
+HOW TO USE IT
+-------------
+To mark a value as tainted:
+
+  taint varname
+
+To remove the taint from a value:
+
+  untaint varname
+
+To determine if a value is tainted:
+
+  info tainted $var
+
+To mark a filehandle as a taint source or sink (or not):
+
+  $aiohandle taint source|sink ?0|n?
+
+More Information
+----------------
+In order to simplify taint propagation, the interpreter
+examines the arguments to every command (plus the command itself).
+If any argument is tainted, the command execution is considered tainted.
+Any new objects (except int and double) created during the execution of the command
+will be marked tainted.
+
+The Rules
+---------
+- The taint and untaint commands operate on variables and taint/untaint the contents of the variable
+- Adding/modifying a list/dict/array element taints that element plus the "container" but not
+  the other elements in that container
+- Tainting a container element taints the container too
+- Untainting a container element does not untaint the container, even if it contains no more tainted elements
+- Tainting or untainting a container taints or untaints all elements in the container
+- Any element of $auto_path that is tainted will be ignored when loading packages with package require
+
+Specific Notes
+--------------
+In general, a conservative approach is used to tainting, so if
+a command creates a new object while any of it's arguments are tainted,
+the new object is also tainted.
+
+However the list-related commands are more intelligent.
+All list-related commands such as lindex, lrange, lassign and lreplace will
+maintain the taint of existing list elements, but will avoid tainting untainted elements.
+For example, if the list {a b t d} contains one tainted element, 't', then [lreverse $a]
+will produce a list with only one tainted element.

--- a/Tcl_shipped.html
+++ b/Tcl_shipped.html
@@ -800,7 +800,7 @@ Object-based I/O (aio), but with a Tcl-compatibility layer
 </li>
 <li>
 <p>
-I/O: Support for sockets and pipes including udp, unix domain sockets and IPv6
+I/O: Support for sockets and pipes including TCP, UDP, UNIX-Domain sockets and IPv6
 </p>
 </li>
 <li>
@@ -850,7 +850,7 @@ Command and variable traces are not supported
 </li>
 <li>
 <p>
-Built-in command line editing
+Built-in command line editing in interactive mode with autocompletion and hints
 </p>
 </li>
 <li>
@@ -870,7 +870,7 @@ Highly suitable for use in an embedded environment
 </li>
 <li>
 <p>
-Support for UDP, IPv6, Unix-Domain sockets in addition to TCP sockets
+Jim does not convert backslash-newline within braces (in order to preserve accurate line numbers)
 </p>
 </li>
 </ol></div>
@@ -885,6 +885,66 @@ Support for UDP, IPv6, Unix-Domain sockets in addition to TCP sockets
 <li>
 <p>
 <a href="#_aio"><strong><code>aio</code></strong></a> - support for configurable read and write buffering
+</p>
+</li>
+<li>
+<p>
+Add support for <a href="#_package"><strong><code>package</code></strong></a> <code>forget</code>
+</p>
+</li>
+<li>
+<p>
+Add <a href="#_aio"><strong><code>aio</code></strong></a> <code>translation</code> support (and fconfigure -translation)
+</p>
+</li>
+<li>
+<p>
+<a href="#_exec"><strong><code>exec</code></strong></a> <a href="https://core.tcl-lang.org/tips/doc/main/tip/424.md">TIP 424</a> - support safer <code><em>exec |</em></code> syntax (also <code><em>open "|| pipeline&#8230;"</em></code>)
+</p>
+</li>
+<li>
+<p>
+New <a href="#_lsubst"><strong><code>lsubst</code></strong></a> command to create lists using subst-style substitution
+</p>
+</li>
+<li>
+<p>
+Add support for <a href="#_regexp"><strong><code>regexp</code></strong></a> <code>-expanded</code> and <a href="#_regsub"><strong><code>regsub</code></strong></a> <code>-expanded</code>
+</p>
+</li>
+<li>
+<p>
+<a href="#cmd_2"><strong><code>vwait</code></strong></a> now accepts a script argument
+</p>
+</li>
+<li>
+<p>
+Add support for <a href="#cmd_1"><strong><code>os.umask</code></strong></a>
+</p>
+</li>
+<li>
+<p>
+Add <a href="#_taint"><strong><code>taint</code></strong></a> support for improved data security
+</p>
+</li>
+<li>
+<p>
+Improved API for creating C commands with <code><em>Jim_RegisterCommand</em></code> for arg checking and usage
+</p>
+</li>
+<li>
+<p>
+New <a href="#_info"><strong><code>info</code></strong></a> <code>usage</code> to return the usage for a proc or native command
+</p>
+</li>
+<li>
+<p>
+New <a href="#_info"><strong><code>info</code></strong></a> <code>aliases</code> to list all aliases
+</p>
+</li>
+<li>
+<p>
+<a href="#_expr"><strong><code>expr</code></strong></a> supports new <code><em>=*</em></code> and <code><em>=~</em></code> matching operators (see <a href="#_expressions">EXPRESSIONS</a>)
 </p>
 </li>
 </ol></div>
@@ -954,7 +1014,7 @@ Add support for <a href="#_lsort"><strong><code>lsort</code></strong></a> <code>
 </li>
 <li>
 <p>
-TIP 603, <a href="#_aio"><strong><code>aio</code></strong></a> <code>stat</code> is now supported to stat a file handle
+<a href="https://core.tcl-lang.org/tips/doc/main/tip/603.md">TIP 603</a>, <a href="#_aio"><strong><code>aio</code></strong></a> <code>stat</code> is now supported to stat a file handle
 </p>
 </li>
 <li>
@@ -984,7 +1044,7 @@ The handles created by <a href="#_socket"><strong><code>socket</code></strong></
 </li>
 <li>
 <p>
-New <a href="#_timerate"><strong><code>timerate</code></strong></a> command as an improvement over <a href="#_time"><strong><code>time</code></strong></a>, somewhat compatible with TIP 527
+New <a href="#_timerate"><strong><code>timerate</code></strong></a> command as an improvement over <a href="#_time"><strong><code>time</code></strong></a>, somewhat compatible with <a href="https://core.tcl-lang.org/tips/doc/main/tip/527.md">TIP 527</a>
 </p>
 </li>
 <li>
@@ -999,7 +1059,7 @@ Add <a href="#_ensemble"><strong><code>ensemble</code></strong></a> command and 
 <div class="olist arabic"><ol class="arabic">
 <li>
 <p>
-TIP 582, comments allowed in expressions
+<a href="https://core.tcl-lang.org/tips/doc/main/tip/582.md">TIP 582</a>, comments allowed in expressions
 </p>
 </li>
 <li>
@@ -1030,7 +1090,7 @@ Add <a href="#_history"><strong><code>history</code></strong></a> <code>keep</co
 </li>
 <li>
 <p>
-Add support for <a href="#_lsearch"><strong><code>lsearch</code></strong></a> <code>-index</code> and <a href="#_lsearch"><strong><code>lsearch</code></strong></a> <code>-stride</code>, the latter per TIP 351
+Add support for <a href="#_lsearch"><strong><code>lsearch</code></strong></a> <code>-index</code> and <a href="#_lsearch"><strong><code>lsearch</code></strong></a> <code>-stride</code>, the latter per <a href="https://core.tcl-lang.org/tips/doc/main/tip/351.md">TIP 351</a>
 </p>
 </li>
 <li>
@@ -1050,7 +1110,7 @@ Add support for <a href="#_lsort"><strong><code>lsort</code></strong></a> <code>
 </li>
 <li>
 <p>
-TIP 526, <a href="#_expr"><strong><code>expr</code></strong></a> now only allows a single argument (unless --compat is enabled)
+<a href="https://core.tcl-lang.org/tips/doc/main/tip/526.md">TIP 526</a>, <a href="#_expr"><strong><code>expr</code></strong></a> now only allows a single argument (unless --compat is enabled)
 </p>
 </li>
 </ol></div>
@@ -1080,17 +1140,17 @@ dictionaries and arrays now preserve insertion order, matching Tcl and the docum
 </li>
 <li>
 <p>
-Add <a href="#_dict"><strong><code>dict</code></strong></a> <code>getwithdefault</code> (and the alias <a href="#_dict"><strong><code>dict</code></strong></a> <code>getdef</code>) per TIP 342
+Add <a href="#_dict"><strong><code>dict</code></strong></a> <code>getwithdefault</code> (and the alias <a href="#_dict"><strong><code>dict</code></strong></a> <code>getdef</code>) per <a href="https://core.tcl-lang.org/tips/doc/main/tip/342.md">TIP 342</a>
 </p>
 </li>
 <li>
 <p>
-Add string comparison operators (lt, gt, le, ge) per TIP 461
+Add string comparison operators (lt, gt, le, ge) per <a href="https://core.tcl-lang.org/tips/doc/main/tip/461.md">TIP 461</a>
 </p>
 </li>
 <li>
 <p>
-Implement 0d radix prefix for decimal per TIP 472
+Implement <code>0d</code> radix prefix for decimal per <a href="https://core.tcl-lang.org/tips/doc/main/tip/472.md">TIP 472</a>
 </p>
 </li>
 </ol></div>
@@ -1484,7 +1544,7 @@ that command.  For example, the command:</p></div>
 the last two, <em>a</em> and <em>22</em>, will be passed as arguments to
 the <a href="#_set"><strong><code>set</code></strong></a> command.  The command name may refer either to a built-in
 Tcl command, an application-specific command bound in with the library
-procedure <em>Jim_CreateCommand</em>, or a command procedure defined with the
+procedure <em>Jim_RegisterCommand</em>, or a command procedure defined with the
 <a href="#_proc"><strong><code>proc</code></strong></a> built-in command.</p></div>
 <div class="paragraph"><p>Arguments are passed literally as text strings.  Individual commands may
 interpret those strings in any fashion they wish.  The <a href="#_set"><strong><code>set</code></strong></a> command,
@@ -1770,94 +1830,20 @@ sequence is replaced by the given character:</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
-<code>\{</code>
-</dt>
-<dd>
-<p>
-    Left brace ({).
-</p>
-</dd>
-<dt class="hdlist1">
-<code>\}</code>
-</dt>
-<dd>
-<p>
-    Right brace (}).
-</p>
-</dd>
-<dt class="hdlist1">
-<code>\[</code>
-</dt>
-<dd>
-<p>
-    Open bracket ([).
-</p>
-</dd>
-<dt class="hdlist1">
-<code>\]</code>
-</dt>
-<dd>
-<p>
-    Close bracket (]).
-</p>
-</dd>
-<dt class="hdlist1">
-<code>\$</code>
-</dt>
-<dd>
-<p>
-    Dollar sign ($).
-</p>
-</dd>
-<dt class="hdlist1">
-<code>\&lt;space&gt;</code>
-</dt>
-<dd>
-<p>
-    Space ( ): doesn&#8217;t terminate argument.
-</p>
-</dd>
-<dt class="hdlist1">
-<code>\;</code>
-</dt>
-<dd>
-<p>
-    Semi-colon: doesn&#8217;t terminate command.
-</p>
-</dd>
-<dt class="hdlist1">
-<code>\"</code>
-</dt>
-<dd>
-<p>
-    Double-quote.
-</p>
-</dd>
-<dt class="hdlist1">
-<code>\&lt;newline&gt;</code>
-</dt>
-<dd>
-<p>
-    Nothing:  this joins two lines together
-    into a single line.  This backslash feature is unique in that
-    it will be applied even when the sequence occurs within braces.
-</p>
-</dd>
-<dt class="hdlist1">
-<code>\\</code>
-</dt>
-<dd>
-<p>
-    Backslash (<em>\</em>).
-</p>
-</dd>
-<dt class="hdlist1">
 <code>\ddd</code>
 </dt>
 <dd>
 <p>
     The digits <code><em>ddd</em></code> (one, two, or three of them) give the octal value of
-    the character.  Note that Jim supports null characters in strings.
+    the byte.  Note that Jim supports null characters in strings.
+</p>
+</dd>
+<dt class="hdlist1">
+<code>\xnn</code>
+</dt>
+<dd>
+<p>
+    The hexidecimal digits <code><em>nn</em></code> give the value of the byte.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -1875,30 +1861,23 @@ sequence is replaced by the given character:</p></div>
     The <em>u</em> form allows for one to four hex digits.
     The <em>U</em> form allows for one to eight hex digits.
     The <em>u{nnn}</em> form allows for one to eight hex digits, but makes it easier to insert
-    characters UTF-8 characters which are followed by a hex digit.
+    UTF-8 characters that are followed by a hex digit.
 </p>
 </dd>
 </dl></div>
+<div class="paragraph"><p>If a backslash is followed by something other than one of the options
+described above, the backslash is skipped and character following the backslash is treated
+as a normal character without any special meaning. The Tcl scanner continues
+normal processing with the next character.  For example, in the
+command</p></div>
 <div class="paragraph"><p>For example, in the command</p></div>
 <div class="listingblock">
 <div class="content">
-<pre><code>    set a {x\[\ yz\141</code></pre>
+<pre><code>    set a \{x\[\ yz\141</code></pre>
 </div></div>
 <div class="paragraph"><p>the second argument to <a href="#_set"><strong><code>set</code></strong></a> will be <code>{x[ yza</code>.</p></div>
-<div class="paragraph"><p>If a backslash is followed by something other than one of the options
-described above, then the backslash is transmitted to the argument
-field without any special processing, and the Tcl scanner continues
-normal processing with the next character.  For example, in the
-command</p></div>
-<div class="listingblock">
-<div class="content">
-<pre><code>    set \*a \{foo</code></pre>
-</div></div>
-<div class="paragraph"><p>The first argument to <a href="#_set"><strong><code>set</code></strong></a> will be <code>*a</code> and the second
-argument will be <code>{foo</code>.</p></div>
 <div class="paragraph"><p>If an argument is enclosed in braces, then backslash sequences inside
-the argument are parsed but no substitution occurs (except for
-backslash-newline):  the backslash
+the argument are parsed but no substitution occurs:  the backslash
 sequence is passed through to the argument as is, without making
 any special interpretation of the characters in the backslash sequence.
 In particular, backslashed braces are not counted in locating the
@@ -2299,6 +2278,24 @@ of precedence:</p></div>
 <p>
     String equal and not equal.  Uses the string value directly without
     attempting to convert to a number first.
+</p>
+</dd>
+<dt class="hdlist1">
+<code>=*</code>
+</dt>
+<dd>
+<p>
+   String glob match. The left and side is the string to match and the right
+   and side is the pattern. See <a href="#_string_matching">STRING MATCHING</a>.
+</p>
+</dd>
+<dt class="hdlist1">
+<code>=~</code>
+</dt>
+<dd>
+<p>
+   String regexp match. The left and side is the string to match and the right
+   and side is the regular expression. See <a href="#_regular_expressions">REGULAR EXPRESSIONS</a>.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -2742,6 +2739,15 @@ defined in jim.h, and are:</p></div>
 <p>
     Indicates that the command called the <a href="#_exit"><strong><code>exit</code></strong></a> command.
     The string contains the exit code.
+</p>
+</dd>
+<dt class="hdlist1">
+<code>JIM_USAGE(-1)</code>
+</dt>
+<dd>
+<p>
+    This is a special return code that is automatically translated into JIM_ERR with the command usage
+    (from Jim_RegisterCommand()) as the message.
 </p>
 </dd>
 </dl></div>
@@ -3443,88 +3449,88 @@ cellspacing="0" cellpadding="4">
 <td align="left" valign="top"><p class="table"><a href="#_lsearch"><strong><code>lsearch</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_lset"><strong><code>lset</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_lsort"><strong><code>lsort</code></strong></a></p></td>
+<td align="left" valign="top"><p class="table"><a href="#_lsubst"><strong><code>lsubst</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_namespace"><strong><code>namespace</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_4"><strong><code>oo</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_open"><strong><code>open</code></strong></a></p></td>
 </tr>
 <tr>
+<td align="left" valign="top"><p class="table"><a href="#_open"><strong><code>open</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_1"><strong><code>os.fork</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_1"><strong><code>os.gethostname</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_1"><strong><code>os.getids</code></strong></a></p></td>
+<td align="left" valign="top"><p class="table"><a href="#cmd_1"><strong><code>os.umask</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_1"><strong><code>os.uptime</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_3"><strong><code>pack</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_3"><strong><code>pack</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_package"><strong><code>package</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_pid"><strong><code>pid</code></strong></a></p></td>
 </tr>
 <tr>
+<td align="left" valign="top"><p class="table"><a href="#_package"><strong><code>package</code></strong></a></p></td>
+<td align="left" valign="top"><p class="table"><a href="#_pid"><strong><code>pid</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_pipe"><strong><code>pipe</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_1"><strong><code>posix</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_proc"><strong><code>proc</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_puts"><strong><code>puts</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_pwd"><strong><code>pwd</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_rand"><strong><code>rand</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_range"><strong><code>range</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_read"><strong><code>read</code></strong></a></p></td>
 </tr>
 <tr>
+<td align="left" valign="top"><p class="table"><a href="#_range"><strong><code>range</code></strong></a></p></td>
+<td align="left" valign="top"><p class="table"><a href="#_read"><strong><code>read</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_ref"><strong><code>ref</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_regexp"><strong><code>regexp</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_regsub"><strong><code>regsub</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_rename"><strong><code>rename</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_return"><strong><code>return</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_scan"><strong><code>scan</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_seek"><strong><code>seek</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_set"><strong><code>set</code></strong></a></p></td>
 </tr>
 <tr>
+<td align="left" valign="top"><p class="table"><a href="#_seek"><strong><code>seek</code></strong></a></p></td>
+<td align="left" valign="top"><p class="table"><a href="#_set"><strong><code>set</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_setref"><strong><code>setref</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_signal"><strong><code>signal</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_sleep"><strong><code>sleep</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_socket"><strong><code>socket</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_source"><strong><code>source</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_split"><strong><code>split</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_stackdump"><strong><code>stackdump</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_stacktrace"><strong><code>stacktrace</code></strong></a></p></td>
 </tr>
 <tr>
+<td align="left" valign="top"><p class="table"><a href="#_stackdump"><strong><code>stackdump</code></strong></a></p></td>
+<td align="left" valign="top"><p class="table"><a href="#_stacktrace"><strong><code>stacktrace</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_string"><strong><code>string</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_subst"><strong><code>subst</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_4"><strong><code>super</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_switch"><strong><code>switch</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_syslog"><strong><code>syslog</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_tailcall"><strong><code>tailcall</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_tcl_autocomplete"><strong><code>tcl::autocomplete</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"><a href="#_tcl_prefix"><strong><code>tcl::prefix</code></strong></a></p></td>
 </tr>
 <tr>
+<td align="left" valign="top"><p class="table"><a href="#_taint"><strong><code>taint</code></strong></a></p></td>
+<td align="left" valign="top"><p class="table"><a href="#_tcl_autocomplete"><strong><code>tcl::autocomplete</code></strong></a></p></td>
+<td align="left" valign="top"><p class="table"><a href="#_tcl_prefix"><strong><code>tcl::prefix</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_tcl_stdhint"><strong><code>tcl::stdhint</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_tell"><strong><code>tell</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_throw"><strong><code>throw</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_time"><strong><code>time</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_timerate"><strong><code>timerate</code></strong></a></p></td>
+</tr>
+<tr>
 <td align="left" valign="top"><p class="table"><a href="#_tree"><strong><code>tree</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_try"><strong><code>try</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_unknown"><strong><code>unknown</code></strong></a></p></td>
-</tr>
-<tr>
 <td align="left" valign="top"><p class="table"><a href="#cmd_3"><strong><code>unpack</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_unset"><strong><code>unset</code></strong></a></p></td>
+<td align="left" valign="top"><p class="table"><a href="#_untaint"><strong><code>untaint</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_upcall"><strong><code>upcall</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_2"><strong><code>update</code></strong></a></p></td>
+</tr>
+<tr>
 <td align="left" valign="top"><p class="table"><a href="#_uplevel"><strong><code>uplevel</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_upvar"><strong><code>upvar</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#cmd_2"><strong><code>vwait</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_wait"><strong><code>wait</code></strong></a></p></td>
-</tr>
-<tr>
 <td align="left" valign="top"><p class="table"><a href="#_while"><strong><code>while</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_xtrace"><strong><code>xtrace</code></strong></a></p></td>
 <td align="left" valign="top"><p class="table"><a href="#_zlib"><strong><code>zlib</code></strong></a></p></td>
-<td align="left" valign="top"><p class="table"></p></td>
-<td align="left" valign="top"><p class="table"></p></td>
-<td align="left" valign="top"><p class="table"></p></td>
-<td align="left" valign="top"><p class="table"></p></td>
 <td align="left" valign="top"><p class="table"></p></td>
 </tr>
 </tbody>
@@ -3862,7 +3868,7 @@ the loop&#8217;s body but continue with the next iteration of the loop.</p></div
 <div class="paragraph"><p><code><strong>curry</strong> <em>args...</em></code></p></div>
 <div class="paragraph"><p>Similar to <a href="#_alias"><strong><code>alias</code></strong></a> except it creates an anonymous procedure (lambda) instead of
 a named procedure.</p></div>
-<div class="paragraph"><p>the following creates a local, unnamed alias for the command <a href="#_info"><strong><code>info</code></strong></a> <code>exists</code>.</p></div>
+<div class="paragraph"><p>The following creates a local, unnamed alias for the command <a href="#_info"><strong><code>info</code></strong></a> <code>exists</code>.</p></div>
 <div class="listingblock">
 <div class="content">
 <pre><code>    set e [local curry info exists]
@@ -3896,6 +3902,16 @@ when the proc or interpreter exits.</p></div>
 command.  The legal <code><em>options</em></code> are:</p></div>
 <div class="dlist"><dl>
 <dt class="hdlist1">
+<code><strong>dict append</strong> <em>dictionaryName key ?string &#8230;?</em></code>
+</dt>
+<dd>
+<p>
+    This appends the given string (or strings) to the value that
+    the given key maps to in <code><em>dictionaryName</em></code>. Non-existent keys
+    are treated as if they map to an empty string.
+</p>
+</dd>
+<dt class="hdlist1">
 <code><strong>dict create</strong> <em>?key value ...?</em></code>
 </dt>
 <dd>
@@ -3915,6 +3931,14 @@ command.  The legal <code><em>options</em></code> are:</p></div>
     of keys through a set of nested dictionaries) exists in the given
     dictionary value.  This returns a true value exactly when <a href="#_dict"><strong><code>dict</code></strong></a> <code>get</code>
     on that path will succeed.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>dict for</strong> <em>{keyvar valuevar} dictionary script</em></code>
+</dt>
+<dd>
+<p>
+   <strong>TBD</strong>
 </p>
 </dd>
 <dt class="hdlist1">
@@ -3953,6 +3977,27 @@ command.  The legal <code><em>options</em></code> are:</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
+<code><strong>dict incr</strong> <em>dictionaryName key ?increment?</em></code>
+</dt>
+<dd>
+<p>
+    This adds the given increment value (an integer that defaults
+    to 1 if not specified) to the value that the given key maps to
+    in <code><em>dictionaryName</em></code>.  Non-existent keys are treated as if
+    they map to 0. It is an error to increment a value for an
+    existing key if that value is not an integer.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>dict info</strong> <em>dictionary</em></code>
+</dt>
+<dd>
+<p>
+    Returns some information about the utilisation of the data
+    within the hashtable that represents <code><em>dictionary</em></code>.
+</p>
+</dd>
+<dt class="hdlist1">
 <code><strong>dict keys</strong> <em>dictionary ?pattern?</em></code>
 </dt>
 <dd>
@@ -3961,6 +4006,16 @@ command.  The legal <code><em>options</em></code> are:</p></div>
     If <code><em>pattern</em></code> is specified, then only those keys whose
     names match <code><em>pattern</em></code> (using <a href="#_string_matching">STRING MATCHING</a> rules)
     are included.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>dict lappend</strong> <em>dictionaryName key ?value &#8230;?</em></code>
+</dt>
+<dd>
+<p>
+    This appends the given items to the list value that the given
+    key maps to in <code><em>dictionaryName</em></code>. Non-existent keys are treated
+    as if they map to the empty list.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -3973,6 +4028,18 @@ command.  The legal <code><em>options</em></code> are:</p></div>
     contain a mapping for the same key, the resulting dictionary
     maps that key to the value according to the last dictionary on
     the command line containing a mapping for that key.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>dict replace</strong> <em>dictionary ?key value &#8230;?</em></code>
+</dt>
+<dd>
+<p>
+    Return a new dictionary that is a copy of <code><em>dictionary</em></code>
+    except with some values different or some
+    extra key/value pairs added. It is legal for this command to
+    be called with no key/value pairs, but illegal for this command
+    to be called with a key but no value.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -4010,6 +4077,26 @@ command.  The legal <code><em>options</em></code> are:</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
+<code><strong>dict update</strong> <em>dictionaryName key varName ?key VarName &#8230;? script</em></code>
+</dt>
+<dd>
+<p>
+   <strong>TBD</strong>
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>dict values</strong> <em>dictionary ?globPattern?</em></code>
+</dt>
+<dd>
+<p>
+    Return a list of all values in <code><em>dictionary</em></code>. If a pattern is
+    supplied, only those values that match it (according to the
+    rules of <a href="#_string"><strong><code>string</code></strong></a> <code>match</code>) will be returned. The returned values
+    will be in the order of that the keys associated with those
+    values were inserted into the dictionary.
+</p>
+</dd>
+<dt class="hdlist1">
 <code><strong>dict with</strong> <em>dictionaryName key ?key ...? script</em></code>
 </dt>
 <dd>
@@ -4040,7 +4127,6 @@ command.  The legal <code><em>options</em></code> are:</p></div>
 </p>
 </dd>
 </dl></div>
-<div class="paragraph"><p><code><strong>dict for, values, incr, append, lappend, update, info, replace</strong></code> to be documented&#8230;</p></div>
 </div>
 <div class="sect2">
 <h3 id="_ensemble">ensemble</h3>
@@ -4048,19 +4134,15 @@ command.  The legal <code><em>options</em></code> are:</p></div>
 <div class="paragraph"><p>Create a single ensemble command that redirects to individual commands based on the prefix.
 By default, the prefix is <code><em>name</em></code> followed by a single space.</p></div>
 <div class="paragraph"><p>For example, consider:</p></div>
-<div class="literalblock">
+<div class="listingblock">
 <div class="content">
-<pre><code>proc {test open} {name} { ... }
-proc {test close} {handle} { ... }
-proc {test show} {handle} { ... }
-ensemble test</code></pre>
+<pre><code>    proc {test open} {name} { ... }
+    proc {test close} {handle} { ... }
+    proc {test show} {handle} { ... }
+    ensemble test</code></pre>
 </div></div>
 <div class="paragraph"><p>Now the <em><code>test</code></em> command has been created that redirects based on the first argument.
-e.g.</p></div>
-<div class="literalblock">
-<div class="content">
-<pre><code>test open $filename =&gt; {test open} $filename</code></pre>
-</div></div>
+e.g. <code><em>test open $filename</em></code> &#8658; <code><em>{test open} $filename</em></code></p></div>
 </div>
 <div class="sect2">
 <h3 id="_env">env</h3>
@@ -4126,6 +4208,7 @@ evaluation (or any error generated by it).</p></div>
 <div class="sect2">
 <h3 id="_exec">exec</h3>
 <div class="paragraph"><p><code><strong>exec</strong> <em>arg ?arg...?</em></code></p></div>
+<div class="paragraph"><p><code><strong>exec</strong> | <em>{cmdlist ...} ?redirection ...?</em></code></p></div>
 <div class="paragraph"><p>This command treats its arguments as the specification
 of one or more UNIX commands to execute as subprocesses.
 The commands take the form of a standard shell pipeline;
@@ -4152,7 +4235,8 @@ messages are suppressed.</p></div>
 is a newline then that character is deleted from the result
 or error message for consistency with normal
 Tcl return values.</p></div>
-<div class="paragraph"><p>An <code><em>arg</em></code> may have one of the following special forms:</p></div>
+<div class="paragraph"><p>An <code><em>arg</em></code> (or <code><em>redirection</em></code> in the second form) may have one of the
+following special forms:</p></div>
 <div class="dlist"><dl>
 <dt class="hdlist1">
 <code>&gt;filename</code>
@@ -4188,7 +4272,7 @@ Tcl return values.</p></div>
 </dt>
 <dd>
 <p>
-    The standard error of the last command in the pipeline
+    The standard error of all commands in the pipeline
     is redirected to the file.
 </p>
 </dd>
@@ -4205,7 +4289,7 @@ Tcl return values.</p></div>
 </dt>
 <dd>
 <p>
-    The standard error of the last command in the pipeline is
+    The standard error of all commands in the pipeline is
     redirected to the given (writable) file descriptor.
 </p>
 </dd>
@@ -4214,8 +4298,8 @@ Tcl return values.</p></div>
 </dt>
 <dd>
 <p>
-    The standard error of the last command in the pipeline is
-    redirected to the same file descriptor as the standard output.
+    The standard error of all commands in the pipeline is
+    redirected command output.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -4223,8 +4307,8 @@ Tcl return values.</p></div>
 </dt>
 <dd>
 <p>
-    Both the standard output and standard error of the last command
-    in the pipeline is redirected to the file.
+    Both standard output from the last command and standard error from all commands
+    in the pipeline are redirected to the file.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -4263,21 +4347,24 @@ Tcl return values.</p></div>
 </p>
 </dd>
 </dl></div>
+<div class="paragraph"><p>Note that any of the forms that take an argument (filename, fileId or string)
+their argument may be a separate word. e.g. <code><em>&lt;&lt; $str</em></code>.</p></div>
 <div class="paragraph"><p>If there is no redirection of standard input, standard error
 or standard output, these are connected to the corresponding
 input or output of the application.</p></div>
-<div class="paragraph"><p>If the last <code><em>arg</em></code> is <code>&amp;</code> then the command will be
-executed in background.
-In this case the standard output from the last command
-in the pipeline will
-go to the application&#8217;s standard output unless
-redirected in the command, and error output from all
-the commands in the pipeline will go to the application&#8217;s
-standard error file. The return value of exec in this case
-is a list of process ids (pids) in the pipeline.</p></div>
+<div class="paragraph"><p>If the last <code><em>arg</em></code> or <code><em>redirection</em></code> is <code>&amp;</code> then the command will be
+executed in background.  In this case the standard output from the last
+command in the pipeline will go to the application&#8217;s standard output
+unless redirected in the command, and error output from all the commands
+in the pipeline will go to the application&#8217;s standard error file. The
+return value of exec in this case is a list of process ids (pids) in
+the pipeline.</p></div>
 <div class="paragraph"><p>Each <code><em>arg</em></code> becomes one word for a command, except for
 <code>|</code>, <code>&lt;</code>, <code>&lt;&lt;</code>, <code>&gt;</code>, and <code>&amp;</code> arguments, and the
 arguments that follow <code>&lt;</code>, <code>&lt;&lt;</code>, and <code>&gt;</code>.</p></div>
+<div class="paragraph"><p>In the second form, <code><em>cmdlist</em></code> is the command list, so there
+is no ambiguity about whether an argument or a redirection.
+Note that this second form is not currently supported by Tcl.</p></div>
 <div class="paragraph"><p>The first word in each command is taken as the command name;
 the directories in the PATH environment variable are searched for
 an executable by the given name.</p></div>
@@ -4333,11 +4420,11 @@ this variable is unset, in which case the original environment is used).</p></di
 </div>
 <div class="sect2">
 <h3 id="_exists">exists</h3>
-<div class="paragraph"><p><code><strong>exists ?-var|-proc|-command|-alias?</strong> <em>name</em></code></p></div>
-<div class="paragraph"><p>Checks the existence of the given variable, procedure, command
-or alias respectively and returns 1 if it exists or 0 if not.  This command
+<div class="paragraph"><p><code><strong>exists ?-var|-proc|-command|-alias|-channel?</strong> <em>name</em></code></p></div>
+<div class="paragraph"><p>Checks the existence of the given variable, procedure, command,
+alias or channel respectively and returns 1 if it exists or 0 if not.  This command
 provides a more simplified/convenient version of <a href="#_info"><strong><code>info</code></strong></a> <code>exists</code>,
-<a href="#_info"><strong><code>info</code></strong></a> <code>procs</code> and <a href="#_info"><strong><code>info</code></strong></a> <code>commands</code>.</p></div>
+<a href="#_info"><strong><code>info</code></strong></a> <code>procs</code>, <a href="#_info"><strong><code>info</code></strong></a> <code>commands</code>, <a href="#_info"><strong><code>info</code></strong></a> <code>aliases</code> and <a href="#_info"><strong><code>info</code></strong></a> <code>channels</code>.</p></div>
 <div class="paragraph"><p>If the type is omitted, a type of <em>-var</em> is used. The type may be abbreviated.</p></div>
 </div>
 <div class="sect2">
@@ -4876,6 +4963,15 @@ The legal <code><em>option</em></code>'s (which may be abbreviated) are:
 </p>
 </dd>
 <dt class="hdlist1">
+<code><strong>info aliases ?-all?</strong> ?<em>pattern</em>?</code>
+</dt>
+<dd>
+<p>
+    Returns a list of alias commands.
+    See <a href="#_info"><strong><code>info</code></strong></a> <code>commands</code> for the meaning of <code><strong>-all</strong></code> and <code><em>pattern</em></code>.
+</p>
+</dd>
+<dt class="hdlist1">
 <code><strong>info body</strong> <em>procname</em></code>
 </dt>
 <dd>
@@ -4885,23 +4981,27 @@ The legal <code><em>option</em></code>'s (which may be abbreviated) are:
 </p>
 </dd>
 <dt class="hdlist1">
-<code><strong>info channels</strong></code>
+<code><strong>info channels ?-all?</strong> ?<em>pattern</em>?</code>
 </dt>
 <dd>
 <p>
-    Returns a list of all open file handles from <a href="#_open"><strong><code>open</code></strong></a> or <a href="#_socket"><strong><code>socket</code></strong></a>
+    Returns a list of open file handles from <a href="#_open"><strong><code>open</code></strong></a> or <a href="#_socket"><strong><code>socket</code></strong></a>.
+    See <a href="#_info"><strong><code>info</code></strong></a> <code>commands</code> for the meaning of <code><strong>-all</strong></code> and <code><em>pattern</em></code>.
 </p>
 </dd>
 <dt class="hdlist1">
-<code><strong>info commands</strong> ?<em>pattern</em>?</code>
+<code><strong>info commands ?-all?</strong> ?<em>pattern</em>?</code>
 </dt>
 <dd>
 <p>
     If <code><em>pattern</em></code> isn&#8217;t specified, returns a list of names of all the
     Tcl commands, including both the built-in commands written in C and
-    the command procedures defined using the <a href="#_proc"><strong><code>proc</code></strong></a> command.
+    the command procedures defined using the <a href="#_proc"><strong><code>proc</code></strong></a> command (including aliases
+    and channels).
     If <code><em>pattern</em></code> is specified, only those names matching <code><em>pattern</em></code>
     (using <a href="#_string_matching">STRING MATCHING</a> rules) are returned.
+    Normally commands containing a space character are not returned.
+    If <code><strong>-all</strong></code> is given, the result does include these commands.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -5067,14 +5167,21 @@ The legal <code><em>option</em></code>'s (which may be abbreviated) are:
 </p>
 </dd>
 <dt class="hdlist1">
-<code><strong>info procs</strong> ?<em>pattern</em>?</code>
+<code><strong>info patchlevel</strong></code>
 </dt>
 <dd>
 <p>
-    If <code><em>pattern</em></code> isn&#8217;t specified, returns a list of all the
-    names of Tcl command procedures.
-    If <code><em>pattern</em></code> is specified, only those names matching <code><em>pattern</em></code>
-    (using <a href="#_string_matching">STRING MATCHING</a> rules) are returned.
+    Returns the build (git) version if available. Otherwise
+    returns the same as <a href="#_info"><strong><code>info</code></strong></a> <code>version</code>.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>info procs ?-all?</strong> ?<em>pattern</em>?</code>
+</dt>
+<dd>
+<p>
+    Returns a list containing the names of Tcl command procedures.
+    See <a href="#_info"><strong><code>info</code></strong></a> <code>commands</code> for the meaning of <code><strong>-all</strong></code> and <code><em>pattern</em></code>.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -5138,6 +5245,24 @@ The legal <code><em>option</em></code>'s (which may be abbreviated) are:
     <code><em>procname</em></code>.  <code><em>procname</em></code> must be the name of a Tcl command
     procedure. An empty dictionary is returned if the procedure has
     no static variables.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>info tainted</strong> <em>str</em></code>
+</dt>
+<dd>
+<p>
+    Returns 1 if the value is tainted, or 0 if not.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>info usage</strong> <em>command</em></code>
+</dt>
+<dd>
+<p>
+    Returns the usage for the given command. For Tcl command procedures, this is based
+    on the arguments defined for the procedure. For a C command, this is the command usage
+    that was specificied when the command was registered.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -5252,6 +5377,51 @@ than variables, a list of unassigned elements is returned.</p></div>
 </div></div>
 </div>
 <div class="sect2">
+<h3 id="_lsubst">lsubst</h3>
+<div class="paragraph"><p><code><strong>lsubst ?-line?</strong> <em>string</em></code></p></div>
+<div class="paragraph"><p>This command is similar to <a href="#_list"><strong><code>list</code></strong></a> in that it creates a list, but uses
+the same rules as scripts when constructing the elements of the list.
+It is somewhat similar to <a href="#_subst"><strong><code>subst</code></strong></a> except it produces a list instead of a string.</p></div>
+<div class="paragraph"><p>This means that variables are substituted, commands are evaluated, backslashes are
+interpreted, the expansion operator is applied and comments are skipped.</p></div>
+<div class="paragraph"><p>Consider the following example.</p></div>
+<div class="paragraph"><p>---
+    set x 1
+    set y {2 3}
+    set z 3
+    lsubst {
+        # This is a list with interpolation
+        $x; # The x variable
+        {<strong>}$y; # The y variable expanded
+        [string cat a b c]; # A command
+        {</strong>}[list 4 5]; # A list expanded into multiple elements
+        "$z$z"; # A string with interpolation
+    }
+---</p></div>
+<div class="paragraph"><p>The result of <a href="#_lsubst"><strong><code>lsubst</code></strong></a> is the following list with 7 elements.</p></div>
+<div class="paragraph"><p>---
+    1 2 3 abc 4 5 33
+---</p></div>
+<div class="paragraph"><p>This is particularly useful when constructing a list (or dict)
+as a data structure as it easily allows for comments and variable and command
+substitution.</p></div>
+<div class="paragraph"><p>Sometimes it is useful to return each "command" as a separate list rather than
+simply running all the words together. This can be accomplished with <a href="#_lsubst"><strong><code>lsubst</code></strong></a> <code>-line</code>.</p></div>
+<div class="paragraph"><p>Consider the following example.</p></div>
+<div class="paragraph"><p>---
+    lsubst -line {
+        # two "lines" because of the semicolon
+        one a; two b
+        # one line with three elements
+        {*}{a b c}
+    }
+---</p></div>
+<div class="paragraph"><p>The result of <a href="#_lsubst"><strong><code>lsubst</code></strong></a> <code>-line</code> is the following list with 3 elements, one for each "command".</p></div>
+<div class="paragraph"><p>---
+{one a} {two b} {a b c}
+---</p></div>
+</div>
+<div class="sect2">
 <h3 id="_local">local</h3>
 <div class="paragraph"><p><code><strong>local</strong> <em>cmd ?arg...?</em></code></p></div>
 <div class="paragraph"><p>First, <a href="#_local"><strong><code>local</code></strong></a> evaluates <code><em>cmd</em></code> with the given arguments. The return value must
@@ -5278,16 +5448,13 @@ continues to have global scope while it is active.</p></div>
     }</code></pre>
 </div></div>
 <div class="paragraph"><p>In this example, the lambda is deleted at the end of the procedure rather
-than waiting until garbage collection.</p></div>
+than waiting until garbage collection. Note that <a href="#_local"><strong><code>local</code></strong></a> returns the command name.</p></div>
 <div class="listingblock">
 <div class="content">
 <pre><code>    proc outer {} {
-      set x [lambda inner {args} {
+      set x [local lambda {args} {
         # will be deleted when 'outer' exits
       }]
-      # Use 'function' here which simply returns $x
-      local function $x
-
       $x ...
       ...
     }</code></pre>
@@ -5920,30 +6087,89 @@ pipeline is directed to the current standard output unless overridden
 by the command. If read-only access is used (e.g. <code><em>access</em></code> is r),
 standard input for the pipeline is taken from the current standard
 input unless overridden by the command.</p></div>
+<div class="paragraph"><p>Note that this incudes new style exec syntax, e.g. <code><em>open |[list | ls -l] r</em></code>.</p></div>
 <div class="paragraph"><p>The <a href="#_pid"><strong><code>pid</code></strong></a> command may be used to return the process ids of the commands
 forming the command pipeline.</p></div>
 <div class="paragraph"><p>See also <a href="#_socket"><strong><code>socket</code></strong></a>, <a href="#_pid"><strong><code>pid</code></strong></a>, <a href="#_exec"><strong><code>exec</code></strong></a></p></div>
 </div>
 <div class="sect2">
 <h3 id="_package">package</h3>
-<div class="paragraph"><p><code><strong>package provide</strong> <em>name ?version?</em></code></p></div>
-<div class="paragraph"><p>Indicates that the current script provides the package named <code><em>name</em></code>.
+<div class="dlist"><dl>
+<dt class="hdlist1">
+<code><strong>package forget</strong> <em>?name &#8230;?</em></code>
+</dt>
+<dd>
+<p>
+Removes the knowledge that the given packages were loaded. This allows new, replacement
+packages to be loaded. Note that it does not remove any effects of the previous packages
+being loaded.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>package provide</strong> <em>name ?version?</em></code>
+</dt>
+<dd>
+<p>
+Indicates that the current script provides the package named <code><em>name</em></code>.
 <strong>Note</strong>: The supplied version is ignored. All packages are registered as version 1.0
-(it is simply accepted for compatibility purposes).</p></div>
-<div class="paragraph"><p>Any script that provides a package may include this statement
-as the first statement, although it is not required.</p></div>
-<div class="paragraph"><p><code><strong>package require</strong> <em>name ?version?</em></code></p></div>
-<div class="paragraph"><p>Searches for the package with the given <code><em>name</em></code> by examining each path
+(it is simply accepted for compatibility purposes).
+</p>
+</dd>
+<dt class="hdlist1">
+ 
+</dt>
+<dd>
+<p>
+Any script that provides a package may include this statement
+as the first statement, although it is not required.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>package require</strong> <em>name ?version?</em></code>
+</dt>
+<dd>
+<p>
+Searches for the package with the given <code><em>name</em></code> by examining each path
 in <em>$::auto_path</em> and trying to load <em>$path/$name.so</em> as a dynamic extension,
-or <em>$path/$name.tcl</em> as a script package.</p></div>
-<div class="paragraph"><p>The first such file which is found is considered to provide the package.
-(The version number is ignored).</p></div>
-<div class="paragraph"><p>If <em>$name.so</em> exists, it is loaded with the <a href="#_load"><strong><code>load</code></strong></a> command,
-otherwise if <em>$name.tcl</em> exists it is loaded with the <a href="#_source"><strong><code>source</code></strong></a> command.</p></div>
-<div class="paragraph"><p>If <a href="#_load"><strong><code>load</code></strong></a> or <a href="#_source"><strong><code>source</code></strong></a> fails, <a href="#_package"><strong><code>package</code></strong></a> <code>require</code> will fail immediately.
-No further attempt will be made to locate the file.</p></div>
-<div class="paragraph"><p><code><strong>package names</strong></code></p></div>
-<div class="paragraph"><p>Returns a list of all known/loaded packages, including internal packages.</p></div>
+or <em>$path/$name.tcl</em> as a script package.
+</p>
+</dd>
+<dt class="hdlist1">
+ 
+</dt>
+<dd>
+<p>
+The first such file which is found is considered to provide the package.
+(The version number is ignored).
+</p>
+</dd>
+<dt class="hdlist1">
+ 
+</dt>
+<dd>
+<p>
+If <em>$name.so</em> exists, it is loaded with the <a href="#_load"><strong><code>load</code></strong></a> command,
+otherwise if <em>$name.tcl</em> exists it is loaded with the <a href="#_source"><strong><code>source</code></strong></a> command.
+</p>
+</dd>
+<dt class="hdlist1">
+ 
+</dt>
+<dd>
+<p>
+If <a href="#_load"><strong><code>load</code></strong></a> or <a href="#_source"><strong><code>source</code></strong></a> fails, <a href="#_package"><strong><code>package</code></strong></a> <code>require</code> will fail immediately.
+No further attempt will be made to locate the file.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>package names</strong></code>
+</dt>
+<dd>
+<p>
+Returns a list of all known/loaded packages, including internal packages.
+</p>
+</dd>
+</dl></div>
 </div>
 <div class="sect2">
 <h3 id="_pid">pid</h3>
@@ -6026,13 +6252,13 @@ and ranging up to but not including <code><em>end</em></code> in steps of <code>
 </div>
 <div class="sect2">
 <h3 id="_read">read</h3>
-<div class="paragraph"><p><code>*read ?-nonewline? <em>fileId ?length?</em></code></p></div>
+<div class="paragraph"><p><code><strong>read</strong> ?-nonewline? <em>fileId ?length?</em></code></p></div>
 <div class="paragraph"><p>Tcl-compatible alterative version of <code><em>fileId</em> <strong>read ?-nonewline?</strong> <em>?length?</em></code></p></div>
 <div class="paragraph"><p>See <a href="#_aio"><strong><code>aio</code></strong></a> <code>read</code></p></div>
 </div>
 <div class="sect2">
 <h3 id="_regexp">regexp</h3>
-<div class="paragraph"><p><code><strong>regexp ?-nocase? ?-line? ?-indices? ?-start</strong> <em>offset</em>? <strong>?-all? ?-inline? ?--?</strong> <em>exp string ?matchVar? ?subMatchVar subMatchVar ...?</em></code></p></div>
+<div class="paragraph"><p><code><strong>regexp ?-nocase? ?-line? ?-indices? ?-start</strong> <em>offset</em>? <strong>?-all? ?-inline? ?-expanded? ?--?</strong> <em>exp string ?matchVar? ?subMatchVar subMatchVar ...?</em></code></p></div>
 <div class="paragraph"><p>Determines whether the regular expression <code><em>exp</em></code> matches part or
 all of <code><em>string</em></code> and returns 1 if it does, 0 if it doesn&#8217;t.</p></div>
 <div class="paragraph"><p>See <a href="#_regular_expressions">REGULAR EXPRESSIONS</a> above for complete information on the
@@ -6130,6 +6356,15 @@ string otherwise.</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
+<code><strong>-expanded</strong></code>
+</dt>
+<dd>
+<p>
+    Enables use of the expanded regular expression syntax where whitespace
+    and comments are ignored.
+</p>
+</dd>
+<dt class="hdlist1">
 <code><strong>--</strong></code>
 </dt>
 <dd>
@@ -6142,7 +6377,7 @@ string otherwise.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_regsub">regsub</h3>
-<div class="paragraph"><p><code><strong>regsub ?-nocase? ?-all? ?-line? ?-command? ?-start</strong> <em>offset</em>? ?<strong>--</strong>? <em>exp string subSpec ?varName?</em></code></p></div>
+<div class="paragraph"><p><code><strong>regsub ?-nocase? ?-all? ?-line? ?-command? ?-expanded? ?-start</strong> <em>offset</em>? ?<strong>--</strong>? <em>exp string subSpec ?varName?</em></code></p></div>
 <div class="paragraph"><p>This command matches the regular expression <code><em>exp</em></code> against
 <code><em>string</em></code> using the rules described in REGULAR EXPRESSIONS
 above.</p></div>
@@ -6245,6 +6480,15 @@ backslashes.</p></div>
     Specifies a character index offset into the string at which to
     start matching the regular expression. <code><em>offset</em></code> will be
     constrained to the bounds of the input string.
+</p>
+</dd>
+<dt class="hdlist1">
+<code><strong>-expanded</strong></code>
+</dt>
+<dd>
+<p>
+    Enables use of the expanded regular expression syntax where whitespace
+    and comments are ignored.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -7155,6 +7399,11 @@ the current call frame. This is similar to <em>exec</em> in Bourne Shell.</p></d
 </div></div>
 </div>
 <div class="sect2">
+<h3 id="_taint">taint</h3>
+<div class="paragraph"><p><code><strong>taint</strong> <em>varname</em></code></p></div>
+<div class="paragraph"><p>Set "taint" on the value contained in the given variable.</p></div>
+</div>
+<div class="sect2">
 <h3 id="_tell">tell</h3>
 <div class="paragraph"><p><code><strong>tell</strong> <em>fileId</em></code></p></div>
 <div class="paragraph"><p>Tcl-compatible version of <code><em>fileId</em> <strong>tell</strong></code></p></div>
@@ -7305,6 +7554,11 @@ is specified. The <em>--</em> argument may be specified to stop option processin
 in case the variable name may be <em>-nocomplain</em>.</p></div>
 </div>
 <div class="sect2">
+<h3 id="_untaint">untaint</h3>
+<div class="paragraph"><p><code><strong>untaint</strong> <em>varname</em></code></p></div>
+<div class="paragraph"><p>Remove "taint" from the value contained in the given variable.</p></div>
+</div>
+<div class="sect2">
 <h3 id="_upcall">upcall</h3>
 <div class="paragraph"><p><code><strong>upcall</strong> <em>command ?args &#8230;?</em></code></p></div>
 <div class="paragraph"><p>May be used from within a proc defined as <a href="#_local"><strong><code>local</code></strong></a> <a href="#_proc"><strong><code>proc</code></strong></a> in order to call
@@ -7451,7 +7705,7 @@ the execution trace is removed.</p></div>
 <div class="paragraph"><p>The following extensions may or may not be available depending upon
 what options were selected when Jim Tcl was built.</p></div>
 <div class="sect2">
-<h3 id="cmd_1">posix: os.fork, os.gethostname, os.getids, os.uptime</h3>
+<h3 id="cmd_1">posix: os.fork, os.gethostname, os.getids, os.uptime, os.umask</h3>
 <div class="dlist"><dl>
 <dt class="hdlist1">
 <code><strong>os.fork</strong></code>
@@ -7484,6 +7738,14 @@ what options were selected when Jim Tcl was built.</p></div>
     uid 1000 euid 1000 gid 100 egid 100</code></pre>
 </div></div>
 <div class="dlist"><dl>
+<dt class="hdlist1">
+<code><strong>os.umask</strong> ?newmask?</code>
+</dt>
+<dd>
+<p>
+    Set or return the current process <em>umask(2)</em>. Returns the previous umask.
+</p>
+</dd>
 <dt class="hdlist1">
 <code><strong>os.uptime</strong></code>
 </dt>
@@ -7839,6 +8101,20 @@ over <a href="#_aio"><strong><code>aio</code></strong></a> <code>read</code> and
 </p>
 </dd>
 <dt class="hdlist1">
+<code>$handle <strong>taint source|sink ?0:n?</strong></code>
+</dt>
+<dd>
+<p>
+    Sets the taint characteristics of the channel. Data read from
+    the channel will have a taint value as set by <code><em>source</em></code>, while
+    a check will be made against data written to the channel against
+    the <code><em>sink</em></code> value. If the taint of the data and the channel
+    match, the operation will fail. By default, channels created
+    by <a href="#_open"><strong><code>open</code></strong></a> are not tainted while channels created by <a href="#_socket"><strong><code>socket</code></strong></a>
+    have both set to 1.
+</p>
+</dd>
+<dt class="hdlist1">
 <code>$handle <strong>tell</strong></code>
 </dt>
 <dd>
@@ -7855,6 +8131,17 @@ over <a href="#_aio"><strong><code>aio</code></strong></a> <code>read</code> and
     If an argument is given, it is set as the timeout of the channel, in milliseconds.
     See <a href="#_aio"><strong><code>aio</code></strong></a> <code>read</code> and <a href="#_aio"><strong><code>aio</code></strong></a> <code>gets</code> for command that use the timeout.
     Note that the timeout is only used if the channel is in blocking mode.
+</p>
+</dd>
+<dt class="hdlist1">
+<code>$handle <strong>translation binary|text</strong></code>
+</dt>
+<dd>
+<p>
+    This has no effect on Unix platforms, but on Windows it changes the mode of the file
+    handle to binary or text. In general, use "wb" as the open mode instead, but this
+    can be useful on existing filehandles such as <code>stdout</code> and <code>stderr</code>. It is probably
+    a good idea to do this immediately before sending any output.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -8092,7 +8379,7 @@ if end-of-file was reached.</p></div>
 </li>
 <li>
 <p>
-<a href="#_fconfigure"><strong><code>fconfigure</code></strong></a> <code>... -translation</code> is accepted but ignored
+<a href="#_fconfigure"><strong><code>fconfigure</code></strong></a> <code>... -translation</code> maps to <a href="#_aio"><strong><code>aio</code></strong></a> <code>translation</code> and suppports only <code>binary</code> and <code>text</code>
 </p>
 </li>
 </ul></div>
@@ -8188,7 +8475,7 @@ handler is removed.</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
-<code><strong>vwait ?-signal?</strong> <em>variable</em></code>
+<code><strong>vwait ?-signal?</strong> <em>variable</em> ?script?</code>
 </dt>
 <dd>
 <p>
@@ -8196,9 +8483,11 @@ handler is removed.</p></div>
     events until the named (global) variable changes or all
     event handlers are removed. The variable need not exist
     beforehand.  If there are no event handlers defined, <a href="#cmd_2"><strong><code>vwait</code></strong></a>
-    returns immediately. If <code><em>-signal</em></code> is specified, <a href="#cmd_2"><strong><code>vwait</code></strong></a> will
+    returns immediately. If <code><strong>-signal</strong></code> is specified, <a href="#cmd_2"><strong><code>vwait</code></strong></a> will
     also quit if a handled signal occurs. In this case, <a href="#_signal"><strong><code>signal</code></strong></a> <code>check -clear</code>
-    can be used to check for the signal that occurred.
+    can be used to check for the signal that occurred. If <code><em>script</em></code> is given
+    it is evaluated after each event. If it returns break, <a href="#cmd_2"><strong><code>vwait</code></strong></a> returns.
+    <a href="#cmd_2"><strong><code>vwait</code></strong></a> also returns with an error if the script returns an error.
 </p>
 </dd>
 <dt class="hdlist1">
@@ -8941,6 +9230,16 @@ the remaining subcommands do nothing.</p></div>
 <div class="paragraph"><p>Provides namespace-related functions. See also: <a href="http://www.tcl.tk/man/tcl8.6/TclCmd/namespace.htm">http://www.tcl.tk/man/tcl8.6/TclCmd/namespace.htm</a></p></div>
 <div class="dlist"><dl>
 <dt class="hdlist1">
+<code><strong>namespace canonical</strong> ?current? ?name?</code>
+</dt>
+<dd>
+<p>
+   Returns the full name of <code><em>name</em></code> within namespace <em><code>current</code></em>.
+   If <em><code>current</code></em> is not given, <a href="#_namespace"><strong><code>namespace</code></strong></a> <code>current</code> is used.
+   If neither are given, returns the current namespace (not qualified with a leading <em>::</em>).
+</p>
+</dd>
+<dt class="hdlist1">
 <code><strong>namespace code</strong> <em>script</em></code>
 </dt>
 <dd>
@@ -8967,7 +9266,7 @@ the remaining subcommands do nothing.</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
-<code><strong>namespace ensemble create</strong>'</code>
+<code><strong>namespace ensemble create</strong></code>
 </dt>
 <dd>
 <p>

--- a/auto.def
+++ b/auto.def
@@ -28,6 +28,7 @@ options {
     full
     allextmod       => "Enable all non-default extensions as modules if prerequisites are found"
     compat          => "Enable some backward compatibility behaviour"
+    taint=1         => "Disable taint support"
     extinfo         => "Show information about available extensions"
     with-jim-shared shared => "Build a shared library instead of a static library"
     jim-regexp=1    => "Prefer POSIX regex if over the the built-in (Tcl-compatible) regex"
@@ -482,9 +483,14 @@ if {[opt-bool compat]} {
     msg-result "Enabling compatibility mode"
     define JIM_COMPAT
 }
+
 if {![opt-bool introspection]} {
     msg-result "Disabling introspection"
     define JIM_NO_INTROSPECTION
+}
+if {[opt-bool taint]} {
+    msg-result "Enabling taint support"
+    define JIM_TAINT
 }
 if {[opt-bool shared with-jim-shared]} {
     msg-result "Building shared library"
@@ -663,7 +669,7 @@ foreach mod $extinfo(module-c) {
 }
 define BUILD_SHOBJS [join $lines \n]
 
-make-config-header jim-config.h -auto {HAVE_LONG_LONG* JIM_UTF8 SIZEOF_INT} -bare JIM_VERSION -none *
+make-config-header jim-config.h -auto {HAVE_LONG_LONG* JIM_UTF8 JIM_TAINT SIZEOF_INT} -bare JIM_VERSION -none *
 make-config-header jimautoconf.h -auto {jim_ext_* TCL_PLATFORM_* TCL_LIBRARY USE_* JIM_* _FILE_OFFSET*} -bare {S_I*}
 make-template Makefile.in
 make-template tests/Makefile.in

--- a/auto.def
+++ b/auto.def
@@ -31,7 +31,7 @@ options {
     taint=1         => "Disable taint support"
     extinfo         => "Show information about available extensions"
     with-jim-shared shared => "Build a shared library instead of a static library"
-    jim-regexp=1    => "Prefer POSIX regex if over the the built-in (Tcl-compatible) regex"
+    jim-regexp=1    => "Prefer POSIX regex over the the built-in (Tcl-compatible) regex"
     docs=1          => "Don't build or install the documentation"
     docdir:path     => "Path to install docs (if built)"
     random-hash     => "Randomise hash tables. more secure but hash table results are not predicable"
@@ -499,6 +499,11 @@ if {[opt-bool shared with-jim-shared]} {
     define JIM_STATICLIB
 }
 define VERSION [format %.2f [expr {[get-define JIM_VERSION] / 100.0}]]
+set githash [get-define VERSION]
+catch {
+    set githash [exec git describe --dirty]
+}
+define JIM_GITVERSION $githash
 define LIBSOEXT [format [get-define SH_SOEXTVER] [get-define VERSION]]
 if {[get-define libdir] ni {/lib /usr/lib /usr/lib64}} {
     define SH_LINKRPATH_FLAGS [format [get-define SH_LINKRPATH] [get-define libdir]]
@@ -669,7 +674,7 @@ foreach mod $extinfo(module-c) {
 }
 define BUILD_SHOBJS [join $lines \n]
 
-make-config-header jim-config.h -auto {HAVE_LONG_LONG* JIM_UTF8 JIM_TAINT SIZEOF_INT} -bare JIM_VERSION -none *
+make-config-header jim-config.h -auto {HAVE_LONG_LONG* JIM_UTF8 JIM_TAINT JIM_GITVERSION SIZEOF_INT} -bare JIM_VERSION -none *
 make-config-header jimautoconf.h -auto {jim_ext_* TCL_PLATFORM_* TCL_LIBRARY USE_* JIM_* _FILE_OFFSET*} -bare {S_I*}
 make-template Makefile.in
 make-template tests/Makefile.in

--- a/ensemble.tcl
+++ b/ensemble.tcl
@@ -18,7 +18,7 @@ proc ensemble {command args} {
 			if {$subcmd in {-commands -help}} {
 				# Need to remove $autoprefix from the front of these
 				set prefixlen [string length $autoprefix]
-				set subcmds [lmap p [lsort [info commands $autoprefix*]] {
+				set subcmds [lmap p [lsort [info commands -all $autoprefix*]] {
 					string range $p $prefixlen end
 				}]
 				if {$subcmd eq "-commands"} {

--- a/examples.api/jim_command.c
+++ b/examples.api/jim_command.c
@@ -44,16 +44,11 @@ MySampleCommandFunc(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 	const char *str;
 	int len;
 
-	if (argc != 2) {
-		Jim_WrongNumArgs(interp, 1, argv, "string");
-		return (JIM_ERR);
-	}
-
+	/* No need to check arg count here as this is checked by Jim_RegisterCmd() */
 	str = Jim_GetString(argv[1], &len);
-	assert(str != NULL);
 	printf("%s\n", str);
 
-	return (JIM_OK);
+	return JIM_OK;
 }
 
 /*
@@ -77,9 +72,8 @@ main(int argc, char **argv)
 	/* And initialise any static extensions */
 	Jim_InitStaticExtensions(interp);
 
-	/* Register our Jim commands. */
-	Jim_CreateCommand(interp, "MySampleCommand", MySampleCommandFunc,
-	    NULL, NULL);
+	/* Register our Jim commands. This includes usage and min/max arg count */
+	Jim_RegisterSimpleCmd(interp, "MySampleCommand", "string", 1, 1, MySampleCommandFunc);
 
 	/* Run a script. */
 	error = Jim_Eval(interp, JIM_PROGRAM);

--- a/examples.api/jim_return.c
+++ b/examples.api/jim_return.c
@@ -44,10 +44,6 @@
 static int
 CountCharsFunc(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-	if (argc != 2) {
-		Jim_WrongNumArgs(interp, 1, argv, "string");
-		return (JIM_ERR);
-	}
 	Jim_SetResult(interp, Jim_NewIntObj(interp, Jim_Length(argv[1])));
 	return (JIM_OK);
 }
@@ -73,10 +69,8 @@ main(int argc, char **argv)
 	/* And initialise any static extensions */
 	Jim_InitStaticExtensions(interp);
 
-
 	/* Register our Jim command. */
-	Jim_CreateCommand(interp, "CountChars", CountCharsFunc,
-	    NULL, NULL);
+	Jim_RegisterSimpleCmd(interp, "CountChars", "string", 1, 1, CountCharsFunc);
 
 	/* Run a script. */
 	error = Jim_Eval(interp, JIM_PROGRAM);

--- a/examples.ext/helloworld.c
+++ b/examples.ext/helloworld.c
@@ -19,6 +19,8 @@ Hello_Cmd(Jim_Interp *interp, int objc, Jim_Obj *const objv[])
 int
 Jim_helloworldInit(Jim_Interp *interp)
 {
-    Jim_CreateCommand(interp, "hello", Hello_Cmd, NULL, NULL);
+    /* Register the package with Jim and check that the ABI matches the interpreter */
+    Jim_PackageProvideCheck(interp, "helloworld");
+    Jim_RegisterSimpleCmd(interp, "hello", "", 0, 0, Hello_Cmd);
     return JIM_OK;
 }

--- a/examples/udp.client
+++ b/examples/udp.client
@@ -26,3 +26,8 @@ foreach i [range 5 10] {
 	# Receive the response - max length of 100
 	puts [$s recvfrom 100]
 }
+
+# If taint is supported, this is an unsafe command
+# and the server will refuse to do it
+$s puts -nonewline {[exec echo hello]}
+puts [$s recvfrom 100]

--- a/examples/udp.server
+++ b/examples/udp.server
@@ -3,6 +3,12 @@
 # Listen on port 20000. No host specified means 0.0.0.0
 set s [socket dgram.server 20000]
 
+# We won't run unsafe commands, but
+# we don't mind sending anything back
+catch {
+	$s taint sink 0
+}
+
 # For each request...
 $s readable {
 	# Get the request (max 80 chars) - need the source address

--- a/initjimsh.tcl
+++ b/initjimsh.tcl
@@ -112,8 +112,8 @@ set tcl::stdhint_col $tcl::stdhint_cols(lcyan)
 # The default hint implementation
 proc tcl::stdhint {string} {
 	set result ""
+	lassign $string cmd arg
 	if {[llength $string] >= 2} {
-		lassign $string cmd arg
 		if {$cmd in $::tcl::stdhint_commands || [info channel $cmd] ne ""} {
 			catch {
 				set help [$cmd -help $arg]
@@ -134,6 +134,23 @@ proc tcl::stdhint {string} {
 					set result [list $prefix$hint {*}$::tcl::stdhint_col]
 				}
 			}
+		}
+	} else {
+		catch {
+			if {[exists -alias $cmd] && [llength [info alias $cmd]] == 1} {
+				# Look through a simple alias. Doesn't really work for anything more complex.
+				# consider 'alias p stderr puts' where we can't really provide the usage
+				# of 'stderr puts'
+				set help [info usage [info alias $cmd]]
+			} else {
+				set help [info usage $cmd]
+			}
+			set hint [join [lrange $help 1 end]]
+			set prefix " "
+			if {[string match "* " $string]} {
+				set prefix ""
+			}
+			set result [list $prefix$hint {*}$::tcl::stdhint_col]
 		}
 	}
 	return $result

--- a/jim-aio.c
+++ b/jim-aio.c
@@ -637,9 +637,7 @@ static int JimSetVariableSocketAddress(Jim_Interp *interp, Jim_Obj *varObjPtr, c
 {
     int ret;
     Jim_Obj *objPtr = JimFormatSocketAddress(interp, sa, salen);
-    Jim_IncrRefCount(objPtr);
     ret = Jim_SetVariable(interp, varObjPtr, objPtr);
-    Jim_DecrRefCount(interp, objPtr);
     return ret;
 }
 
@@ -1181,7 +1179,6 @@ static int aio_cmd_gets(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     if (argc) {
         if (Jim_SetVariable(interp, argv[0], objPtr) != JIM_OK) {
-            Jim_FreeNewObj(interp, objPtr);
             return JIM_ERR;
         }
 

--- a/jim-array.c
+++ b/jim-array.c
@@ -260,6 +260,6 @@ static const jim_subcmd_type array_command_table[] = {
 int Jim_arrayInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "array");
-    Jim_CreateCommand(interp, "array", Jim_SubCmdProc, (void *)array_command_table, NULL);
+    Jim_RegisterSubCmd(interp, "array", array_command_table, NULL);
     return JIM_OK;
 }

--- a/jim-clock.c
+++ b/jim-clock.c
@@ -213,6 +213,6 @@ static const jim_subcmd_type clock_command_table[] = {
 int Jim_clockInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "clock");
-    Jim_CreateCommand(interp, "clock", Jim_SubCmdProc, (void *)clock_command_table, NULL);
+    Jim_RegisterSubCmd(interp, "clock", clock_command_table, NULL);
     return JIM_OK;
 }

--- a/jim-eventloop.c
+++ b/jim-eventloop.c
@@ -573,8 +573,7 @@ static int JimELVwaitCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     }
 
     if (argc - signal != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "?-signal? name");
-        return JIM_ERR;
+        return JIM_USAGE;
     }
 
     oldValue = Jim_GetGlobalVariable(interp, argv[1 + signal], JIM_NONE);
@@ -640,9 +639,8 @@ static int JimELUpdateCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv
     if (argc == 1) {
         flags = JIM_ALL_EVENTS;
     }
-    else if (argc > 2 || Jim_GetEnum(interp, argv[1], options, &option, NULL, JIM_ERRMSG | JIM_ENUM_ABBREV) != JIM_OK) {
-        Jim_WrongNumArgs(interp, 1, argv, "?idletasks?");
-        return JIM_ERR;
+    else if (argc > 2 || Jim_GetEnum(interp, argv[1], options, &option, NULL, JIM_ENUM_ABBREV) != JIM_OK) {
+        return JIM_USAGE;
     }
 
     eventLoop->suppress_bgerror = 0;
@@ -679,11 +677,6 @@ static int JimELAfterCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     enum
     { AFTER_CANCEL, AFTER_INFO, AFTER_IDLE, AFTER_RESTART, AFTER_EXPIRE, AFTER_CREATE };
     int option = AFTER_CREATE;
-
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "option ?arg ...?");
-        return JIM_ERR;
-    }
     if (Jim_GetDouble(interp, argv[1], &ms) != JIM_OK) {
         if (Jim_GetEnum(interp, argv[1], options, &option, "argument", JIM_ERRMSG) != JIM_OK) {
             return JIM_ERR;
@@ -792,9 +785,9 @@ int Jim_eventloopInit(Jim_Interp *interp)
 
     Jim_SetAssocData(interp, "eventloop", JimELAssocDataDeleProc, eventLoop);
 
-    Jim_CreateCommand(interp, "vwait", JimELVwaitCommand, eventLoop, NULL);
-    Jim_CreateCommand(interp, "update", JimELUpdateCommand, eventLoop, NULL);
-    Jim_CreateCommand(interp, "after", JimELAfterCommand, eventLoop, NULL);
+    Jim_RegisterCmd(interp, "vwait", "?-signal? name", 1, 2, JimELVwaitCommand, NULL, eventLoop, 0);
+    Jim_RegisterCmd(interp, "update", "?idletasks?", 0, 1, JimELUpdateCommand, NULL, eventLoop, 0);
+    Jim_RegisterCmd(interp, "after", "option ?arg ...?", 1, -1, JimELAfterCommand, NULL, eventLoop, 0);
 
     return JIM_OK;
 }

--- a/jim-exec.c
+++ b/jim-exec.c
@@ -700,9 +700,71 @@ static unsigned JimExecClassifyArg(const char *arg)
 }
 
 /**
+ * Parses the exec pipeline in TIP424 format into two lists, cmdList and redirectList.
+ * (These must start as empty lists)
+ *
+ * Returns JIM_OK if ok or JIM_ERR on error.
+ */
+static int JimParsePipeline(Jim_Interp *interp, int argc, Jim_Obj *const *argv, Jim_Obj *cmdList, Jim_Obj *redirectList)
+{
+    int i;
+    /* Add an initial empty commandlist */
+    int first = 1;
+    const char *arg = NULL;
+
+    for (i = 0; i < argc; i++) {
+        unsigned ett;
+        if (first) {
+            if (Jim_ListLength(interp, argv[i]) == 0) {
+                Jim_SetResultString(interp, "empty command list", -1);
+                return JIM_ERR;
+            }
+            Jim_ListAppendElement(interp, cmdList, argv[i]);
+            first = 0;
+            continue;
+        }
+        /* Remaining items should be redirections or | */
+        arg = Jim_String(argv[i]);
+        ett = JimExecClassifyArg(arg);
+        if (ett == JIM_ETT_BAD || ett == JIM_ETT_CMD) {
+            Jim_SetResultFormatted(interp, "invalid redirection %s", arg);
+            return JIM_ERR;
+        }
+        if (ett & JIM_ETT_PIPE) {
+            Jim_ListAppendElement(interp, cmdList, argv[i]);
+            first = 1;
+            continue;
+        }
+        Jim_ListAppendElement(interp, redirectList, argv[i]);
+        if ((ett & JIM_ETT_NOARG)) {
+            /* This means we need an arg */
+            if (i >= argc - 1) {
+                /* This is an error */
+                Jim_SetResultFormatted(interp, "can't specify \"%#s\" as last word in command", argv[i]);
+                return -1;
+            }
+            i++;
+            Jim_ListAppendElement(interp, redirectList, argv[i]);
+        }
+    }
+
+    if (first) {
+        if (Jim_ListLength(interp, cmdList)) {
+            Jim_SetResultFormatted(interp, "cmdlist required after %s", arg);
+        }
+        else {
+            Jim_SetResultString(interp, "cmdlist is required", -1);
+        }
+        return JIM_ERR;
+    }
+
+    return JIM_OK;
+}
+
+/**
  * Parses the exec pipeline in legacy format into two lists, cmdList and redirectList.
  * (These must start as empty lists)
- * 
+ *
  * cmdList contains a list of {cmdlist ?sep cmdlist ...? }
  * i.e. pairs of cmdlist (a list of {command arg...}) and a separator:  | or |&
  * with the separator missing after the last command list.
@@ -1267,14 +1329,23 @@ static int
 JimCreatePipeline(Jim_Interp *interp, int argc, Jim_Obj *const *argv, phandle_t **pidArrayPtr,
     int *outPipePtr, int *errFilePtr)
 {
-    /* JimParsePipelineLegacy builds cmdList and redirectList */
+    int rc = -1;
+    int ret;
+
     Jim_Obj *cmdList = Jim_NewListObj(interp, NULL, 0);
     Jim_Obj *redirectList = Jim_NewListObj(interp, NULL, 0);
     Jim_IncrRefCount(cmdList);
     Jim_IncrRefCount(redirectList);
 
-    int rc = -1;
-    if (JimParsePipelineLegacy(interp, argc, argv, cmdList, redirectList) == JIM_OK) {
+    if (argc > 1 && Jim_CompareStringImmediate(interp, argv[0], "|")) {
+        /* TIP424 exec format */
+        ret = JimParsePipeline(interp, argc - 1, argv + 1, cmdList, redirectList);
+    }
+    else {
+        /* legacy exec format */
+        ret = JimParsePipelineLegacy(interp, argc, argv, cmdList, redirectList);
+    }
+    if (ret == JIM_OK) {
         /* OK, try to exec */
         rc = JimExecPipeline(interp, cmdList, redirectList, pidArrayPtr, outPipePtr, errFilePtr);
     }

--- a/jim-exec.c
+++ b/jim-exec.c
@@ -374,6 +374,11 @@ static int Jim_ExecCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     Jim_Obj *errStrObj;
     struct WaitInfoTable *table = Jim_CmdPrivData(interp);
 
+    if (Jim_CheckTaint(interp, JIM_TAINT_ANY)) {
+        Jim_SetTaintError(interp, 1, argv);
+        return JIM_ERR;
+    }
+
     /*
      * See if the command is to be run in the background; if so, create
      * the command, detach it, and return.

--- a/jim-file.c
+++ b/jim-file.c
@@ -1102,19 +1102,7 @@ static const jim_subcmd_type file_command_table[] = {
 
 static int Jim_CdCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    const char *path;
-
-    if (Jim_CheckTaint(interp, JIM_TAINT_ANY)) {
-        Jim_SetTaintError(interp, 1, argv);
-        return JIM_ERR;
-    }
-
-    if (argc != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "dirname");
-        return JIM_ERR;
-    }
-
-    path = Jim_String(argv[1]);
+    const char *path = Jim_String(argv[1]);
 
     if (chdir(path) != 0) {
         Jim_SetResultFormatted(interp, "couldn't change working directory to \"%s\": %s", path,
@@ -1143,8 +1131,8 @@ static int Jim_PwdCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 int Jim_fileInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "file");
-    Jim_CreateCommand(interp, "file", Jim_SubCmdProc, (void *)file_command_table, NULL);
-    Jim_CreateCommand(interp, "pwd", Jim_PwdCmd, NULL, NULL);
-    Jim_CreateCommand(interp, "cd", Jim_CdCmd, NULL, NULL);
+    Jim_RegisterSubCmd(interp, "file", file_command_table, NULL);
+    Jim_RegisterSimpleCmd(interp, "pwd", "", 0, 0, Jim_PwdCmd);
+    Jim_RegisterCmd(interp, "cd", "dirname", 1, 1, Jim_CdCmd, NULL, NULL, JIM_CMD_NOTAINT);
     return JIM_OK;
 }

--- a/jim-file.c
+++ b/jim-file.c
@@ -999,6 +999,7 @@ static const jim_subcmd_type file_command_table[] = {
         file_cmd_delete,
         1,
         -1,
+        JIM_MODFLAG_NOTAINT,
         /* Description: Deletes the files or directories (must be empty unless -force) */
     },
     {   "mkdir",
@@ -1006,6 +1007,7 @@ static const jim_subcmd_type file_command_table[] = {
         file_cmd_mkdir,
         1,
         -1,
+        JIM_MODFLAG_NOTAINT,
         /* Description: Creates the directories */
     },
     {   "tempfile",
@@ -1013,6 +1015,7 @@ static const jim_subcmd_type file_command_table[] = {
         file_cmd_tempfile,
         0,
         1,
+        JIM_MODFLAG_NOTAINT,
         /* Description: Creates a temporary filename */
     },
     {   "rename",
@@ -1020,6 +1023,7 @@ static const jim_subcmd_type file_command_table[] = {
         file_cmd_rename,
         2,
         3,
+        JIM_MODFLAG_NOTAINT,
         /* Description: Renames a file */
     },
 #if defined(HAVE_LINK) && defined(HAVE_SYMLINK)
@@ -1099,6 +1103,11 @@ static const jim_subcmd_type file_command_table[] = {
 static int Jim_CdCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     const char *path;
+
+    if (Jim_CheckTaint(interp, JIM_TAINT_ANY)) {
+        Jim_SetTaintError(interp, 1, argv);
+        return JIM_ERR;
+    }
 
     if (argc != 2) {
         Jim_WrongNumArgs(interp, 1, argv, "dirname");

--- a/jim-history.c
+++ b/jim-history.c
@@ -149,6 +149,6 @@ static const jim_subcmd_type history_command_table[] = {
 int Jim_historyInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "history");
-    Jim_CreateCommand(interp, "history", Jim_SubCmdProc, (void *)history_command_table, NULL);
+    Jim_RegisterSubCmd(interp, "history", history_command_table, NULL);
     return JIM_OK;
 }

--- a/jim-history.c
+++ b/jim-history.c
@@ -24,7 +24,6 @@ static int history_cmd_getline(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     /* Returns the length of the string if varName was specified */
     if (argc == 2) {
         if (Jim_SetVariable(interp, argv[1], objPtr) != JIM_OK) {
-            Jim_FreeNewObj(interp, objPtr);
             return JIM_ERR;
         }
         Jim_SetResultInt(interp, Jim_Length(objPtr));

--- a/jim-interp.c
+++ b/jim-interp.c
@@ -88,7 +88,7 @@ static int interp_cmd_alias(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     aliasPrefixList = Jim_NewListObj(interp, argv + 1, argc - 1);
     Jim_IncrRefCount(aliasPrefixList);
 
-    Jim_CreateCommand(child, Jim_String(argv[0]), JimInterpAliasProc, aliasPrefixList, JimInterpDelAlias);
+    Jim_RegisterCmd(child, Jim_String(argv[0]), NULL, 0, -1, JimInterpAliasProc, JimInterpDelAlias, aliasPrefixList, 0);
     return JIM_OK;
 }
 
@@ -146,11 +146,6 @@ static int JimInterpCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         "argv", "argc", "argv0", "jim::argv0", "jim::exe", "jim::lineedit", NULL
     };
 
-    if (argc != 1) {
-        Jim_WrongNumArgs(interp, 1, argv, "");
-        return JIM_ERR;
-    }
-
     /* Create the interpreter command */
     child = Jim_CreateInterp();
     Jim_RegisterCoreCommands(child);
@@ -165,7 +160,7 @@ static int JimInterpCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     Jim_SetAssocData(child, "interp.parent", NULL, interp);
 
     snprintf(buf, sizeof(buf), "interp.handle%ld", Jim_GetId(interp));
-    Jim_CreateCommand(interp, buf, JimInterpSubCmdProc, child, JimInterpDelProc);
+    Jim_RegisterCmd(interp, buf, "subcommand ?arg ...?", 1, -1, JimInterpSubCmdProc, JimInterpDelProc, child, 0);
     Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
     return JIM_OK;
 }
@@ -173,7 +168,7 @@ static int JimInterpCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 int Jim_interpInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "interp");
-    Jim_CreateCommand(interp, "interp", JimInterpCommand, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "interp", "", 0, 0, JimInterpCommand);
 
     return JIM_OK;
 }

--- a/jim-json.c
+++ b/jim-json.c
@@ -289,9 +289,7 @@ static int parse_json_decode_options(Jim_Interp *interp, int argc, Jim_Obj *cons
 	}
 
 	if (i != argc - 1) {
-		Jim_WrongNumArgs(interp, 1, argv,
-			"?-index? ?-null nullvalue? ?-schema? json");
-		return JIM_ERR;
+		return JIM_USAGE;
 	}
 
 	return JIM_OK;
@@ -369,7 +367,7 @@ json_decode(Jim_Interp *interp, int argc, Jim_Obj *const argv[])
 	state.nullObj = Jim_NewStringObj(interp, "null", -1);
 	Jim_IncrRefCount(state.nullObj);
 
-	if (parse_json_decode_options(interp, argc, argv, &state) != JIM_OK) {
+	if ((ret = parse_json_decode_options(interp, argc, argv, &state)) != JIM_OK) {
 		goto done;
 	}
 
@@ -431,7 +429,7 @@ int
 Jim_jsonInit(Jim_Interp *interp)
 {
 	Jim_PackageProvideCheck(interp, "json");
-	Jim_CreateCommand(interp, "json::decode", json_decode, NULL, NULL);
+	Jim_RegisterSimpleCmd(interp, "json::decode", "?-index? ?-null nullvalue? ?-schema? json", 1, 5, json_decode);
 	/* Load the Tcl implementation of the json encoder if possible */
 	Jim_PackageRequire(interp, "jsonencode", 0);
 	return JIM_OK;

--- a/jim-load.c
+++ b/jim-load.c
@@ -119,20 +119,11 @@ void Jim_FreeLoadHandles(Jim_Interp *interp)
 /* [load] */
 static int Jim_LoadCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (Jim_CheckTaint(interp, JIM_TAINT_ANY)) {
-        Jim_SetTaintError(interp, 1, argv);
-        return JIM_ERR;
-    }
-
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "libraryFile");
-        return JIM_ERR;
-    }
     return Jim_LoadLibrary(interp, Jim_String(argv[1]));
 }
 
 int Jim_loadInit(Jim_Interp *interp)
 {
-    Jim_CreateCommand(interp, "load", Jim_LoadCoreCommand, NULL, NULL);
+    Jim_RegisterCmd(interp, "load", "libraryFile", 1, 1, Jim_LoadCoreCommand, NULL, NULL, JIM_CMD_NOTAINT);
     return JIM_OK;
 }

--- a/jim-load.c
+++ b/jim-load.c
@@ -119,6 +119,11 @@ void Jim_FreeLoadHandles(Jim_Interp *interp)
 /* [load] */
 static int Jim_LoadCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
+    if (Jim_CheckTaint(interp, JIM_TAINT_ANY)) {
+        Jim_SetTaintError(interp, 1, argv);
+        return JIM_ERR;
+    }
+
     if (argc < 2) {
         Jim_WrongNumArgs(interp, 1, argv, "libraryFile");
         return JIM_ERR;

--- a/jim-mk.cpp
+++ b/jim-mk.cpp
@@ -2258,13 +2258,12 @@ int Jim_mkInit(Jim_Interp *interp)
 {
     char version[MK_VERSION_SPACE];
 
+    Jim_PackageProvideCheck(interp, "mk");
+
     snprintf(version, MK_VERSION_SPACE, "%d.%d.%d",
         d4_MetakitLibraryVersion / 100,
         d4_MetakitLibraryVersion % 100 / 10,
         d4_MetakitLibraryVersion % 10);
-
-    if (Jim_PackageProvide(interp, "mk", version, JIM_ERRMSG))
-        return JIM_ERR;
 
     Jim_CreateCommand(interp, "storage", JimStorageCommand, NULL, NULL);
     Jim_CreateCommand(interp, "cursor", JimCursorCommand, NULL, NULL);

--- a/jim-namespace.c
+++ b/jim-namespace.c
@@ -156,10 +156,6 @@ static int JimVariableCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     int retcode = JIM_OK;
 
-    if (argc > 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "name ?value?");
-        return JIM_ERR;
-    }
     if (argc > 1) {
         Jim_Obj *targetNameObj;
         Jim_Obj *localNameObj;
@@ -334,8 +330,7 @@ static int JimNamespaceCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 int Jim_namespaceInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "namespace");
-    Jim_CreateCommand(interp, "namespace", JimNamespaceCmd, NULL, NULL);
-    Jim_CreateCommand(interp, "variable", JimVariableCmd, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "namespace", "subcommand ?arg ...?", 1, -1, JimNamespaceCmd);
+    Jim_RegisterSimpleCmd(interp, "variable", "name ?value?", 1, 2, JimVariableCmd);
     return JIM_OK;
 }
-

--- a/jim-pack.c
+++ b/jim-pack.c
@@ -281,11 +281,6 @@ static int Jim_UnpackCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     jim_wide pos;
     jim_wide width;
 
-    if (argc != 5) {
-        Jim_WrongNumArgs(interp, 1, argv,
-                "binvalue -intbe|-intle|-uintbe|-uintle|-floatbe|-floatle|-str bitpos bitwidth");
-        return JIM_ERR;
-    }
     if (Jim_GetEnum(interp, argv[2], options, &option, NULL, JIM_ERRMSG) != JIM_OK) {
         return JIM_ERR;
     }
@@ -378,11 +373,6 @@ static int Jim_PackCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     int len;
     int freeobj = 0;
 
-    if (argc != 5 && argc != 6) {
-        Jim_WrongNumArgs(interp, 1, argv,
-                "varName value -intle|-intbe|-floatle|-floatbe|-str bitwidth ?bitoffset?");
-        return JIM_ERR;
-    }
     if (Jim_GetEnum(interp, argv[3], options, &option, NULL, JIM_ERRMSG) != JIM_OK) {
         return JIM_ERR;
     }
@@ -476,7 +466,7 @@ static int Jim_PackCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 int Jim_packInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "pack");
-    Jim_CreateCommand(interp, "unpack", Jim_UnpackCmd, NULL, NULL);
-    Jim_CreateCommand(interp, "pack", Jim_PackCmd, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "pack", "varName value -intle|-intbe|-floatle|-floatbe|-str bitwidth ?bitoffset?", 4, 5, Jim_PackCmd);
+    Jim_RegisterSimpleCmd(interp, "unpack", "binvalue -intbe|-intle|-uintbe|-uintle|-floatbe|-floatle|-str bitpos bitwidth", 4, 4, Jim_UnpackCmd);
     return JIM_OK;
 }

--- a/jim-pack.c
+++ b/jim-pack.c
@@ -371,7 +371,6 @@ static int Jim_PackCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     double fvalue;
     Jim_Obj *stringObjPtr;
     int len;
-    int freeobj = 0;
 
     if (Jim_GetEnum(interp, argv[3], options, &option, NULL, JIM_ERRMSG) != JIM_OK) {
         return JIM_ERR;
@@ -406,10 +405,8 @@ static int Jim_PackCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     if (!stringObjPtr) {
         /* Create the string if it doesn't exist */
         stringObjPtr = Jim_NewEmptyStringObj(interp);
-        freeobj = 1;
     }
     else if (Jim_IsShared(stringObjPtr)) {
-        freeobj = 1;
         stringObjPtr = Jim_DuplicateObj(interp, stringObjPtr);
     }
 
@@ -455,10 +452,7 @@ static int Jim_PackCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     }
 
     if (Jim_SetVariable(interp, argv[1], stringObjPtr) != JIM_OK) {
-        if (freeobj) {
-            Jim_FreeNewObj(interp, stringObjPtr);
-            return JIM_ERR;
-        }
+        return JIM_ERR;
     }
     return JIM_OK;
 }

--- a/jim-package.c
+++ b/jim-package.c
@@ -277,6 +277,6 @@ static const jim_subcmd_type package_command_table[] = {
 
 int Jim_packageInit(Jim_Interp *interp)
 {
-    Jim_CreateCommand(interp, "package", Jim_SubCmdProc, (void *)package_command_table, NULL);
+    Jim_RegisterSubCmd(interp, "package", package_command_table, NULL);
     return JIM_OK;
 }

--- a/jim-package.c
+++ b/jim-package.c
@@ -47,7 +47,13 @@ static char *JimFindPackage(Jim_Interp *interp, Jim_Obj *prefixListObj, const ch
 
     for (i = 0; i < prefixc; i++) {
         Jim_Obj *prefixObjPtr = Jim_ListGetIndex(interp, prefixListObj, i);
-        const char *prefix = Jim_String(prefixObjPtr);
+        const char *prefix;
+
+        if (Jim_GetObjTaint(prefixObjPtr)) {
+            /* This element is tainted, so ignore it */
+            continue;
+        }
+        prefix = Jim_String(prefixObjPtr);
 
         /* Loadable modules are tried first */
 #ifdef jim_ext_load
@@ -111,10 +117,8 @@ static int JimLoadPackage(Jim_Interp *interp, const char *name, int flags)
             }
             Jim_Free(path);
         }
-
-        return retCode;
     }
-    return JIM_ERR;
+    return retCode;
 }
 
 int Jim_PackageRequire(Jim_Interp *interp, const char *name, int flags)

--- a/jim-posix.c
+++ b/jim-posix.c
@@ -58,10 +58,6 @@ static int Jim_PosixForkCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
 
     JIM_NOTUSED(argv);
 
-    if (argc != 1) {
-        Jim_WrongNumArgs(interp, 1, argv, "");
-        return JIM_ERR;
-    }
     if ((pid = fork()) == -1) {
         Jim_PosixSetError(interp);
         return JIM_ERR;
@@ -76,10 +72,6 @@ static int Jim_PosixGetidsCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
 {
     Jim_Obj *objv[8];
 
-    if (argc != 1) {
-        Jim_WrongNumArgs(interp, 1, argv, "");
-        return JIM_ERR;
-    }
     objv[0] = Jim_NewStringObj(interp, "uid", -1);
     objv[1] = Jim_NewIntObj(interp, getuid());
     objv[2] = Jim_NewStringObj(interp, "euid", -1);
@@ -98,10 +90,6 @@ static int Jim_PosixGethostnameCommand(Jim_Interp *interp, int argc, Jim_Obj *co
     char *buf;
     int rc = JIM_OK;
 
-    if (argc != 1) {
-        Jim_WrongNumArgs(interp, 1, argv, "");
-        return JIM_ERR;
-    }
     buf = Jim_Alloc(JIM_HOST_NAME_MAX);
     if (gethostname(buf, JIM_HOST_NAME_MAX) == -1) {
         Jim_PosixSetError(interp);
@@ -118,11 +106,6 @@ static int Jim_PosixUptimeCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
 {
 #ifdef HAVE_STRUCT_SYSINFO_UPTIME
     struct sysinfo info;
-
-    if (argc != 1) {
-        Jim_WrongNumArgs(interp, 1, argv, "");
-        return JIM_ERR;
-    }
 
     if (sysinfo(&info) == -1) {
         Jim_PosixSetError(interp);
@@ -141,12 +124,12 @@ int Jim_posixInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "posix");
 #ifdef HAVE_FORK
-    Jim_CreateCommand(interp, "os.fork", Jim_PosixForkCommand, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "os.fork", "", 0, 0, Jim_PosixForkCommand);
 #endif
 #if !defined(JIM_BOOTSTRAP)
-    Jim_CreateCommand(interp, "os.getids", Jim_PosixGetidsCommand, NULL, NULL);
-    Jim_CreateCommand(interp, "os.gethostname", Jim_PosixGethostnameCommand, NULL, NULL);
-    Jim_CreateCommand(interp, "os.uptime", Jim_PosixUptimeCommand, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "os.gethostname", "", 0, 0, Jim_PosixGethostnameCommand);
+    Jim_RegisterSimpleCmd(interp, "os.getids", "", 0, 0, Jim_PosixGetidsCommand);
+    Jim_RegisterSimpleCmd(interp, "os.uptime", "", 0, 0, Jim_PosixUptimeCommand);
 #endif /* JIM_BOOTSTRAP */
     return JIM_OK;
 }

--- a/jim-posix.c
+++ b/jim-posix.c
@@ -45,6 +45,9 @@
 #ifdef HAVE_SYS_SYSINFO_H
 #include <sys/sysinfo.h>
 #endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
 
 static void Jim_PosixSetError(Jim_Interp *interp)
 {
@@ -118,6 +121,25 @@ static int Jim_PosixUptimeCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
 #endif
     return JIM_OK;
 }
+
+static int Jim_PosixUmaskCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    mode_t oldmask;
+
+    if (argc == 2) {
+        long mask;
+        if (Jim_GetLong(interp, argv[1], &mask) != JIM_OK) {
+            return JIM_ERR;
+        }
+        oldmask = umask(mask);
+    }
+    else {
+        oldmask = umask(0);
+        umask(oldmask);
+    }
+    Jim_SetResultInt(interp, oldmask);
+    return JIM_OK;
+}
 #endif /* JIM_BOOTSTRAP */
 
 int Jim_posixInit(Jim_Interp *interp)
@@ -130,6 +152,7 @@ int Jim_posixInit(Jim_Interp *interp)
     Jim_RegisterSimpleCmd(interp, "os.gethostname", "", 0, 0, Jim_PosixGethostnameCommand);
     Jim_RegisterSimpleCmd(interp, "os.getids", "", 0, 0, Jim_PosixGetidsCommand);
     Jim_RegisterSimpleCmd(interp, "os.uptime", "", 0, 0, Jim_PosixUptimeCommand);
+    Jim_RegisterSimpleCmd(interp, "os.umask", "?newmask?", 0, 1, Jim_PosixUmaskCommand);
 #endif /* JIM_BOOTSTRAP */
     return JIM_OK;
 }

--- a/jim-readdir.c
+++ b/jim-readdir.c
@@ -77,8 +77,7 @@ int Jim_ReaddirCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         nocomplain = 1;
     }
     if (argc != 2 && !nocomplain) {
-        Jim_WrongNumArgs(interp, 1, argv, "?-nocomplain? dirPath");
-        return JIM_ERR;
+        return JIM_USAGE;
     }
 
     dirPath = Jim_String(argv[1 + nocomplain]);
@@ -115,6 +114,6 @@ int Jim_ReaddirCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 int Jim_readdirInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "readdir");
-    Jim_CreateCommand(interp, "readdir", Jim_ReaddirCmd, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "readdir", "?-nocomplain? dirPath", 1, 2, Jim_ReaddirCmd);
     return JIM_OK;
 }

--- a/jim-readline.c
+++ b/jim-readline.c
@@ -43,10 +43,6 @@ static int JimRlReadlineCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
 {
     char *line;
 
-    if (argc != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "prompt");
-        return JIM_ERR;
-    }
     line = readline(Jim_String(argv[1]));
     if (!line) {
         return JIM_EXIT;
@@ -57,10 +53,6 @@ static int JimRlReadlineCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
 
 static int JimRlAddHistoryCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "string");
-        return JIM_ERR;
-    }
     add_history(Jim_String(argv[1]));
     return JIM_OK;
 }
@@ -68,7 +60,7 @@ static int JimRlAddHistoryCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
 int Jim_readlineInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "readline");
-    Jim_CreateCommand(interp, "readline.readline", JimRlReadlineCommand, NULL, NULL);
-    Jim_CreateCommand(interp, "readline.addhistory", JimRlAddHistoryCommand, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "readline.readline", "prompt", 1, 1, JimRlReadlineCommand);
+    Jim_RegisterSimpleCmd(interp, "readline.addhistory", "string", 1, 1, JimRlAddHistoryCommand);
     return JIM_OK;
 }

--- a/jim-redis.c
+++ b/jim-redis.c
@@ -201,8 +201,7 @@ static int jim_redis_cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         async = 1;
     }
     if (argc - async != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "?-async? socket-stream");
-        return JIM_ERR;
+        return JIM_USAGE;
     }
 
     /* Invoke getfd to get the file descriptor */
@@ -229,7 +228,7 @@ static int jim_redis_cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     /* Now delete the original stream */
     Jim_DeleteCommand(interp, argv[1 + async]);
     snprintf(buf, sizeof(buf), "redis.handle%ld", Jim_GetId(interp));
-    Jim_CreateCommand(interp, buf, jim_redis_subcmd, c, jim_redis_del_proc);
+    Jim_RegisterCmd(interp, buf, "subcommand ?arg ...?", 1, -1, jim_redis_subcmd, jim_redis_del_proc, c, 0);
 
     Jim_SetResult(interp, Jim_MakeGlobalNamespaceName(interp, Jim_NewStringObj(interp, buf, -1)));
 
@@ -240,6 +239,6 @@ int
 Jim_redisInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "redis");
-    Jim_CreateCommand(interp, "redis", jim_redis_cmd, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "redis", "?-async? socket-stream", 1, 2, jim_redis_cmd);
     return JIM_OK;
 }

--- a/jim-redis.c
+++ b/jim-redis.c
@@ -135,6 +135,10 @@ static int jim_redis_subcmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
             reply = NULL;
         }
     }
+    else if (Jim_GetObjTaint(argv[1]) & JIM_TAINT_ANY) {
+        Jim_SetTaintError(interp, 1, argv);
+        return JIM_ERR;
+    }
     else {
         int nargs = argc - 1;
         args = Jim_Alloc(sizeof(*args) * nargs);
@@ -209,7 +213,7 @@ static int jim_redis_cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         ret = Jim_GetLong(interp, Jim_GetResult(interp), &fd) == JIM_ERR;
     }
     if (ret != JIM_OK) {
-        Jim_SetResultFormatted(interp, "%#s: not a valid stream handle: %#s", argv[0], argv[1]);
+        Jim_SetResultFormatted(interp, "%#s: not a valid stream handle: %#s", argv[0], argv[1 + async]);
         return ret;
     }
 

--- a/jim-regexp.c
+++ b/jim-regexp.c
@@ -137,10 +137,10 @@ int Jim_RegexpCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     int eflags = 0;
     int option;
     enum {
-        OPT_INDICES,  OPT_NOCASE, OPT_LINE, OPT_ALL, OPT_INLINE, OPT_START, OPT_END
+        OPT_INDICES,  OPT_NOCASE, OPT_LINE, OPT_ALL, OPT_INLINE, OPT_START, OPT_EXPANDED, OPT_END
     };
     static const char * const options[] = {
-        "-indices", "-nocase", "-line", "-all", "-inline", "-start", "--", NULL
+        "-indices", "-nocase", "-line", "-all", "-inline", "-start", "-expanded", "--", NULL
     };
 
     for (i = 1; i < argc; i++) {
@@ -185,6 +185,15 @@ int Jim_RegexpCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
                     return JIM_ERR;
                 }
                 break;
+
+            case OPT_EXPANDED:
+#ifdef REG_EXPANDED
+                regcomp_flags |= REG_EXPANDED;
+                break;
+#else
+                Jim_SetResultFormatted(interp, "not supported: %#s", argv[i]);
+                return JIM_ERR;
+#endif
         }
     }
     if (argc - i < 2) {
@@ -361,10 +370,10 @@ int Jim_RegsubCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     const char *pattern;
     int option;
     enum {
-        OPT_NOCASE, OPT_LINE, OPT_ALL, OPT_START, OPT_COMMAND, OPT_END
+        OPT_NOCASE, OPT_LINE, OPT_ALL, OPT_START, OPT_COMMAND, OPT_EXPANDED, OPT_END
     };
     static const char * const options[] = {
-        "-nocase", "-line", "-all", "-start", "-command", "--", NULL
+        "-nocase", "-line", "-all", "-start", "-command", "-expanded", "--", NULL
     };
 
     for (i = 1; i < argc; i++) {
@@ -405,6 +414,15 @@ int Jim_RegsubCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
             case OPT_COMMAND:
                 opt_command = 1;
                 break;
+
+            case OPT_EXPANDED:
+#ifdef REG_EXPANDED
+                regcomp_flags |= REG_EXPANDED;
+                break;
+#else
+                Jim_SetResultFormatted(interp, "not supported: %#s", argv[i]);
+                return JIM_ERR;
+#endif
         }
     }
     if (argc - i != 3 && argc - i != 4) {

--- a/jim-regexp.c
+++ b/jim-regexp.c
@@ -308,7 +308,6 @@ int Jim_RegexpCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
             result = Jim_SetVariable(interp, argv[i + 2 + j], resultObj);
 
             if (result != JIM_OK) {
-                Jim_FreeObj(interp, resultObj);
                 break;
             }
         }
@@ -617,9 +616,6 @@ cmd_error:
 
             if (result == JIM_OK) {
                 Jim_SetResultInt(interp, num_matches);
-            }
-            else {
-                Jim_FreeObj(interp, resultObj);
             }
         }
         else {

--- a/jim-regexp.c
+++ b/jim-regexp.c
@@ -143,13 +143,6 @@ int Jim_RegexpCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         "-indices", "-nocase", "-line", "-all", "-inline", "-start", "--", NULL
     };
 
-    if (argc < 3) {
-      wrongNumArgs:
-        Jim_WrongNumArgs(interp, 1, argv,
-            "?-switch ...? exp string ?matchVar? ?subMatchVar ...?");
-        return JIM_ERR;
-    }
-
     for (i = 1; i < argc; i++) {
         const char *opt = Jim_String(argv[i]);
 
@@ -186,7 +179,7 @@ int Jim_RegexpCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
             case OPT_START:
                 if (++i == argc) {
-                    goto wrongNumArgs;
+                    return JIM_USAGE;
                 }
                 if (Jim_GetIndex(interp, argv[i], &offset) != JIM_OK) {
                     return JIM_ERR;
@@ -195,7 +188,7 @@ int Jim_RegexpCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         }
     }
     if (argc - i < 2) {
-        goto wrongNumArgs;
+        return JIM_USAGE;
     }
 
     regex = SetRegexpFromAny(interp, argv[i], regcomp_flags);
@@ -374,13 +367,6 @@ int Jim_RegsubCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         "-nocase", "-line", "-all", "-start", "-command", "--", NULL
     };
 
-    if (argc < 4) {
-      wrongNumArgs:
-        Jim_WrongNumArgs(interp, 1, argv,
-            "?-switch ...? exp string subSpec ?varName?");
-        return JIM_ERR;
-    }
-
     for (i = 1; i < argc; i++) {
         const char *opt = Jim_String(argv[i]);
 
@@ -409,7 +395,7 @@ int Jim_RegsubCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
             case OPT_START:
                 if (++i == argc) {
-                    goto wrongNumArgs;
+                    return JIM_USAGE;
                 }
                 if (Jim_GetIndex(interp, argv[i], &offset) != JIM_OK) {
                     return JIM_ERR;
@@ -422,7 +408,7 @@ int Jim_RegsubCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         }
     }
     if (argc - i != 3 && argc - i != 4) {
-        goto wrongNumArgs;
+        return JIM_USAGE;
     }
 
 	/* Need to ensure that this is unshared, so just duplicate it always */
@@ -639,7 +625,7 @@ cmd_error:
 int Jim_regexpInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "regexp");
-    Jim_CreateCommand(interp, "regexp", Jim_RegexpCmd, NULL, NULL);
-    Jim_CreateCommand(interp, "regsub", Jim_RegsubCmd, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "regexp", "?-switch ...? exp string ?matchVar? ?subMatchVar ...?", 2, -1, Jim_RegexpCmd);
+    Jim_RegisterSimpleCmd(interp, "regsub", "?-switch ...? exp string subSpec ?varName?", 3, -1, Jim_RegsubCmd);
     return JIM_OK;
 }

--- a/jim-sdl.c
+++ b/jim-sdl.c
@@ -471,11 +471,6 @@ static int JimSdlSurfaceCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
     long vals[2];
     const char *title;
 
-    if (argc != 3 && argc != 4) {
-        Jim_WrongNumArgs(interp, 1, argv, "xres yres ?title?");
-        return JIM_ERR;
-    }
-
     if (JimSdlGetLongs(interp, 2, argv + 1, vals) != JIM_OK) {
         return JIM_ERR;
     }
@@ -536,6 +531,6 @@ static int JimSdlSurfaceCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
 int Jim_sdlInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "sdl");
-    Jim_CreateCommand(interp, "sdl.screen", JimSdlSurfaceCommand, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "sdl.screen", "xres yres ?title?", 2, 3, JimSdlSurfaceCommand);
     return JIM_OK;
 }

--- a/jim-subcmd.c
+++ b/jim-subcmd.c
@@ -259,3 +259,15 @@ int Jim_SubCmdProc(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
     return Jim_CallSubCmd(interp, ct, argc, argv);
 }
+
+Jim_Cmd *Jim_RegisterSubCmd(Jim_Interp *interp, const char *cmdname,
+	const jim_subcmd_type *command_table, Jim_DelCmdProc *delProc)
+{
+    return Jim_RegisterCmd(interp, cmdname,
+        "subcommand ?arg ...?",
+        1, -1,
+        Jim_SubCmdProc,
+        delProc,
+        (void *)command_table,
+        0);
+}

--- a/jim-subcmd.h
+++ b/jim-subcmd.h
@@ -62,9 +62,9 @@ Jim_ParseSubCmd(Jim_Interp *interp, const jim_subcmd_type *command_table, int ar
  * Parses the args against the given command table and executes the subcommand if found
  * or sets an appropriate error if the subcommand or arguments is invalid.
  *
- * Can be used directly with Jim_CreateCommand() where the ClientData is the command table.
+ * Typically used via Jim_RegisterCmd()
  *
- * e.g. Jim_CreateCommand(interp, "mycmd", Jim_SubCmdProc, command_table, NULL);
+ * e.g. Jim_RegisterSubCmd(interp, "mycmd", command_table, NULL);
  */
 int Jim_SubCmdProc(Jim_Interp *interp, int argc, Jim_Obj *const *argv);
 
@@ -86,6 +86,12 @@ int Jim_CallSubCmd(Jim_Interp *interp, const jim_subcmd_type *ct, int argc, Jim_
  * additional checks if the args are wrong.
  */
 void Jim_SubCmdArgError(Jim_Interp *interp, const jim_subcmd_type *ct, Jim_Obj *subcmd);
+
+/**
+ * Convenience wrapper around Jim_RegisterCmd() to register a subcmd command.
+ */
+Jim_Cmd *Jim_RegisterSubCmd(Jim_Interp *interp, const char *cmdname,
+	const jim_subcmd_type *command_table, Jim_DelCmdProc *delProc);
 
 #ifdef __cplusplus
 }

--- a/jim-subcmd.h
+++ b/jim-subcmd.h
@@ -13,6 +13,10 @@ extern "C" {
 
 #define JIM_MODFLAG_HIDDEN   0x0001		/* Don't show the subcommand in usage or commands */
 #define JIM_MODFLAG_FULLARGV 0x0002		/* Subcmd proc gets called with full argv */
+#define JIM_MODFLAG_NOTAINT  0x0004		/* May not be called with tainted data */
+
+#define JIM_SUBCMD_BADARGS -1
+#define JIM_SUBCMD_TAINTED -2
 
 /* Custom flags start at 0x0100 */
 

--- a/jim-syslog.c
+++ b/jim-syslog.c
@@ -79,12 +79,6 @@ int Jim_SyslogCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     int i = 1;
     SyslogInfo *info = Jim_CmdPrivData(interp);
 
-    if (argc <= 1) {
-      wrongargs:
-        Jim_WrongNumArgs(interp, 1, argv,
-            "?-facility cron|daemon|...? ?-ident string? ?-options int? ?debug|info|...? message");
-        return JIM_ERR;
-    }
     while (i < argc - 1) {
         if (Jim_CompareStringImmediate(interp, argv[i], "-facility")) {
             int entry =
@@ -146,7 +140,7 @@ int Jim_SyslogCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     }
 
     if (i != argc - 1) {
-        goto wrongargs;
+        return JIM_USAGE;
     }
     if (!info->logOpened) {
         if (!info->ident[0]) {
@@ -181,7 +175,8 @@ int Jim_syslogInit(Jim_Interp *interp)
     info->facility = LOG_USER;
     info->ident[0] = 0;
 
-    Jim_CreateCommand(interp, "syslog", Jim_SyslogCmd, info, Jim_SyslogCmdDelete);
+    Jim_RegisterCmd(interp, "syslog", "?-facility cron|daemon|...? ?-ident string? ?-options int? ?debug|info|...? message",
+        1, -1, Jim_SyslogCmd, Jim_SyslogCmdDelete, info, 0);
 
     return JIM_OK;
 }

--- a/jim-tclprefix.c
+++ b/jim-tclprefix.c
@@ -64,10 +64,6 @@ static int Jim_TclPrefixCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const
     static const char * const options[] = { "match", "all", "longest", NULL };
     enum { OPT_MATCH, OPT_ALL, OPT_LONGEST };
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "subcommand ?arg ...?");
-        return JIM_ERR;
-    }
     if (Jim_GetEnum(interp, argv[1], options, &option, NULL, JIM_ERRMSG | JIM_ENUM_ABBREV) != JIM_OK)
         return Jim_CheckShowCommands(interp, argv[1], options);
 
@@ -215,6 +211,6 @@ static int Jim_TclPrefixCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const
 int Jim_tclprefixInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "tclprefix");
-    Jim_CreateCommand(interp, "tcl::prefix", Jim_TclPrefixCoreCommand, NULL, NULL);
+    Jim_RegisterSimpleCmd(interp, "tcl::prefix", "subcommand ?arg ...?", 1, -1, Jim_TclPrefixCoreCommand);
     return JIM_OK;
 }

--- a/jim-win32.c
+++ b/jim-win32.c
@@ -100,6 +100,10 @@ Win32_ShellExecute(Jim_Interp *interp, int objc, Jim_Obj * const *objv)
         Jim_WrongNumArgs(interp, 1, objv, "verb path ?parameters?");
         return JIM_ERR;
     }
+    if (Jim_CheckTaint(interp, JIM_TAINT_ANY)) {
+        Jim_SetTaintError(interp, 1, objv);
+        return JIM_ERR;
+    }
     verb = Jim_String(objv[1]);
     file = Jim_String(objv[2]);
     GetCurrentDirectoryA(MAX_PATH + 1, cwd);

--- a/jim-zlib.c
+++ b/jim-zlib.c
@@ -302,15 +302,10 @@ static const jim_subcmd_type zlib_command_table[] = {
     { NULL }
 };
 
-static int JimZlibCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return Jim_CallSubCmd(interp, Jim_ParseSubCmd(interp, zlib_command_table, argc, argv), argc, argv);
-}
-
 int Jim_zlibInit(Jim_Interp *interp)
 {
     Jim_PackageProvideCheck(interp, "zlib");
-    Jim_CreateCommand(interp, "zlib", JimZlibCmd, 0, 0);
+    Jim_RegisterSubCmd(interp, "zlib", zlib_command_table, NULL);
 
     return JIM_OK;
 }

--- a/jim.c
+++ b/jim.c
@@ -6065,12 +6065,12 @@ static void JimSetStackTrace(Jim_Interp *interp, Jim_Obj *stackTraceObj)
     Jim_IncrRefCount(stackTraceObj);
     Jim_DecrRefCount(interp, interp->stackTrace);
     interp->stackTrace = stackTraceObj;
-    interp->errorFlag = 1;
+    interp->hasErrorStackTrace = 1;
 }
 
 static void JimSetErrorStack(Jim_Interp *interp, ScriptObj *script)
 {
-    if (!interp->errorFlag) {
+    if (!interp->hasErrorStackTrace) {
         int i;
         Jim_Obj *stackTrace = Jim_NewListObj(interp, NULL, 0);
 
@@ -11289,7 +11289,7 @@ int Jim_EvalObj(Jim_Interp *interp, Jim_Obj *scriptObjPtr)
     JimPushEvalFrame(interp, &frame, scriptObjPtr);
 
     /* Collect a new error stack trace if an error occurs */
-    interp->errorFlag = 0;
+    interp->hasErrorStackTrace = 0;
     argv = sargv;
 
     /* Execute every command sequentially until the end of the script
@@ -14985,7 +14985,7 @@ wrongargs:
     else {
         exitCode = Jim_EvalObj(interp, argv[idx]);
         /* Once caught, a new error will set a stack trace again */
-        interp->errorFlag = 0;
+        interp->hasErrorStackTrace = 0;
     }
     interp->signal_level -= sig;
 

--- a/jim.c
+++ b/jim.c
@@ -14110,20 +14110,20 @@ static int Jim_UplevelCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
 /* [expr] */
 static int Jim_ExprCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    int retcode;
-
-    if (argc == 2) {
-        retcode = Jim_EvalExpression(interp, argv[1]);
-    }
-    else {
+#ifdef JIM_COMPAT
+    if (argc > 2) {
+        int retcode;
         Jim_Obj *objPtr;
 
         objPtr = Jim_ConcatObj(interp, argc - 1, argv + 1);
         Jim_IncrRefCount(objPtr);
         retcode = Jim_EvalExpression(interp, objPtr);
         Jim_DecrRefCount(interp, objPtr);
+
+        return retcode;
     }
-    return retcode;
+#endif
+    return Jim_EvalExpression(interp, argv[1]);
 }
 
 static int JimBreakContinueHelper(Jim_Interp *interp, int argc, Jim_Obj *const *argv, int retcode)
@@ -16696,7 +16696,7 @@ static const struct jim_core_cmd_def_t {
     {"eval", Jim_EvalCoreCommand, 1, -1, "arg ?arg ...?" },
     {"exists", Jim_ExistsCoreCommand, 1, 2, "?-command|-proc|-alias|-channel|-var? name" },
     {"exit", Jim_ExitCoreCommand, 0, 1, "?exitCode?" },
-#ifndef JIM_COMPAT
+#ifdef JIM_COMPAT
     {"expr", Jim_ExprCoreCommand, 1, -1, "expression ?...?" },
 #else
     {"expr", Jim_ExprCoreCommand, 1, 1, "expression" },

--- a/jim.c
+++ b/jim.c
@@ -12117,6 +12117,8 @@ static Jim_Obj *JimHashtablePatternMatch(Jim_Interp *interp, Jim_HashTable *ht, 
 #define JIM_CMDLIST_ALIASES 4
 #define JIM_CMDLIST_CHANNELS 8
 
+#define JIM_CMDLIST_ALL 0x1000
+
 /**
  * Adds matching command names (procs, channels) to the list.
  */
@@ -12126,16 +12128,20 @@ static void JimCommandMatch(Jim_Interp *interp, Jim_Obj *listObjPtr,
     Jim_Cmd *cmdPtr = (Jim_Cmd *)value;
     int match = 1;
 
-    if (type == JIM_CMDLIST_PROCS && !(cmdPtr->flags & JIM_CMD_ISPROC)) {
+    if ((type & JIM_CMDLIST_PROCS) && !(cmdPtr->flags & JIM_CMD_ISPROC)) {
         /* not a proc */
         return;
     }
-    if (type == JIM_CMDLIST_CHANNELS && !(cmdPtr->flags & JIM_CMD_ISCHANNEL)) {
+    if ((type & JIM_CMDLIST_CHANNELS) && !(cmdPtr->flags & JIM_CMD_ISCHANNEL)) {
         /* not a channel */
         return;
     }
     if ((type & JIM_CMDLIST_ALIASES) && !(cmdPtr->flags & JIM_CMD_ISALIAS)) {
         /* not an alias */
+        return;
+    }
+    if (!(type & JIM_CMDLIST_ALL) && strchr(Jim_String(keyObj), ' ')) {
+        /* contains a space and not -all */
         return;
     }
 
@@ -12164,10 +12170,9 @@ static Jim_Obj *JimCommandsList(Jim_Interp *interp, Jim_Obj *patternObjPtr, int 
 }
 
 /* Keep these in order */
-#define JIM_VARLIST_GLOBALS 0
-#define JIM_VARLIST_LOCALS 1
-#define JIM_VARLIST_VARS 2
-#define JIM_VARLIST_MASK 0x000f
+#define JIM_VARLIST_GLOBALS 1
+#define JIM_VARLIST_LOCALS 2
+#define JIM_VARLIST_VARS 4
 
 #define JIM_VARLIST_VALUES 0x1000
 
@@ -12179,7 +12184,7 @@ static void JimVariablesMatch(Jim_Interp *interp, Jim_Obj *listObjPtr,
 {
     Jim_VarVal *vv = (Jim_VarVal *)value;
 
-    if ((type & JIM_VARLIST_MASK) != JIM_VARLIST_LOCALS || vv->linkFramePtr == NULL) {
+    if (!(type & JIM_VARLIST_LOCALS) || vv->linkFramePtr == NULL) {
         if (patternObj == NULL || Jim_StringMatchObj(interp, patternObj, keyObj, 0)) {
             Jim_ListAppendElement(interp, listObjPtr, keyObj);
             if (type & JIM_VARLIST_VALUES) {
@@ -12192,13 +12197,13 @@ static void JimVariablesMatch(Jim_Interp *interp, Jim_Obj *listObjPtr,
 /* mode is JIM_VARLIST_xxx */
 static Jim_Obj *JimVariablesList(Jim_Interp *interp, Jim_Obj *patternObjPtr, int mode)
 {
-    if (mode == JIM_VARLIST_LOCALS && interp->framePtr == interp->topFramePtr) {
+    if ((mode & JIM_VARLIST_LOCALS) && interp->framePtr == interp->topFramePtr) {
         /* For [info locals], if we are at top level an empty list
          * is returned. I don't agree, but we aim at compatibility (SS) */
         return interp->emptyObj;
     }
     else {
-        Jim_CallFrame *framePtr = (mode == JIM_VARLIST_GLOBALS) ? interp->topFramePtr : interp->framePtr;
+        Jim_CallFrame *framePtr = (mode & JIM_VARLIST_GLOBALS) ? interp->topFramePtr : interp->framePtr;
         return JimHashtablePatternMatch(interp, &framePtr->vars, patternObjPtr, JimVariablesMatch,
             mode);
     }
@@ -15666,7 +15671,7 @@ static int JimIsGlobalNamespace(Jim_Obj *objPtr)
 static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     Jim_Obj *objPtr;
-    int mode = 0;
+    int mode = 1;
 
     /* Must be kept in order with the array below */
     enum {
@@ -15704,8 +15709,8 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         JIM_DEF_SUBCMD("aliases", "?-all? ?pattern?", 0, 2),
         JIM_DEF_SUBCMD("args", "procname", 1, 1),
         JIM_DEF_SUBCMD("body", "procname", 1, 1),
-        JIM_DEF_SUBCMD("channels", "?pattern?", 0, 1),
-        JIM_DEF_SUBCMD("commands", "?pattern?", 0, 1),
+        JIM_DEF_SUBCMD("channels", "?-all? ?pattern?", 0, 2),
+        JIM_DEF_SUBCMD("commands", "?-all? ?pattern?", 0, 2),
         JIM_DEF_SUBCMD("complete", "script ?missing?", 1, 2),
         JIM_DEF_SUBCMD("exists", "varName", 1, 1),
         JIM_DEF_SUBCMD("frame", "?levelNum?", 0, 1),
@@ -15716,7 +15721,7 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         JIM_DEF_SUBCMD("locals", "?pattern?", 0, 1),
         JIM_DEF_SUBCMD("nameofexecutable", NULL, 0, 0),
         JIM_DEF_SUBCMD("patchlevel", NULL, 0, 0),
-        JIM_DEF_SUBCMD("procs", "?pattern?", 0, 1),
+        JIM_DEF_SUBCMD("procs", "?-all? ?pattern?", 0, 2),
         JIM_DEF_SUBCMD("references", NULL, 0, 0),
         JIM_DEF_SUBCMD("returncodes", "?code?", 0, 1),
         JIM_DEF_SUBCMD("script", "?filename?", 0, 1),
@@ -15778,7 +15783,7 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
             Jim_SetResultBool(interp, argv[2]->taint != 0);
             return JIM_OK;
         case INFO_CHANNELS:
-            mode++;             /* JIM_CMDLIST_CHANNELS */
+            mode <<= 1;             /* JIM_CMDLIST_CHANNELS */
 #ifndef jim_ext_aio
             Jim_SetResultString(interp, "aio not enabled", -1);
             return JIM_ERR;
@@ -15788,10 +15793,19 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
             mode <<= 1;             /* JIM_CMDLIST_ALIASES */
             /* fall through */
         case INFO_PROCS:
-            mode++;             /* JIM_CMDLIST_PROCS */
+            mode <<= 1;             /* JIM_CMDLIST_PROCS */
             /* fall through */
-        case INFO_COMMANDS:
-            /* mode 0 => JIM_CMDLIST_COMMANDS */
+        case INFO_COMMANDS:{
+            int n = 0;
+            /* mode = 1 => JIM_CMDLIST_COMMANDS */
+            if (argc > 2 && Jim_CompareStringImmediate(interp, argv[2], "-all")) {
+                mode |= JIM_CMDLIST_ALL;
+                n++;
+            }
+            if (argc < 2 + n || argc > 3 + n) {
+                Jim_SetResultFormatted(interp, "wrong # args: should be \"info %#s %s\"", argv[1], cmds[option].args);
+                return JIM_ERR;
+            }
 #ifdef jim_ext_namespace
             if (!nons) {
                 /* Called as 'info -nons commands|procs' so respect the current namespace */
@@ -15800,17 +15814,18 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
                 }
             }
 #endif
-            Jim_SetResult(interp, JimCommandsList(interp, (argc == 3) ? argv[2] : NULL, mode));
+            Jim_SetResult(interp, JimCommandsList(interp, (argc == 3 + n) ? argv[2 + n] : NULL, mode));
             return JIM_OK;
+        }
 
         case INFO_VARS:
-            mode++;             /* JIM_VARLIST_VARS */
+            mode <<= 1;             /* JIM_VARLIST_VARS */
             /* fall through */
         case INFO_LOCALS:
-            mode++;             /* JIM_VARLIST_LOCALS */
+            mode <<= 1;             /* JIM_VARLIST_LOCALS */
             /* fall through */
         case INFO_GLOBALS:
-            /* mode 0 => JIM_VARLIST_GLOBALS */
+            /* mode = 1 => JIM_VARLIST_GLOBALS */
 #ifdef jim_ext_namespace
             if (!nons) {
                 if (Jim_Length(interp->framePtr->nsObj) || (argc == 3 && JimIsGlobalNamespace(argv[2]))) {

--- a/jim.c
+++ b/jim.c
@@ -2227,6 +2227,7 @@ Jim_Obj *Jim_NewObj(Jim_Interp *interp)
      * kind of GC implemented should take care to avoid
      * scanning objects with refCount == 0. */
     objPtr->refCount = 0;
+    objPtr->taint = interp->taint;
     /* All the other fields are left uninitialized to save time.
      * The caller will probably want to set them to the right
      * value anyway. */
@@ -2293,6 +2294,8 @@ Jim_Obj *Jim_DuplicateObj(Jim_Interp *interp, Jim_Obj *objPtr)
     Jim_Obj *dupPtr;
 
     dupPtr = Jim_NewObj(interp);
+    dupPtr->taint = objPtr->taint;
+
     if (objPtr->bytes == NULL) {
         /* Object does not have a valid string representation. */
         dupPtr->bytes = NULL;
@@ -2573,6 +2576,7 @@ void Jim_AppendObj(Jim_Interp *interp, Jim_Obj *objPtr, Jim_Obj *appendObjPtr)
     int len;
     const char *str = Jim_GetString(appendObjPtr, &len);
     Jim_AppendString(interp, objPtr, str, len);
+    objPtr->taint |= appendObjPtr->taint;
 }
 
 void Jim_AppendStrings(Jim_Interp *interp, Jim_Obj *objPtr, ...)
@@ -3744,6 +3748,7 @@ static void JimSetScriptFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr)
     ParseTokenList tokenlist;
     Jim_Obj *fileNameObj;
     int line;
+    int oldtaint;
 
     /* Try to get information about filename / line number */
     fileNameObj = Jim_GetSourceInfo(interp, objPtr, &line);
@@ -3762,6 +3767,11 @@ static void JimSetScriptFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr)
     ScriptAddToken(&tokenlist, scriptText + scriptTextLen, 0, JIM_TT_EOF, 0);
 
     /* Create the "real" script tokens from the parsed tokens */
+
+    /* Set the correct taint on the objects in the script */
+    oldtaint = interp->taint;
+    interp->taint = objPtr->taint;
+
     script = Jim_Alloc(sizeof(*script));
     memset(script, 0, sizeof(*script));
     script->inUse = 1;
@@ -3779,6 +3789,8 @@ static void JimSetScriptFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr)
     Jim_FreeIntRep(interp, objPtr);
     Jim_SetIntRepPtr(objPtr, script);
     objPtr->typePtr = &scriptObjType;
+
+    interp->taint = oldtaint;
 }
 
 /**
@@ -4590,7 +4602,7 @@ static int SetVariableFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr)
 
 /* -------------------- Variables related functions ------------------------- */
 static int JimDictSugarSet(Jim_Interp *interp, Jim_Obj *ObjPtr, Jim_Obj *valObjPtr);
-static Jim_Obj *JimDictSugarGet(Jim_Interp *interp, Jim_Obj *ObjPtr, int flags);
+static Jim_Obj *JimDictSugarGet(Jim_Interp *interp, Jim_Obj *objPtr, int flags);
 
 static int JimSetNewVariable(Jim_HashTable *ht, Jim_Obj *nameObjPtr, Jim_VarVal *vv)
 {
@@ -4981,6 +4993,7 @@ static void JimDictSugarParseVarKey(Jim_Interp *interp, Jim_Obj *objPtr,
     JimPanic((p == NULL, "JimDictSugarParseVarKey() called for non-dict-sugar (%s)", str));
 
     varObjPtr = Jim_NewStringObj(interp, str, p - str);
+    varObjPtr->taint = objPtr->taint;
 
     p++;
     keyLen = (str + len) - p;
@@ -4990,6 +5003,7 @@ static void JimDictSugarParseVarKey(Jim_Interp *interp, Jim_Obj *objPtr,
 
     /* Create the objects with the variable name and key. */
     keyObjPtr = Jim_NewStringObj(interp, p, keyLen);
+    keyObjPtr->taint = objPtr->taint;
 
     Jim_IncrRefCount(varObjPtr);
     Jim_IncrRefCount(keyObjPtr);
@@ -6288,6 +6302,7 @@ Jim_Obj *Jim_NewIntObj(Jim_Interp *interp, jim_wide wideValue)
     objPtr = Jim_NewObj(interp);
     objPtr->typePtr = &intObjType;
     objPtr->bytes = NULL;
+    objPtr->taint = 0;
     objPtr->internalRep.wideValue = wideValue;
     return objPtr;
 }
@@ -6436,6 +6451,7 @@ Jim_Obj *Jim_NewDoubleObj(Jim_Interp *interp, double doubleValue)
     objPtr = Jim_NewObj(interp);
     objPtr->typePtr = &doubleObjType;
     objPtr->bytes = NULL;
+    objPtr->taint = 0;
     objPtr->internalRep.doubleValue = doubleValue;
     return objPtr;
 }
@@ -6842,6 +6858,7 @@ static int SetListFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr)
                 continue;
             elementPtr = JimParserGetTokenObj(interp, &parser);
             Jim_SetSourceInfo(interp, elementPtr, fileNameObj, parser.tline);
+            elementPtr->taint = objPtr->taint;
             ListAppendElement(objPtr, elementPtr);
         }
     }
@@ -6856,6 +6873,7 @@ Jim_Obj *Jim_NewListObj(Jim_Interp *interp, Jim_Obj *const *elements, int len)
     objPtr = Jim_NewObj(interp);
     objPtr->typePtr = &listObjType;
     objPtr->bytes = NULL;
+    objPtr->taint = 0;
     objPtr->internalRep.listValue.ele = NULL;
     objPtr->internalRep.listValue.len = 0;
     objPtr->internalRep.listValue.maxLen = 0;
@@ -7175,6 +7193,7 @@ static void ListInsertElements(Jim_Obj *listPtr, int idx, int elemc, Jim_Obj *co
     memmove(point + elemc, point, (currentLen - idx) * sizeof(Jim_Obj *));
     for (i = 0; i < elemc; ++i) {
         point[i] = elemVec[i];
+        listPtr->taint |= point[i]->taint;
         Jim_IncrRefCount(point[i]);
     }
     listPtr->internalRep.listValue.len += elemc;
@@ -7323,6 +7342,7 @@ static int ListSetIndex(Jim_Interp *interp, Jim_Obj *listPtr, int idx,
         idx = listPtr->internalRep.listValue.len + idx;
     Jim_DecrRefCount(interp, listPtr->internalRep.listValue.ele[idx]);
     listPtr->internalRep.listValue.ele[idx] = newObjPtr;
+    listPtr->taint |= newObjPtr->taint;
     Jim_IncrRefCount(newObjPtr);
     return JIM_OK;
 }
@@ -7861,6 +7881,7 @@ static int DictAddElement(Jim_Interp *interp, Jim_Obj *objPtr,
             dict->table[dict->len++] = valueObjPtr;
 
         }
+        objPtr->taint |= keyObjPtr->taint | valueObjPtr->taint;
         return JIM_OK;
     }
 }
@@ -8019,6 +8040,9 @@ int Jim_SetDictKeysVector(Jim_Interp *interp, Jim_Obj *varNamePtr,
                 if (newObjPtr || (flags & JIM_MUSTEXIST)) {
                     goto err;
                 }
+            }
+            if (newObjPtr) {
+                varObjPtr->taint |= newObjPtr->taint;
             }
             break;
         }
@@ -9795,6 +9819,9 @@ static int SetExprFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr)
 
     exprText = Jim_GetString(objPtr, &exprTextLen);
 
+    int oldtaint = interp->taint;
+    interp->taint = objPtr->taint;
+
     /* Initially tokenise the expression into tokenlist */
     ScriptTokenListInit(&tokenlist);
 
@@ -9861,6 +9888,9 @@ static int SetExprFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr)
     Jim_FreeIntRep(interp, objPtr);
     Jim_SetIntRepPtr(objPtr, expr);
     objPtr->typePtr = &exprObjType;
+
+    interp->taint = oldtaint;
+
     return rc;
 }
 
@@ -10919,6 +10949,7 @@ tailcall:
         (retcode = JimTraceCallback(interp, "cmd", objc, objv)) == JIM_OK) {
         /* Call it -- Make sure result is an empty object. */
         Jim_SetEmptyResult(interp);
+        interp->taint = Jim_CalcTaint(objc, objv);
         if (cmdPtr->isproc) {
             retcode = JimCallProcedure(interp, cmdPtr, objc, objv);
         }
@@ -11086,6 +11117,7 @@ static Jim_Obj *JimInterpolateTokens(Jim_Interp *interp, const ScriptToken * tok
     Jim_Obj *sintv[JIM_EVAL_SINTV_LEN];
     Jim_Obj *objPtr;
     char *s;
+    int taint = 0;
 
     if (tokens <= JIM_EVAL_SINTV_LEN)
         intv = sintv;
@@ -11123,6 +11155,7 @@ static Jim_Obj *JimInterpolateTokens(Jim_Interp *interp, const ScriptToken * tok
                 }
                 return NULL;
         }
+        taint |= intv[i]->taint;
         Jim_IncrRefCount(intv[i]);
         Jim_String(intv[i]);
         totlen += intv[i]->length;
@@ -11138,6 +11171,7 @@ static Jim_Obj *JimInterpolateTokens(Jim_Interp *interp, const ScriptToken * tok
     /* Concatenate every token in an unique
      * object. */
     objPtr = Jim_NewStringObjNoAlloc(interp, NULL, 0);
+    objPtr->taint = taint;
 
     if (tokens == 4 && token[0].type == JIM_TT_ESC && token[1].type == JIM_TT_ESC
         && token[2].type == JIM_TT_VAR) {
@@ -11408,6 +11442,7 @@ int Jim_EvalObj(Jim_Interp *interp, Jim_Obj *scriptObjPtr)
         if (retcode == JIM_OK && argc) {
             /* Invoke the command */
             retcode = JimInvokeCommand(interp, argc, argv);
+            interp->taint = 0;
             /* Check for a signal after each command */
             if (Jim_CheckSignal(interp)) {
                 retcode = JIM_SIGNAL;
@@ -11828,6 +11863,7 @@ static int SetSubstFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr, int flags
     struct JimParserCtx parser;
     struct ScriptObj *script = Jim_Alloc(sizeof(*script));
     ParseTokenList tokenlist;
+    int oldtaint;
 
     /* Initially parse the subst into tokens (in tokenlist) */
     ScriptTokenListInit(&tokenlist);
@@ -11842,6 +11878,9 @@ static int SetSubstFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr, int flags
         ScriptAddToken(&tokenlist, parser.tstart, parser.tend - parser.tstart + 1, parser.tt,
             parser.tline);
     }
+
+    oldtaint = interp->taint;
+    interp->taint = objPtr->taint;
 
     /* Create the "real" subst/script tokens from the initial token list */
     script->inUse = 1;
@@ -11869,6 +11908,7 @@ static int SetSubstFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr, int flags
     Jim_FreeIntRep(interp, objPtr);
     Jim_SetIntRepPtr(objPtr, script);
     objPtr->typePtr = &scriptObjType;
+    interp->taint = oldtaint;
     return JIM_OK;
 }
 
@@ -11908,23 +11948,57 @@ int Jim_SubstObj(Jim_Interp *interp, Jim_Obj *substObjPtr, Jim_Obj **resObjPtrPt
 /* -----------------------------------------------------------------------------
  * Core commands utility functions
  * ---------------------------------------------------------------------------*/
-void Jim_WrongNumArgs(Jim_Interp *interp, int argc, Jim_Obj *const *argv, const char *msg)
+static Jim_Obj *JimJoinCmdArgs(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     Jim_Obj *objPtr;
     Jim_Obj *listObjPtr;
 
-    JimPanic((argc == 0, "Jim_WrongNumArgs() called with argc=0"));
-
     listObjPtr = Jim_NewListObj(interp, argv, argc);
 
-    if (msg && *msg) {
-        Jim_ListAppendElement(interp, listObjPtr, Jim_NewStringObj(interp, msg, -1));
-    }
     Jim_IncrRefCount(listObjPtr);
     objPtr = Jim_ListJoin(interp, listObjPtr, " ", 1);
     Jim_DecrRefCount(interp, listObjPtr);
+    Jim_IncrRefCount(objPtr);
 
-    Jim_SetResultFormatted(interp, "wrong # args: should be \"%#s\"", objPtr);
+    return objPtr;
+}
+
+void Jim_WrongNumArgs(Jim_Interp *interp, int argc, Jim_Obj *const *argv, const char *msg)
+{
+    Jim_Obj *objPtr = JimJoinCmdArgs(interp, argc, argv);
+    if (*msg) {
+        Jim_SetResultFormatted(interp, "wrong # args: should be \"%#s %s\"", objPtr, msg);
+    }
+    else {
+        Jim_SetResultFormatted(interp, "wrong # args: should be \"%#s\"", objPtr);
+    }
+    Jim_DecrRefCount(interp, objPtr);
+}
+
+/**
+ * Calculates the taint of the given objects (skipping NULL entries).
+ */
+int Jim_CalcTaint(int argc, Jim_Obj *const *argv)
+{
+    int taint = 0;
+#ifdef JIM_TAINT
+    int i;
+    for (i = 0; i < argc; i++) {
+        if (argv[i]) {
+            taint |= argv[i]->taint;
+        }
+    }
+#endif
+    return taint;
+}
+
+void Jim_SetTaintError(Jim_Interp *interp, int cmdargs, Jim_Obj *const *argv)
+{
+#ifdef JIM_TAINT
+    Jim_Obj *objPtr = JimJoinCmdArgs(interp, cmdargs, argv);
+    Jim_SetResultFormatted(interp, "%#s: tainted data", objPtr);
+    Jim_DecrRefCount(interp, objPtr);
+#endif
 }
 
 /**
@@ -13675,7 +13749,7 @@ static int Jim_DebugCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
         JIM_DEF_SUBCMD("exprlen", "expression", 1, 1),
         JIM_DEF_SUBCMD("invstr", "object", 1, 1),
         JIM_DEF_SUBCMD("objcount", NULL, 0, 0),
-        JIM_DEF_SUBCMD("objects", NULL, 0, 0),
+        JIM_DEF_SUBCMD("objects", "?-taint?", 0, 1),
         JIM_DEF_SUBCMD("refcount", "object", 1, 1),
         JIM_DEF_SUBCMD("scriptlen", "script", 1, 1),
         JIM_DEF_SUBCMD("show", "object", 1, 1),
@@ -13721,6 +13795,17 @@ static int Jim_DebugCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
 
         case OPT_OBJECTS:{
             Jim_Obj *objPtr, *listObjPtr, *subListObjPtr;
+            int tainted;
+
+            if (argc == 3) {
+                if (Jim_CompareStringImmediate(interp, argv[2], "-taint")) {
+                    tainted = 1;
+                }
+                else {
+                    Jim_SubCmdArgError(interp, ct, argv[0]);
+                    return JIM_ERR;
+                }
+            }
 
             /* Count the number of live objects. */
             objPtr = interp->liveList;
@@ -13729,14 +13814,24 @@ static int Jim_DebugCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
                 char buf[128];
                 const char *type = objPtr->typePtr ? objPtr->typePtr->name : "";
 
-                subListObjPtr = Jim_NewListObj(interp, NULL, 0);
-                sprintf(buf, "%p", objPtr);
-                Jim_ListAppendElement(interp, subListObjPtr, Jim_NewStringObj(interp, buf, -1));
-                Jim_ListAppendElement(interp, subListObjPtr, Jim_NewStringObj(interp, type, -1));
-                Jim_ListAppendElement(interp, subListObjPtr, Jim_NewIntObj(interp, objPtr->refCount));
-                Jim_ListAppendElement(interp, subListObjPtr, objPtr);
-                Jim_ListAppendElement(interp, listObjPtr, subListObjPtr);
-                objPtr = objPtr->nextObjPtr;
+                /* Return a list of the objects */
+                listObjPtr = Jim_NewListObj(interp, NULL, 0);
+                for (objPtr = interp->liveList; objPtr; objPtr = objPtr->nextObjPtr) {
+                    char buf[128];
+                    const char *type = objPtr->typePtr ? objPtr->typePtr->name : "";
+
+                    if (objPtr == listObjPtr || (tainted && !objPtr->taint)) {
+                        continue;
+                    }
+
+                    subListObjPtr = Jim_NewListObj(interp, NULL, 0);
+                    sprintf(buf, "%p", objPtr);
+                    Jim_ListAppendElement(interp, subListObjPtr, Jim_NewStringObj(interp, buf, -1));
+                    Jim_ListAppendElement(interp, subListObjPtr, Jim_NewStringObj(interp, type, -1));
+                    Jim_ListAppendElement(interp, subListObjPtr, Jim_NewIntObj(interp, objPtr->refCount));
+                    Jim_ListAppendElement(interp, subListObjPtr, objPtr);
+                    Jim_ListAppendElement(interp, listObjPtr, subListObjPtr);
+                }
             }
             Jim_SetResult(interp, listObjPtr);
             return JIM_OK;
@@ -13765,9 +13860,9 @@ static int Jim_DebugCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
             charlen = len;
     #endif
             char buf[256];
-            snprintf(buf, sizeof(buf), "refcount: %d, type: %s\n"
+            snprintf(buf, sizeof(buf), "refcount: %d, taint: %d, type: %s\n"
                 "chars (%d):",
-                argv[2]->refCount, JimObjTypeName(argv[2]), charlen);
+                argv[2]->refCount, argv[2]->taint, JimObjTypeName(argv[2]), charlen);
             Jim_SetResultFormatted(interp, "%s <<%s>>\n", buf, s);
             snprintf(buf, sizeof(buf), "bytes (%d):", len);
             Jim_AppendString(interp, Jim_GetResult(interp), buf, -1);
@@ -14256,6 +14351,61 @@ static int Jim_ApplyCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
     }
 }
 
+#ifdef JIM_TAINT
+static int JimTaintVariable(Jim_Interp *interp, Jim_Obj *nameObjPtr, int taint)
+{
+    Jim_Obj *valueObjPtr = Jim_GetVariable(interp, nameObjPtr, JIM_ERRMSG | JIM_UNSHARED);
+
+    if (valueObjPtr == NULL) {
+        return JIM_ERR;
+    }
+
+    if (Jim_IsShared(valueObjPtr)) {
+        valueObjPtr = Jim_DuplicateObj(interp, valueObjPtr);
+        Jim_SetVariable(interp, nameObjPtr, valueObjPtr);
+    }
+
+    /* If this is an array element or a list, need to invalidate the string rep to
+     * force recalc. When it is regenerated, the whole string will be tainted if any component is.
+     */
+    if (taint && nameObjPtr->typePtr == &dictSubstObjType) {
+        /* Tainting an array element taints the array too */
+        Jim_Obj *objPtr = Jim_GetVariable(interp, nameObjPtr->internalRep.dictSubstValue.varNameObjPtr, JIM_NONE);
+        if (objPtr) {
+            SetStringFromAny(interp, valueObjPtr);
+            valueObjPtr->taint = taint;
+            objPtr->taint |= taint;
+        }
+    }
+
+    /* Manually tainting destroys any non-string rep */
+    SetStringFromAny(interp, valueObjPtr);
+    valueObjPtr->taint = taint;
+
+    //printf("taint of %s is %d\n", valueObjPtr->bytes, valueObjPtr->taint);
+    return JIM_OK;
+}
+
+/* [taint] */
+static int Jim_TaintCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    if (argc != 2) {
+        Jim_WrongNumArgs(interp, 1, argv, "varname");
+        return JIM_ERR;
+    }
+    return JimTaintVariable(interp, argv[1], 1);
+}
+
+/* [untaint] */
+static int Jim_UntaintCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+{
+    if (argc != 2) {
+        Jim_WrongNumArgs(interp, 1, argv, "varname");
+        return JIM_ERR;
+    }
+    return JimTaintVariable(interp, argv[1], 0);
+}
+#endif
 
 /* [concat] */
 static int Jim_ConcatCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
@@ -15661,6 +15811,7 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         INFO_SOURCE,
         INFO_STACKTRACE,
         INFO_STATICS,
+        INFO_TAINTED,
         INFO_VARS,
         INFO_VERSION,
         INFO_COUNT
@@ -15687,6 +15838,7 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         JIM_DEF_SUBCMD("source", "source ?filename line?", 1, 3),
         JIM_DEF_SUBCMD("stacktrace", NULL, 0, 0),
         JIM_DEF_SUBCMD("statics", "procname", 1, 1),
+        JIM_DEF_SUBCMD("tainted", "str", 1, 1),
         JIM_DEF_SUBCMD("vars", "?pattern?", 0, 1),
         JIM_DEF_SUBCMD("version", NULL, 0, 0),
         { NULL }
@@ -15732,6 +15884,13 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
             return JIM_OK;
         }
 
+        case INFO_TAINTED:
+            if (argc != 3) {
+                Jim_WrongNumArgs(interp, 2, argv, "value");
+                return JIM_ERR;
+            }
+            Jim_SetResultBool(interp, argv[2]->taint != 0);
+            return JIM_OK;
         case INFO_CHANNELS:
             mode++;             /* JIM_CMDLIST_CHANNELS */
 #ifndef jim_ext_aio
@@ -16334,14 +16493,18 @@ static int Jim_SourceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
 {
     int retval;
 
+    if (Jim_CheckTaint(interp, JIM_TAINT_ANY)) {
+        Jim_SetTaintError(interp, 1, argv);
+        return JIM_ERR;
+    }
+
     if (argc != 2) {
         Jim_WrongNumArgs(interp, 1, argv, "fileName");
         return JIM_ERR;
     }
     retval = Jim_EvalFile(interp, Jim_String(argv[1]));
-    if (retval == JIM_RETURN)
-        return JIM_OK;
-    return retval;
+
+    return retval == JIM_RETURN ? JIM_OK : retval;
 }
 
 /* [lreverse] */
@@ -16540,6 +16703,10 @@ static const struct {
     {"upcall", Jim_UpcallCoreCommand},
     {"apply", Jim_ApplyCoreCommand},
     {"stacktrace", Jim_StacktraceCoreCommand},
+#ifdef JIM_TAINT
+    {"taint", Jim_TaintCoreCommand},
+    {"untaint", Jim_UntaintCoreCommand},
+#endif
     {NULL, NULL},
 };
 

--- a/jim.c
+++ b/jim.c
@@ -11998,6 +11998,7 @@ void Jim_SetTaintError(Jim_Interp *interp, int cmdargs, Jim_Obj *const *argv)
     Jim_Obj *objPtr = JimJoinCmdArgs(interp, cmdargs, argv);
     Jim_SetResultFormatted(interp, "%#s: tainted data", objPtr);
     Jim_DecrRefCount(interp, objPtr);
+    Jim_SetGlobalVariableStr(interp, "errorCode", Jim_NewStringObj(interp, "TAINTED", -1));
 #endif
 }
 

--- a/jim.c
+++ b/jim.c
@@ -16120,12 +16120,17 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
                 return JIM_OK;
             }
 
-        case INFO_VERSION:
-        case INFO_PATCHLEVEL:{
-                char buf[(JIM_INTEGER_SPACE * 2) + 1];
+        case INFO_PATCHLEVEL:
+           /* bootstrap jimsh doesn't have this so fall through */
+#ifdef JIM_GITVERSION
+            Jim_SetResultString(interp, JIM_GITVERSION, -1);
+            return JIM_OK;
+#endif
 
-                sprintf(buf, "%d.%d", JIM_VERSION / 100, JIM_VERSION % 100);
-                Jim_SetResultString(interp, buf, -1);
+        case INFO_VERSION:{
+                char versionbuf[64];
+                snprintf(versionbuf, sizeof(versionbuf), "%d.%d", JIM_VERSION / 100, JIM_VERSION % 100);
+                Jim_SetResultString(interp, versionbuf, -1);
                 return JIM_OK;
             }
 

--- a/jim.c
+++ b/jim.c
@@ -156,6 +156,7 @@ static void JimRandomBytes(Jim_Interp *interp, void *dest, unsigned int len);
 static int JimSetNewVariable(Jim_HashTable *ht, Jim_Obj *nameObjPtr, Jim_VarVal *vv);
 static Jim_VarVal *JimFindVariable(Jim_HashTable *ht, Jim_Obj *nameObjPtr);
 static int SetVariableFromAny(Jim_Interp *interp, struct Jim_Obj *objPtr);
+static int JimCallNative(Jim_Interp *interp, Jim_Cmd *cmd, int argc, Jim_Obj *const *argv);
 
 #define JIM_DICT_SUGAR 100      /* Only returned by SetVariableFromAny() */
 
@@ -3836,7 +3837,7 @@ static void JimIncrCmdRefCount(Jim_Cmd *cmdPtr)
 static void JimDecrCmdRefCount(Jim_Interp *interp, Jim_Cmd *cmdPtr)
 {
     if (--cmdPtr->inUse == 0) {
-        if (cmdPtr->isproc) {
+        if (cmdPtr->flags & JIM_CMD_ISPROC) {
             Jim_DecrRefCount(interp, cmdPtr->u.proc.argListObjPtr);
             Jim_DecrRefCount(interp, cmdPtr->u.proc.bodyObjPtr);
             Jim_DecrRefCount(interp, cmdPtr->u.proc.nsObj);
@@ -4105,30 +4106,48 @@ static void JimCreateCommand(Jim_Interp *interp, Jim_Obj *nameObjPtr, Jim_Cmd *c
     Jim_ReplaceHashEntry(&interp->commands, nameObjPtr, cmd);
 }
 
-int Jim_CreateCommandObj(Jim_Interp *interp, Jim_Obj *cmdNameObj,
-    Jim_CmdProc *cmdProc, void *privData, Jim_DelCmdProc *delProc)
+/* commands */
+Jim_Cmd *Jim_RegisterCommand(Jim_Interp *interp, Jim_Obj *cmdNameObj,
+    Jim_CmdProc *cmdProc,
+    Jim_DelCmdProc *delProc,
+    const char *usage,
+    const char *help,
+    short minargs,
+    short maxargs,
+    int flags,
+    void *privData)
 {
+    JimPanic(((flags & JIM_CMD_ISPROC), "Jim_RegisterCommand called with JIM_CMD_ISPROC flag"));
     Jim_Cmd *cmdPtr = Jim_Alloc(sizeof(*cmdPtr));
 
     /* Store the new details for this command */
     memset(cmdPtr, 0, sizeof(*cmdPtr));
     cmdPtr->inUse = 1;
+    cmdPtr->flags = flags;
     cmdPtr->u.native.delProc = delProc;
     cmdPtr->u.native.cmdProc = cmdProc;
+    cmdPtr->u.native.usage = usage;
+    cmdPtr->u.native.help = help;
+    cmdPtr->u.native.minargs = minargs;
+    cmdPtr->u.native.maxargs = maxargs;
     cmdPtr->u.native.privData = privData;
 
     Jim_IncrRefCount(cmdNameObj);
     JimCreateCommand(interp, cmdNameObj, cmdPtr);
     Jim_DecrRefCount(interp, cmdNameObj);
 
-    return JIM_OK;
+    return cmdPtr;
 }
 
-
+/* This remains for backward compatiblity to create a command
+ * with no arg limitations or usage/help.
+ * Prefer one of the Jim_Register* variants instead.
+ */
 int Jim_CreateCommand(Jim_Interp *interp, const char *cmdNameStr,
     Jim_CmdProc *cmdProc, void *privData, Jim_DelCmdProc *delProc)
 {
-    return Jim_CreateCommandObj(interp, Jim_NewStringObj(interp, cmdNameStr, -1), cmdProc, privData, delProc);
+    Jim_RegisterCmd(interp, cmdNameStr, NULL, 0, -1, cmdProc, delProc, privData, 0);
+    return JIM_OK;
 }
 
 static int JimCreateProcedureStatics(Jim_Interp *interp, Jim_Cmd *cmdPtr, Jim_Obj *staticsListObjPtr)
@@ -4249,7 +4268,7 @@ static const char *Jim_memrchr(const char *p, int c, int len)
 static void JimUpdateProcNamespace(Jim_Interp *interp, Jim_Cmd *cmdPtr, Jim_Obj *nameObjPtr)
 {
 #ifdef jim_ext_namespace
-    if (cmdPtr->isproc) {
+    if (cmdPtr->flags & JIM_CMD_ISPROC) {
         int len;
         const char *cmdname = Jim_GetStringNoQualifier(nameObjPtr, &len);
         /* XXX: Really need JimNamespaceSplit() */
@@ -4288,7 +4307,7 @@ static Jim_Cmd *JimCreateProcedureCmd(Jim_Interp *interp, Jim_Obj *argListObjPtr
     assert(cmdPtr);
     memset(cmdPtr, 0, sizeof(*cmdPtr));
     cmdPtr->inUse = 1;
-    cmdPtr->isproc = 1;
+    cmdPtr->flags = JIM_CMD_ISPROC;
     cmdPtr->u.proc.argListObjPtr = argListObjPtr;
     cmdPtr->u.proc.argListLen = argListLen;
     cmdPtr->u.proc.bodyObjPtr = bodyObjPtr;
@@ -4509,7 +4528,7 @@ Jim_Cmd *Jim_GetCommand(Jim_Interp *interp, Jim_Obj *objPtr, int flags)
         Jim_IncrRefCount(interp->framePtr->nsObj);
         Jim_DecrRefCount(interp, qualifiedNameObj);
     }
-    while (cmd->u.proc.upcall) {
+    while ((cmd->flags & JIM_CMD_ISPROC) && cmd->u.proc.upcall) {
         cmd = cmd->prevCmd;
     }
     return cmd;
@@ -6028,7 +6047,7 @@ static Jim_Obj *JimProcForEvalFrame(Jim_Interp *interp, Jim_EvalFrame *frame)
     if (frame == interp->evalFrame || (frame->cmd && frame->cmd->cmdNameObj)) {
         Jim_EvalFrame *e;
         for (e = frame->parent; e; e = e->parent) {
-            if (e->cmd && e->cmd->isproc && e->cmd->cmdNameObj) {
+            if (e->cmd && (e->cmd->flags & JIM_CMD_ISPROC) && e->cmd->cmdNameObj) {
                 break;
             }
         }
@@ -10763,10 +10782,6 @@ static int Jim_IncrCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     jim_wide wideValue, increment = 1;
     Jim_Obj *intObjPtr;
 
-    if (argc != 2 && argc != 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "varName ?increment?");
-        return JIM_ERR;
-    }
     if (argc == 3) {
         if (Jim_GetWideExpr(interp, argv[2], &increment) != JIM_OK)
             return JIM_ERR;
@@ -10950,12 +10965,16 @@ tailcall:
         /* Call it -- Make sure result is an empty object. */
         Jim_SetEmptyResult(interp);
         interp->taint = Jim_CalcTaint(objc, objv);
-        if (cmdPtr->isproc) {
+        if (cmdPtr->flags & JIM_CMD_ISPROC) {
             retcode = JimCallProcedure(interp, cmdPtr, objc, objv);
         }
+        else if ((cmdPtr->flags & JIM_CMD_NOTAINT) && Jim_CheckTaint(interp, JIM_TAINT_ANY)) {
+            Jim_SetTaintError(interp, 1, objv);
+            retcode = JIM_ERR;
+        }
         else {
-            interp->cmdPrivData = cmdPtr->u.native.privData;
-            retcode = cmdPtr->u.native.cmdProc(interp, objc, objv);
+            retcode = JimCallNative(interp, cmdPtr, objc, objv);
+            /* XXX Could it return -2 for tainted? */
         }
         if (retcode == JIM_ERR) {
             JimSetErrorStack(interp, NULL);
@@ -11281,7 +11300,7 @@ int Jim_EvalObj(Jim_Interp *interp, Jim_Obj *scriptObjPtr)
     }
     if (script->len == 3
         && token[1].objPtr->typePtr == &commandObjType
-        && token[1].objPtr->internalRep.cmdValue.cmdPtr->isproc == 0
+        && (token[1].objPtr->internalRep.cmdValue.cmdPtr->flags & JIM_CMD_ISPROC) == 0
         && token[1].objPtr->internalRep.cmdValue.cmdPtr->u.native.cmdProc == Jim_IncrCoreCommand
         && token[2].objPtr->typePtr == &variableObjType) {
 
@@ -11507,46 +11526,64 @@ static int JimSetProcArg(Jim_Interp *interp, Jim_Obj *argNameObj, Jim_Obj *argVa
     return retcode;
 }
 
+/* Returns a zero-ref count usage string for the command.
+ * If no usage is availabe, just returns "cmd ..."
+ */
+static Jim_Obj *JimCmdUsage(Jim_Interp *interp, Jim_Obj *cmdNameObj, Jim_Cmd *cmd)
+{
+    Jim_Obj *usage = Jim_DuplicateObj(interp, cmdNameObj);
+
+    if (cmd->flags & JIM_CMD_ISPROC) {
+        int i;
+        for (i = 0; i < cmd->u.proc.argListLen; i++) {
+            Jim_AppendString(interp, usage, " ", 1);
+
+            if (i == cmd->u.proc.argsPos) {
+                if (cmd->u.proc.arglist[i].defaultObjPtr) {
+                    /* Renamed args */
+                    Jim_AppendString(interp, usage, "?", 1);
+                    Jim_AppendObj(interp, usage, cmd->u.proc.arglist[i].defaultObjPtr);
+                    Jim_AppendString(interp, usage, " ...?", -1);
+                }
+                else {
+                    /* We have plain args */
+                    Jim_AppendString(interp, usage, "?arg ...?", -1);
+                }
+            }
+            else {
+                if (cmd->u.proc.arglist[i].defaultObjPtr) {
+                    Jim_AppendString(interp, usage, "?", 1);
+                    Jim_AppendObj(interp, usage, cmd->u.proc.arglist[i].nameObjPtr);
+                    Jim_AppendString(interp, usage, "?", 1);
+                }
+                else {
+                    const char *arg = Jim_String(cmd->u.proc.arglist[i].nameObjPtr);
+                    if (*arg == '&') {
+                        arg++;
+                    }
+                    Jim_AppendString(interp, usage, arg, -1);
+                }
+            }
+        }
+    }
+    else if (cmd->u.native.usage) {
+        if (*cmd->u.native.usage) {
+            Jim_AppendStrings(interp, usage, " ", cmd->u.native.usage, NULL);
+        }
+    }
+    else {
+        Jim_AppendString(interp, usage, " ...", -1);
+    }
+
+    return usage;
+}
+
 /**
  * Sets the interp result to be an error message indicating the required proc args.
  */
 static void JimSetProcWrongArgs(Jim_Interp *interp, Jim_Obj *procNameObj, Jim_Cmd *cmd)
 {
-    /* Create a nice error message, consistent with Tcl 8.5 */
-    Jim_Obj *argmsg = Jim_NewStringObj(interp, "", 0);
-    int i;
-
-    for (i = 0; i < cmd->u.proc.argListLen; i++) {
-        Jim_AppendString(interp, argmsg, " ", 1);
-
-        if (i == cmd->u.proc.argsPos) {
-            if (cmd->u.proc.arglist[i].defaultObjPtr) {
-                /* Renamed args */
-                Jim_AppendString(interp, argmsg, "?", 1);
-                Jim_AppendObj(interp, argmsg, cmd->u.proc.arglist[i].defaultObjPtr);
-                Jim_AppendString(interp, argmsg, " ...?", -1);
-            }
-            else {
-                /* We have plain args */
-                Jim_AppendString(interp, argmsg, "?arg ...?", -1);
-            }
-        }
-        else {
-            if (cmd->u.proc.arglist[i].defaultObjPtr) {
-                Jim_AppendString(interp, argmsg, "?", 1);
-                Jim_AppendObj(interp, argmsg, cmd->u.proc.arglist[i].nameObjPtr);
-                Jim_AppendString(interp, argmsg, "?", 1);
-            }
-            else {
-                const char *arg = Jim_String(cmd->u.proc.arglist[i].nameObjPtr);
-                if (*arg == '&') {
-                    arg++;
-                }
-                Jim_AppendString(interp, argmsg, arg, -1);
-            }
-        }
-    }
-    Jim_SetResultFormatted(interp, "wrong # args: should be \"%#s%#s\"", procNameObj, argmsg);
+    Jim_SetResultFormatted(interp, "wrong # args: should be \"%#s\"", JimCmdUsage(interp, procNameObj, cmd));
 }
 
 #ifdef jim_ext_namespace
@@ -11697,6 +11734,36 @@ badargset:
     interp->procLevel--;
 
     return retcode;
+}
+
+static int JimCallNative(Jim_Interp *interp, Jim_Cmd *cmd, int argc, Jim_Obj *const *argv)
+{
+    int argsok = 1;
+    int ret;
+
+    /* Check arg count */
+    if (argc - 1 < cmd->u.native.minargs) {
+        argsok = 0;
+    }
+    else if (cmd->u.native.maxargs >= 0 && argc - 1 > cmd->u.native.maxargs) {
+        argsok = 0;
+    }
+    else if (cmd->u.native.maxargs < -1 && (argc - 1) % -cmd->u.native.maxargs != 0) {
+        /* -2 means must have n * 2 args */
+        argsok = 0;
+    }
+    if (argsok) {
+        interp->cmdPrivData = cmd->u.native.privData;
+        ret = cmd->u.native.cmdProc(interp, argc, argv);
+        if (ret >= 0) {
+            return ret;
+        }
+        /* This means an argument error */
+    }
+
+    //printf("Wrong args for %s, argc=%d, minargs=%d, maxargs=%d\n", Jim_String(argv[0]), argc, cmd->u.native.minargs, cmd->u.native.maxargs);
+    Jim_SetResultFormatted(interp, "wrong # args: should be \"%#s\"", JimCmdUsage(interp, argv[0], cmd));
+    return JIM_ERR;
 }
 
 int Jim_EvalSource(Jim_Interp *interp, const char *filename, int lineno, const char *script)
@@ -11963,6 +12030,10 @@ static Jim_Obj *JimJoinCmdArgs(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     return objPtr;
 }
 
+ /* This function should not be necessary for simple commands.
+  * Instead set minargs/maxargs and a usage string when registering the command and
+  * optionally return JIM_USAGE from the command proc to generate a usage message.
+  */
 void Jim_WrongNumArgs(Jim_Interp *interp, int argc, Jim_Obj *const *argv, const char *msg)
 {
     Jim_Obj *objPtr = JimJoinCmdArgs(interp, argc, argv);
@@ -12041,9 +12112,10 @@ static Jim_Obj *JimHashtablePatternMatch(Jim_Interp *interp, Jim_HashTable *ht, 
 }
 
 /* Keep these in order */
-#define JIM_CMDLIST_COMMANDS 0
-#define JIM_CMDLIST_PROCS 1
-#define JIM_CMDLIST_CHANNELS 2
+#define JIM_CMDLIST_COMMANDS 1
+#define JIM_CMDLIST_PROCS 2
+#define JIM_CMDLIST_ALIASES 4
+#define JIM_CMDLIST_CHANNELS 8
 
 /**
  * Adds matching command names (procs, channels) to the list.
@@ -12052,30 +12124,36 @@ static void JimCommandMatch(Jim_Interp *interp, Jim_Obj *listObjPtr,
     Jim_Obj *keyObj, void *value, Jim_Obj *patternObj, int type)
 {
     Jim_Cmd *cmdPtr = (Jim_Cmd *)value;
+    int match = 1;
 
-    if (type == JIM_CMDLIST_PROCS && !cmdPtr->isproc) {
+    if (type == JIM_CMDLIST_PROCS && !(cmdPtr->flags & JIM_CMD_ISPROC)) {
         /* not a proc */
+        return;
+    }
+    if (type == JIM_CMDLIST_CHANNELS && !(cmdPtr->flags & JIM_CMD_ISCHANNEL)) {
+        /* not a channel */
+        return;
+    }
+    if ((type & JIM_CMDLIST_ALIASES) && !(cmdPtr->flags & JIM_CMD_ISALIAS)) {
+        /* not an alias */
         return;
     }
 
     Jim_IncrRefCount(keyObj);
 
-    if (type != JIM_CMDLIST_CHANNELS || Jim_AioFilehandle(interp, keyObj) >= 0) {
-        int match = 1;
-        if (patternObj) {
-            int plen, slen;
-            const char *pattern = Jim_GetStringNoQualifier(patternObj, &plen);
-            const char *str = Jim_GetStringNoQualifier(keyObj, &slen);
+    if (patternObj) {
+        int plen, slen;
+        const char *pattern = Jim_GetStringNoQualifier(patternObj, &plen);
+        const char *str = Jim_GetStringNoQualifier(keyObj, &slen);
 #ifdef JIM_NO_INTROSPECTION
-            /* Only exact match supported with no introspection */
-            match = (JimStringCompareUtf8(pattern, plen, str, slen, 0) == 0);
+        /* Only exact match supported with no introspection */
+        match = (JimStringCompareUtf8(pattern, plen, str, slen, 0) == 0);
 #else
-            match = JimGlobMatch(pattern, plen, str, slen, 0);
+        match = JimGlobMatch(pattern, plen, str, slen, 0);
 #endif
-        }
-        if (match) {
-            Jim_ListAppendElement(interp, listObjPtr, keyObj);
-        }
+    }
+    if (match) {
+        Jim_ListAppendElement(interp, listObjPtr, keyObj);
     }
     Jim_DecrRefCount(interp, keyObj);
 }
@@ -12196,10 +12274,6 @@ static int JimInfoFrame(Jim_Interp *interp, Jim_Obj *levelObjPtr, Jim_Obj **objP
 /* fake [puts] -- not the real puts, just for debugging. */
 static int Jim_PutsCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 2 && argc != 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "?-nonewline? string");
-        return JIM_ERR;
-    }
     if (argc == 3) {
         if (!Jim_CompareStringImmediate(interp, argv[1], "-nonewline")) {
             Jim_SetResultString(interp, "The second argument must " "be -nonewline", -1);
@@ -12255,11 +12329,7 @@ static int JimSubDivHelper(Jim_Interp *interp, int argc, Jim_Obj *const *argv, i
     double doubleValue, doubleRes = 0;
     int i = 2;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "number ?number ... number?");
-        return JIM_ERR;
-    }
-    else if (argc == 2) {
+    if (argc == 2) {
         /* The arity = 2 case is different. For [- x] returns -x,
          * while [/ x] returns 1/x. */
         if (Jim_GetWide(interp, argv[1], &wideValue) != JIM_OK) {
@@ -12354,10 +12424,6 @@ static int Jim_DivCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv
 /* [set] */
 static int Jim_SetCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 2 && argc != 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "varName ?newValue?");
-        return JIM_ERR;
-    }
     if (argc == 2) {
         Jim_Obj *objPtr;
 
@@ -12428,11 +12494,6 @@ static int JimCheckLoopRetcode(Jim_Interp *interp, int retval)
 /* [while] */
 static int Jim_WhileCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "condition body");
-        return JIM_ERR;
-    }
-
     /* The general purpose implementation of while starts here */
     while (1) {
         int boolean = 0, retval;
@@ -12469,11 +12530,6 @@ static int Jim_ForCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv
     int immediate = 0;
     Jim_Obj *varNamePtr = NULL;
     Jim_Obj *stopVarNamePtr = NULL;
-
-    if (argc != 5) {
-        Jim_WrongNumArgs(interp, 1, argv, "start test next body");
-        return JIM_ERR;
-    }
 
     /* Do the initialisation */
     if ((retval = Jim_EvalObj(interp, argv[1])) != JIM_OK) {
@@ -12664,11 +12720,6 @@ static int Jim_LoopCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     jim_wide incr = 1;
     Jim_Obj *bodyObjPtr;
 
-    if (argc < 4 || argc > 6) {
-        Jim_WrongNumArgs(interp, 1, argv, "var ?first? limit ?incr? body");
-        return JIM_ERR;
-    }
-
     retval = Jim_GetWideExpr(interp, argv[2], &i);
     if (argc > 4 && retval == JIM_OK) {
         retval = Jim_GetWideExpr(interp, argv[3], &limit);
@@ -12781,9 +12832,8 @@ static int JimForeachMapHelper(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     Jim_Obj *script;
     Jim_Obj *resultObj;
 
-    if (argc < 4 || argc % 2 != 0) {
-        Jim_WrongNumArgs(interp, 1, argv, "varList list ?varList list ...? script");
-        return JIM_ERR;
+    if (argc % 2 != 0) {
+        return JIM_USAGE;
     }
     script = argv[argc - 1];    /* Last argument is a script */
     numargs = (argc - 1 - 1);    /* argc - 'foreach' - script */
@@ -12896,11 +12946,6 @@ static int Jim_LassignCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
     Jim_ListIter iter;
     Jim_Obj *resultObj;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "varList list ?varName ...?");
-        return JIM_ERR;
-    }
-
     JimListIterInit(&iter, argv[1]);
 
     for (i = 2; i < argc; i++) {
@@ -12926,50 +12971,50 @@ static int Jim_IfCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     int boolean, retval, current = 1, falsebody = 0;
 
-    if (argc >= 3) {
-        while (1) {
-            /* Far not enough arguments given! */
-            if (current >= argc)
-                goto err;
-            if ((retval = Jim_GetBoolFromExpr(interp, argv[current++], &boolean))
-                != JIM_OK)
-                return retval;
-            /* There lacks something, isn't it? */
-            if (current >= argc)
-                goto err;
-            if (Jim_CompareStringImmediate(interp, argv[current], "then"))
-                current++;
-            /* Tsk tsk, no then-clause? */
-            if (current >= argc)
-                goto err;
-            if (boolean)
-                return Jim_EvalObj(interp, argv[current]);
-            /* Ok: no else-clause follows */
-            if (++current >= argc) {
-                Jim_SetResult(interp, Jim_NewEmptyStringObj(interp));
-                return JIM_OK;
-            }
-            falsebody = current++;
-            if (Jim_CompareStringImmediate(interp, argv[falsebody], "else")) {
-                /* IIICKS - else-clause isn't last cmd? */
-                if (current != argc - 1)
-                    goto err;
-                return Jim_EvalObj(interp, argv[current]);
-            }
-            else if (Jim_CompareStringImmediate(interp, argv[falsebody], "elseif"))
-                /* Ok: elseif follows meaning all the stuff
-                 * again (how boring...) */
-                continue;
-            /* OOPS - else-clause is not last cmd? */
-            else if (falsebody != argc - 1)
-                goto err;
-            return Jim_EvalObj(interp, argv[falsebody]);
+    while (1) {
+        /* not enough arguments given! */
+        if (current >= argc) {
+            return JIM_USAGE;
         }
-        return JIM_OK;
+        if ((retval = Jim_GetBoolFromExpr(interp, argv[current++], &boolean))
+            != JIM_OK)
+            return retval;
+        /* There lacks something, isn't it? */
+        if (current >= argc) {
+            return JIM_USAGE;
+        }
+        if (Jim_CompareStringImmediate(interp, argv[current], "then"))
+            current++;
+        /* Tsk tsk, no then-clause? */
+        if (current >= argc) {
+            return JIM_USAGE;
+        }
+        if (boolean)
+            return Jim_EvalObj(interp, argv[current]);
+        /* Ok: no else-clause follows */
+        if (++current >= argc) {
+            Jim_SetResult(interp, Jim_NewEmptyStringObj(interp));
+            return JIM_OK;
+        }
+        falsebody = current++;
+        if (Jim_CompareStringImmediate(interp, argv[falsebody], "else")) {
+            /* IIICKS - else-clause isn't last cmd? */
+            if (current != argc - 1) {
+                return JIM_USAGE;
+            }
+            return Jim_EvalObj(interp, argv[current]);
+        }
+        else if (Jim_CompareStringImmediate(interp, argv[falsebody], "elseif"))
+            /* Ok: elseif follows meaning all the stuff
+             * again (how boring...) */
+            continue;
+        /* OOPS - else-clause is not last cmd? */
+        else if (falsebody != argc - 1) {
+            return JIM_USAGE;
+        }
+        return Jim_EvalObj(interp, argv[falsebody]);
     }
-  err:
-    Jim_WrongNumArgs(interp, 1, argv, "condition ?then? trueBody ?elseif ...? ?else? falseBody");
-    return JIM_ERR;
+    return JIM_OK;
 }
 
 
@@ -13012,12 +13057,6 @@ static int Jim_SwitchCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
     Jim_Obj *command = NULL, *scriptObj = NULL, *strObj;
     Jim_Obj **caseList;
 
-    if (argc < 3) {
-      wrongnumargs:
-        Jim_WrongNumArgs(interp, 1, argv, "?options? string "
-            "pattern body ... ?default body?   or   " "{pattern body ?pattern body ...?}");
-        return JIM_ERR;
-    }
     for (opt = 1; opt < argc; ++opt) {
         const char *option = Jim_String(argv[opt]);
 
@@ -13038,7 +13077,7 @@ static int Jim_SwitchCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
         else if (strncmp(option, "-command", 2) == 0) {
             matchOpt = SWITCH_CMD;
             if ((argc - opt) < 2)
-                goto wrongnumargs;
+                return JIM_USAGE;
             command = argv[++opt];
         }
         else {
@@ -13048,7 +13087,7 @@ static int Jim_SwitchCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
             return JIM_ERR;
         }
         if ((argc - opt) < 2)
-            goto wrongnumargs;
+            return JIM_USAGE;
     }
     strObj = argv[opt++];
     patCount = argc - opt;
@@ -13058,7 +13097,7 @@ static int Jim_SwitchCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
     else
         caseList = (Jim_Obj **)&argv[opt];
     if (patCount == 0 || patCount % 2 != 0)
-        goto wrongnumargs;
+        return JIM_USAGE;
     for (i = 0; scriptObj == NULL && i < patCount; i += 2) {
         Jim_Obj *patObj = caseList[i];
 
@@ -13128,10 +13167,6 @@ static int Jim_LindexCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
     Jim_Obj *objPtr;
     int ret;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "list ?index ...?");
-        return JIM_ERR;
-    }
     ret = Jim_ListIndices(interp, argv[1], argv + 2, argc - 2, &objPtr, JIM_NONE);
     if (ret < 0) {
         /* Returns an empty object if the index
@@ -13148,10 +13183,6 @@ static int Jim_LindexCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
 /* [llength] */
 static int Jim_LlengthCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "list");
-        return JIM_ERR;
-    }
     Jim_SetResultInt(interp, Jim_ListLength(interp, argv[1]));
     return JIM_OK;
 }
@@ -13179,13 +13210,6 @@ static int Jim_LsearchCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
     Jim_Obj *indexObj = NULL;
     int match_flags = 0;
     long stride = 1;
-
-    if (argc < 3) {
-      wrongargs:
-        Jim_WrongNumArgs(interp, 1, argv,
-            "?-exact|-glob|-regexp|-command 'command'? ?-bool|-inline? ?-not? ?-nocase? ?-all? ?-stride len? ?-index val? list value");
-        return JIM_ERR;
-    }
 
     for (i = 1; i < argc - 2; i++) {
         int option;
@@ -13217,7 +13241,7 @@ static int Jim_LsearchCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
                 break;
             case OPT_COMMAND:
                 if (i >= argc - 2) {
-                    goto wrongargs;
+                    return JIM_USAGE;
                 }
                 commandObj = argv[++i];
                 /* fallthru */
@@ -13227,13 +13251,13 @@ static int Jim_LsearchCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
                 break;
             case OPT_INDEX:
                 if (i >= argc - 2) {
-                    goto wrongargs;
+                    return JIM_USAGE;
                 }
                 indexObj = argv[++i];
                 break;
             case OPT_STRIDE:
                 if (i >= argc - 2) {
-                    goto wrongargs;
+                    return JIM_USAGE;
                 }
                 if (Jim_GetLong(interp, argv[++i], &stride) != JIM_OK) {
                     return JIM_ERR;
@@ -13248,7 +13272,7 @@ static int Jim_LsearchCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
 
     argc -= i;
     if (argc < 2) {
-        goto wrongargs;
+        return JIM_USAGE;
     }
     argv += i;
 
@@ -13394,10 +13418,6 @@ static int Jim_LappendCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
     int new_obj = 0;
     int i;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "varName ?value value ...?");
-        return JIM_ERR;
-    }
     listObjPtr = Jim_GetVariable(interp, argv[1], JIM_UNSHARED);
     if (!listObjPtr) {
         /* Create the list if it does not exist */
@@ -13425,10 +13445,6 @@ static int Jim_LinsertCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
     int idx, len;
     Jim_Obj *listPtr;
 
-    if (argc < 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "list index ?element ...?");
-        return JIM_ERR;
-    }
     listPtr = argv[1];
     if (Jim_IsShared(listPtr))
         listPtr = Jim_DuplicateObj(interp, listPtr);
@@ -13456,10 +13472,6 @@ static int Jim_LreplaceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const 
     Jim_Obj *listObj;
     Jim_Obj *newListObj;
 
-    if (argc < 4) {
-        Jim_WrongNumArgs(interp, 1, argv, "list first last ?element ...?");
-        return JIM_ERR;
-    }
     if (Jim_GetIndex(interp, argv[2], &first) != JIM_OK ||
         Jim_GetIndex(interp, argv[3], &last) != JIM_OK) {
         return JIM_ERR;
@@ -13499,11 +13511,7 @@ static int Jim_LreplaceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const 
 /* [lset] */
 static int Jim_LsetCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc < 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "listVar ?index ...? value");
-        return JIM_ERR;
-    }
-    else if (argc == 3) {
+    if (argc == 3) {
         /* With no indexes, simply implements [set] */
         if (Jim_SetVariable(interp, argv[1], argv[2]) != JIM_OK)
             return JIM_ERR;
@@ -13533,12 +13541,6 @@ static int Jim_LsortCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const arg
     int listlen;
 
     struct lsort_info info;
-
-    if (argc < 2) {
-wrongargs:
-        Jim_WrongNumArgs(interp, 1, argv, "?options? list");
-        return JIM_ERR;
-    }
 
     info.type = JIM_LSORT_ASCII;
     info.order = 1;
@@ -13589,7 +13591,7 @@ wrongargs:
                 break;
             case OPT_STRIDE:
                 if (i >= argc - 2) {
-                    goto wrongargs;
+                    return JIM_USAGE;
                 }
                 if (Jim_GetLong(interp, argv[++i], &stride) != JIM_OK) {
                     return JIM_ERR;
@@ -13667,10 +13669,6 @@ static int Jim_AppendCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
     Jim_Obj *stringObjPtr;
     int i;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "varName ?value ...?");
-        return JIM_ERR;
-    }
     if (argc == 2) {
         stringObjPtr = Jim_GetVariable(interp, argv[1], JIM_ERRMSG);
         if (!stringObjPtr)
@@ -13796,8 +13794,9 @@ static int Jim_DebugCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
 
         case OPT_OBJECTS:{
             Jim_Obj *objPtr, *listObjPtr, *subListObjPtr;
-            int tainted;
+            int tainted = 0;
 
+#ifdef JIM_TAINT
             if (argc == 3) {
                 if (Jim_CompareStringImmediate(interp, argv[2], "-taint")) {
                     tainted = 1;
@@ -13807,32 +13806,25 @@ static int Jim_DebugCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
                     return JIM_ERR;
                 }
             }
+#endif
 
-            /* Count the number of live objects. */
-            objPtr = interp->liveList;
+            /* Return a list of the objects */
             listObjPtr = Jim_NewListObj(interp, NULL, 0);
-            while (objPtr) {
+            for (objPtr = interp->liveList; objPtr; objPtr = objPtr->nextObjPtr) {
                 char buf[128];
                 const char *type = objPtr->typePtr ? objPtr->typePtr->name : "";
 
-                /* Return a list of the objects */
-                listObjPtr = Jim_NewListObj(interp, NULL, 0);
-                for (objPtr = interp->liveList; objPtr; objPtr = objPtr->nextObjPtr) {
-                    char buf[128];
-                    const char *type = objPtr->typePtr ? objPtr->typePtr->name : "";
-
-                    if (objPtr == listObjPtr || (tainted && !objPtr->taint)) {
-                        continue;
-                    }
-
-                    subListObjPtr = Jim_NewListObj(interp, NULL, 0);
-                    sprintf(buf, "%p", objPtr);
-                    Jim_ListAppendElement(interp, subListObjPtr, Jim_NewStringObj(interp, buf, -1));
-                    Jim_ListAppendElement(interp, subListObjPtr, Jim_NewStringObj(interp, type, -1));
-                    Jim_ListAppendElement(interp, subListObjPtr, Jim_NewIntObj(interp, objPtr->refCount));
-                    Jim_ListAppendElement(interp, subListObjPtr, objPtr);
-                    Jim_ListAppendElement(interp, listObjPtr, subListObjPtr);
+                if (objPtr == listObjPtr || (tainted && !objPtr->taint)) {
+                    continue;
                 }
+
+                subListObjPtr = Jim_NewListObj(interp, NULL, 0);
+                sprintf(buf, "%p", objPtr);
+                Jim_ListAppendElement(interp, subListObjPtr, Jim_NewStringObj(interp, buf, -1));
+                Jim_ListAppendElement(interp, subListObjPtr, Jim_NewStringObj(interp, type, -1));
+                Jim_ListAppendElement(interp, subListObjPtr, Jim_NewIntObj(interp, objPtr->refCount));
+                Jim_ListAppendElement(interp, subListObjPtr, objPtr);
+                Jim_ListAppendElement(interp, listObjPtr, subListObjPtr);
             }
             Jim_SetResult(interp, listObjPtr);
             return JIM_OK;
@@ -13910,11 +13902,6 @@ static int Jim_EvalCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
 {
     int rc;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "arg ?arg ...?");
-        return JIM_ERR;
-    }
-
     if (argc == 2) {
         rc = Jim_EvalObj(interp, argv[1]);
     }
@@ -13928,46 +13915,39 @@ static int Jim_EvalCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
 /* [uplevel] */
 static int Jim_UplevelCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc >= 2) {
-        int retcode;
-        Jim_CallFrame *savedCallFrame, *targetCallFrame;
-        const char *str;
+    int retcode;
+    Jim_CallFrame *savedCallFrame, *targetCallFrame;
+    const char *str;
 
-        /* Save the old callframe pointer */
-        savedCallFrame = interp->framePtr;
+    /* Save the old callframe pointer */
+    savedCallFrame = interp->framePtr;
 
-        /* Lookup the target frame pointer */
-        str = Jim_String(argv[1]);
-        if ((str[0] >= '0' && str[0] <= '9') || str[0] == '#') {
-            targetCallFrame = Jim_GetCallFrameByLevel(interp, argv[1]);
-            argc--;
-            argv++;
-        }
-        else {
-            targetCallFrame = Jim_GetCallFrameByLevel(interp, NULL);
-        }
-        if (targetCallFrame == NULL) {
-            return JIM_ERR;
-        }
-        if (argc < 2) {
-            Jim_WrongNumArgs(interp, 1, argv - 1, "?level? command ?arg ...?");
-            return JIM_ERR;
-        }
-        /* Eval the code in the target callframe. */
-        interp->framePtr = targetCallFrame;
-        if (argc == 2) {
-            retcode = Jim_EvalObj(interp, argv[1]);
-        }
-        else {
-            retcode = Jim_EvalObj(interp, Jim_ConcatObj(interp, argc - 1, argv + 1));
-        }
-        interp->framePtr = savedCallFrame;
-        return retcode;
+    /* Lookup the target frame pointer */
+    str = Jim_String(argv[1]);
+    if ((str[0] >= '0' && str[0] <= '9') || str[0] == '#') {
+        targetCallFrame = Jim_GetCallFrameByLevel(interp, argv[1]);
+        argc--;
+        argv++;
     }
     else {
-        Jim_WrongNumArgs(interp, 1, argv, "?level? command ?arg ...?");
+        targetCallFrame = Jim_GetCallFrameByLevel(interp, NULL);
+    }
+    if (targetCallFrame == NULL) {
         return JIM_ERR;
     }
+    if (argc < 2) {
+        return JIM_USAGE;
+    }
+    /* Eval the code in the target callframe. */
+    interp->framePtr = targetCallFrame;
+    if (argc == 2) {
+        retcode = Jim_EvalObj(interp, argv[1]);
+    }
+    else {
+        retcode = Jim_EvalObj(interp, Jim_ConcatObj(interp, argc - 1, argv + 1));
+    }
+    interp->framePtr = savedCallFrame;
+    return retcode;
 }
 
 /* [expr] */
@@ -13978,13 +13958,7 @@ static int Jim_ExprCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     if (argc == 2) {
         retcode = Jim_EvalExpression(interp, argv[1]);
     }
-#ifndef JIM_COMPAT
     else {
-        Jim_WrongNumArgs(interp, 1, argv, "expression");
-        retcode = JIM_ERR;
-    }
-#else
-    else if (argc > 2) {
         Jim_Obj *objPtr;
 
         objPtr = Jim_ConcatObj(interp, argc - 1, argv + 1);
@@ -13992,20 +13966,11 @@ static int Jim_ExprCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         retcode = Jim_EvalExpression(interp, objPtr);
         Jim_DecrRefCount(interp, objPtr);
     }
-    else {
-        Jim_WrongNumArgs(interp, 1, argv, "expression ?...?");
-        return JIM_ERR;
-    }
-#endif
     return retcode;
 }
 
 static int JimBreakContinueHelper(Jim_Interp *interp, int argc, Jim_Obj *const *argv, int retcode)
 {
-    if (argc != 1 && argc != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "?level?");
-        return JIM_ERR;
-    }
     if (argc == 2) {
         long level;
         int ret = Jim_GetLong(interp, argv[1], &level);
@@ -14093,8 +14058,7 @@ static int Jim_ReturnCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
     }
 
     if (i != argc - 1 && i != argc) {
-        Jim_WrongNumArgs(interp, 1, argv,
-            "?-code code? ?-errorinfo stacktrace? ?-level level? ?result?");
+        return JIM_USAGE;
     }
 
     /* If a stack trace is supplied and code is error, set the stack trace */
@@ -14168,29 +14132,18 @@ static void JimAliasCmdDelete(Jim_Interp *interp, void *privData)
 
 static int Jim_AliasCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    Jim_Obj *prefixListObj;
-
-    if (argc < 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "newname command ?args ...?");
-        return JIM_ERR;
-    }
-
-    prefixListObj = Jim_NewListObj(interp, argv + 2, argc - 2);
+    Jim_Obj *prefixListObj = Jim_NewListObj(interp, argv + 2, argc - 2);
     Jim_IncrRefCount(prefixListObj);
     Jim_SetResult(interp, argv[1]);
 
-    return Jim_CreateCommandObj(interp, argv[1], JimAliasCmd, prefixListObj, JimAliasCmdDelete);
+    Jim_RegisterCommand(interp, argv[1], JimAliasCmd, JimAliasCmdDelete, NULL, NULL, 0, -1, JIM_CMD_ISALIAS, prefixListObj);
+    return JIM_OK;
 }
 
 /* [proc] */
 static int Jim_ProcCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     Jim_Cmd *cmd;
-
-    if (argc != 4 && argc != 5) {
-        Jim_WrongNumArgs(interp, 1, argv, "name arglist ?statics? body");
-        return JIM_ERR;
-    }
 
     if (argc == 4) {
         cmd = JimCreateProcedureCmd(interp, argv[2], NULL, argv[3], NULL);
@@ -14218,11 +14171,6 @@ static int Jim_ProcCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
 /* [xtrace] */
 static int Jim_XtraceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "callback");
-        return JIM_ERR;
-    }
-
     if (interp->traceCmdObj) {
         Jim_DecrRefCount(interp, interp->traceCmdObj);
         interp->traceCmdObj = NULL;
@@ -14240,11 +14188,6 @@ static int Jim_XtraceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
 static int Jim_LocalCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     int retcode;
-
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "cmd ?args ...?");
-        return JIM_ERR;
-    }
 
     /* Evaluate the arguments with 'local' in force */
     interp->local++;
@@ -14273,83 +14216,71 @@ static int Jim_LocalCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
 /* [upcall] */
 static int Jim_UpcallCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "cmd ?args ...?");
+    int retcode;
+
+    Jim_Cmd *cmdPtr = Jim_GetCommand(interp, argv[1], JIM_ERRMSG);
+    if (cmdPtr == NULL || !(cmdPtr->flags & JIM_CMD_ISPROC) || !cmdPtr->prevCmd) {
+        Jim_SetResultFormatted(interp, "no previous command: \"%#s\"", argv[1]);
         return JIM_ERR;
     }
-    else {
-        int retcode;
+    /* OK. Mark this command as being in an upcall */
+    cmdPtr->u.proc.upcall++;
+    JimIncrCmdRefCount(cmdPtr);
 
-        Jim_Cmd *cmdPtr = Jim_GetCommand(interp, argv[1], JIM_ERRMSG);
-        if (cmdPtr == NULL || !cmdPtr->isproc || !cmdPtr->prevCmd) {
-            Jim_SetResultFormatted(interp, "no previous command: \"%#s\"", argv[1]);
-            return JIM_ERR;
-        }
-        /* OK. Mark this command as being in an upcall */
-        cmdPtr->u.proc.upcall++;
-        JimIncrCmdRefCount(cmdPtr);
+    /* Invoke the command as normal */
+    retcode = Jim_EvalObjVector(interp, argc - 1, argv + 1);
 
-        /* Invoke the command as normal */
-        retcode = Jim_EvalObjVector(interp, argc - 1, argv + 1);
+    /* No longer in an upcall */
+    cmdPtr->u.proc.upcall--;
+    JimDecrCmdRefCount(interp, cmdPtr);
 
-        /* No longer in an upcall */
-        cmdPtr->u.proc.upcall--;
-        JimDecrCmdRefCount(interp, cmdPtr);
-
-        return retcode;
-    }
+    return retcode;
 }
 
 /* [apply] */
 static int Jim_ApplyCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "lambdaExpr ?arg ...?");
+    int ret;
+    Jim_Cmd *cmd;
+    Jim_Obj *argListObjPtr;
+    Jim_Obj *bodyObjPtr;
+    Jim_Obj *nsObj = NULL;
+    Jim_Obj **nargv;
+
+    int len = Jim_ListLength(interp, argv[1]);
+    if (len != 2 && len != 3) {
+        Jim_SetResultFormatted(interp, "can't interpret \"%#s\" as a lambda expression", argv[1]);
         return JIM_ERR;
     }
-    else {
-        int ret;
-        Jim_Cmd *cmd;
-        Jim_Obj *argListObjPtr;
-        Jim_Obj *bodyObjPtr;
-        Jim_Obj *nsObj = NULL;
-        Jim_Obj **nargv;
 
-        int len = Jim_ListLength(interp, argv[1]);
-        if (len != 2 && len != 3) {
-            Jim_SetResultFormatted(interp, "can't interpret \"%#s\" as a lambda expression", argv[1]);
-            return JIM_ERR;
-        }
-
-        if (len == 3) {
+    if (len == 3) {
 #ifdef jim_ext_namespace
-            /* Note that the namespace is always treated as global */
-            nsObj = Jim_ListGetIndex(interp, argv[1], 2);
+        /* Note that the namespace is always treated as global */
+        nsObj = Jim_ListGetIndex(interp, argv[1], 2);
 #else
-            Jim_SetResultString(interp, "namespaces not enabled", -1);
-            return JIM_ERR;
-#endif
-        }
-        argListObjPtr = Jim_ListGetIndex(interp, argv[1], 0);
-        bodyObjPtr = Jim_ListGetIndex(interp, argv[1], 1);
-
-        cmd = JimCreateProcedureCmd(interp, argListObjPtr, NULL, bodyObjPtr, nsObj);
-
-        if (cmd) {
-            /* Create a new argv array with a dummy argv[0], for error messages */
-            nargv = Jim_Alloc((argc - 2 + 1) * sizeof(*nargv));
-            nargv[0] = Jim_NewStringObj(interp, "apply lambdaExpr", -1);
-            Jim_IncrRefCount(nargv[0]);
-            memcpy(&nargv[1], argv + 2, (argc - 2) * sizeof(*nargv));
-            ret = JimCallProcedure(interp, cmd, argc - 2 + 1, nargv);
-            Jim_DecrRefCount(interp, nargv[0]);
-            Jim_Free(nargv);
-
-            JimDecrCmdRefCount(interp, cmd);
-            return ret;
-        }
+        Jim_SetResultString(interp, "namespaces not enabled", -1);
         return JIM_ERR;
+#endif
     }
+    argListObjPtr = Jim_ListGetIndex(interp, argv[1], 0);
+    bodyObjPtr = Jim_ListGetIndex(interp, argv[1], 1);
+
+    cmd = JimCreateProcedureCmd(interp, argListObjPtr, NULL, bodyObjPtr, nsObj);
+
+    if (cmd) {
+        /* Create a new argv array with a dummy argv[0], for error messages */
+        nargv = Jim_Alloc((argc - 2 + 1) * sizeof(*nargv));
+        nargv[0] = Jim_NewStringObj(interp, "apply lambdaExpr", -1);
+        Jim_IncrRefCount(nargv[0]);
+        memcpy(&nargv[1], argv + 2, (argc - 2) * sizeof(*nargv));
+        ret = JimCallProcedure(interp, cmd, argc - 2 + 1, nargv);
+        Jim_DecrRefCount(interp, nargv[0]);
+        Jim_Free(nargv);
+
+        JimDecrCmdRefCount(interp, cmd);
+        return ret;
+    }
+    return JIM_ERR;
 }
 
 #ifdef JIM_TAINT
@@ -14436,8 +14367,7 @@ static int Jim_UpvarCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
 
     /* Check for arity */
     if (argc < 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "?level? otherVar localVar ?otherVar localVar ...?");
-        return JIM_ERR;
+        return JIM_USAGE;
     }
 
     /* Now... for every other/local couple: */
@@ -14453,10 +14383,6 @@ static int Jim_GlobalCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
 {
     int i;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "varName ?varName ...?");
-        return JIM_ERR;
-    }
     /* Link every var to the toplevel having the same name */
     if (interp->framePtr->level == 0)
         return JIM_OK;          /* global at toplevel... */
@@ -14573,7 +14499,7 @@ static int Jim_StringCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
     static const jim_subcmd_type cmds[OPT_COUNT + 1] = {
         JIM_DEF_SUBCMD("bytelength", "string", 1, 1),
         JIM_DEF_SUBCMD("byterange", "string first last", 3, 3),
-        JIM_DEF_SUBCMD("cat", "?...?", 0, -1),
+        JIM_DEF_SUBCMD("cat", "?string ...?", 0, -1),
         JIM_DEF_SUBCMD("compare", "?-nocase? ?-length int? string1 string2", 2, 5),
         JIM_DEF_SUBCMD("equal", "?-nocase? ?-length int? string1 string2", 2, 5),
         JIM_DEF_SUBCMD("first", "subString string ?index?", 2, 3),
@@ -14891,10 +14817,6 @@ static int Jim_TimeCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     long i, count = 1;
     jim_wide start, elapsed;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "script ?count?");
-        return JIM_ERR;
-    }
     if (argc == 3) {
         if (Jim_GetLong(interp, argv[2], &count) != JIM_OK)
             return JIM_ERR;
@@ -14923,7 +14845,7 @@ static int Jim_TimeCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
 }
 
 /* [timerate] */
-static int Jim_TimeRateCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
+static int Jim_TimerateCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
     long us = 0;
     jim_wide start, delta, overhead;
@@ -14932,10 +14854,6 @@ static int Jim_TimeRateCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const 
     int count;
     int n;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "script ?milliseconds?");
-        return JIM_ERR;
-    }
     if (argc == 3) {
         if (Jim_GetLong(interp, argv[2], &us) != JIM_OK)
             return JIM_ERR;
@@ -14992,10 +14910,6 @@ static int Jim_ExitCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
 {
     long exitCode = 0;
 
-    if (argc > 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "?exitCode?");
-        return JIM_ERR;
-    }
     if (argc == 2) {
         if (Jim_GetLong(interp, argv[1], &exitCode) != JIM_OK)
             return JIM_ERR;
@@ -15024,10 +14938,6 @@ static int JimMatchReturnCodes(Jim_Interp *interp, Jim_Obj *retcodeListObj, int 
 /* Implements both [try] and [catch] */
 static int JimCatchTryHelper(Jim_Interp *interp, int istry, int argc, Jim_Obj *const *argv)
 {
-    static const char * const wrongargs_catchtry[2] = {
-        "?-?no?code ... --? script ?resultVarName? ?optionVarName?",
-        "?-?no?code ... --? script ?on|trap codes vars script? ... ?finally script?"
-    };
     int exitCode = 0;
     int i;
     int sig = 0;
@@ -15080,7 +14990,7 @@ static int JimCatchTryHelper(Jim_Interp *interp, int istry, int argc, Jim_Obj *c
             option = Jim_FindByName(arg, jimReturnCodes, jimReturnCodesSize);
         }
         if (option < 0) {
-            goto wrongargs;
+            return JIM_USAGE;
         }
 
         if (ignore) {
@@ -15094,9 +15004,7 @@ static int JimCatchTryHelper(Jim_Interp *interp, int istry, int argc, Jim_Obj *c
     idx = i;
 
     if (argc - idx < 1) {
-wrongargs:
-        Jim_WrongNumArgs(interp, 1, argv, wrongargs_catchtry[istry]);
-        return JIM_ERR;
+        return JIM_USAGE;
     }
 
     if ((ignore_mask & (1 << JIM_SIGNAL)) == 0) {
@@ -15139,12 +15047,12 @@ wrongargs:
                 case TRY_ON:
                 case TRY_TRAP:
                     if (idx + 4 > argc) {
-                        goto wrongargs;
+                        return JIM_USAGE;
                     }
                     if (option == TRY_ON) {
                         ret = JimMatchReturnCodes(interp, argv[idx + 1], exitCode);
                         if (ret > JIM_OK) {
-                            goto wrongargs;
+                            return JIM_USAGE;
                         }
                     }
                     else if (errorCodeObj) {
@@ -15182,7 +15090,7 @@ wrongargs:
                     break;
                 case TRY_FINALLY:
                     if (idx + 2 != argc) {
-                        goto wrongargs;
+                        return JIM_USAGE;
                     }
                     finallyScriptObj = argv[idx + 1];
                     idx += 2;
@@ -15291,10 +15199,6 @@ static int Jim_TryCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv
 /* [ref] */
 static int Jim_RefCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 3 && argc != 4) {
-        Jim_WrongNumArgs(interp, 1, argv, "string tag ?finalizer?");
-        return JIM_ERR;
-    }
     if (argc == 3) {
         Jim_SetResult(interp, Jim_NewReference(interp, argv[1], argv[2], NULL));
     }
@@ -15309,10 +15213,6 @@ static int Jim_GetrefCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
 {
     Jim_Reference *refPtr;
 
-    if (argc != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "reference");
-        return JIM_ERR;
-    }
     if ((refPtr = Jim_GetReference(interp, argv[1])) == NULL)
         return JIM_ERR;
     Jim_SetResult(interp, refPtr->objPtr);
@@ -15324,10 +15224,6 @@ static int Jim_SetrefCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
 {
     Jim_Reference *refPtr;
 
-    if (argc != 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "reference newValue");
-        return JIM_ERR;
-    }
     if ((refPtr = Jim_GetReference(interp, argv[1])) == NULL)
         return JIM_ERR;
     Jim_IncrRefCount(argv[2]);
@@ -15340,10 +15236,6 @@ static int Jim_SetrefCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
 /* [collect] */
 static int Jim_CollectCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 1) {
-        Jim_WrongNumArgs(interp, 1, argv, "");
-        return JIM_ERR;
-    }
     Jim_SetResultInt(interp, Jim_Collect(interp));
 
     /* Free all the freed objects. */
@@ -15359,10 +15251,6 @@ static int Jim_CollectCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
 /* [finalize] reference ?newValue? */
 static int Jim_FinalizeCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 2 && argc != 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "reference ?finalizerProc?");
-        return JIM_ERR;
-    }
     if (argc == 2) {
         Jim_Obj *cmdNamePtr;
 
@@ -15405,11 +15293,6 @@ static int JimInfoReferences(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 /* [rename] */
 static int Jim_RenameCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "oldName newName");
-        return JIM_ERR;
-    }
-
     return Jim_RenameCommand(interp, argv[1], argv[2]);
 }
 
@@ -15744,10 +15627,6 @@ static int Jim_SubstCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
     int flags = JIM_SUBST_FLAG;
     Jim_Obj *objPtr;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "?options? string");
-        return JIM_ERR;
-    }
     for (i = 1; i < (argc - 1); i++) {
         int option;
 
@@ -15792,6 +15671,7 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     /* Must be kept in order with the array below */
     enum {
         INFO_ALIAS,
+        INFO_ALIASES,
         INFO_ARGS,
         INFO_BODY,
         INFO_CHANNELS,
@@ -15800,6 +15680,7 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         INFO_EXISTS,
         INFO_FRAME,
         INFO_GLOBALS,
+        INFO_HELP,
         INFO_HOSTNAME,
         INFO_LEVEL,
         INFO_LOCALS,
@@ -15813,12 +15694,14 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         INFO_STACKTRACE,
         INFO_STATICS,
         INFO_TAINTED,
+        INFO_USAGE,
         INFO_VARS,
         INFO_VERSION,
         INFO_COUNT
     };
     static const jim_subcmd_type cmds[INFO_COUNT + 1] = {
         JIM_DEF_SUBCMD("alias", "command", 1, 1),
+        JIM_DEF_SUBCMD("aliases", "?-all? ?pattern?", 0, 2),
         JIM_DEF_SUBCMD("args", "procname", 1, 1),
         JIM_DEF_SUBCMD("body", "procname", 1, 1),
         JIM_DEF_SUBCMD("channels", "?pattern?", 0, 1),
@@ -15827,6 +15710,7 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         JIM_DEF_SUBCMD("exists", "varName", 1, 1),
         JIM_DEF_SUBCMD("frame", "?levelNum?", 0, 1),
         JIM_DEF_SUBCMD("globals", "?pattern?", 0, 1),
+        JIM_DEF_SUBCMD("help", "command", 1, 1),
         JIM_DEF_SUBCMD("hostname", NULL, 0, 0),
         JIM_DEF_SUBCMD("level", "?levelNum?", 0, 1),
         JIM_DEF_SUBCMD("locals", "?pattern?", 0, 1),
@@ -15839,7 +15723,8 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
         JIM_DEF_SUBCMD("source", "source ?filename line?", 1, 3),
         JIM_DEF_SUBCMD("stacktrace", NULL, 0, 0),
         JIM_DEF_SUBCMD("statics", "procname", 1, 1),
-        JIM_DEF_SUBCMD("tainted", "str", 1, 1),
+        JIM_DEF_SUBCMD("tainted", "value", 1, 1),
+        JIM_DEF_SUBCMD("usage", "command", 1, 1),
         JIM_DEF_SUBCMD("vars", "?pattern?", 0, 1),
         JIM_DEF_SUBCMD("version", NULL, 0, 0),
         { NULL }
@@ -15877,7 +15762,7 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
             if ((cmdPtr = Jim_GetCommand(interp, argv[2], JIM_ERRMSG)) == NULL) {
                 return JIM_ERR;
             }
-            if (cmdPtr->isproc || cmdPtr->u.native.cmdProc != JimAliasCmd) {
+            if ((cmdPtr->flags & JIM_CMD_ISALIAS) == 0) {
                 Jim_SetResultFormatted(interp, "command \"%#s\" is not an alias", argv[2]);
                 return JIM_ERR;
             }
@@ -15899,6 +15784,9 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
             return JIM_ERR;
 #endif
             /* fall through */
+        case INFO_ALIASES:
+            mode <<= 1;             /* JIM_CMDLIST_ALIASES */
+            /* fall through */
         case INFO_PROCS:
             mode++;             /* JIM_CMDLIST_PROCS */
             /* fall through */
@@ -15906,6 +15794,7 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
             /* mode 0 => JIM_CMDLIST_COMMANDS */
 #ifdef jim_ext_namespace
             if (!nons) {
+                /* Called as 'info -nons commands|procs' so respect the current namespace */
                 if (Jim_Length(interp->framePtr->nsObj) || (argc == 3 && JimIsGlobalNamespace(argv[2]))) {
                     return Jim_EvalPrefix(interp, "namespace info", argc - 1, argv + 1);
                 }
@@ -15996,6 +15885,27 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
             }
             return JIM_OK;
 
+        case INFO_USAGE:
+        case INFO_HELP:{
+            Jim_Cmd *cmdPtr = Jim_GetCommand(interp, argv[2], JIM_ERRMSG);
+            if (!cmdPtr) {
+                return JIM_ERR;
+            }
+            if (option == INFO_USAGE) {
+                Jim_SetResult(interp, JimCmdUsage(interp, argv[2], cmdPtr));
+                return JIM_OK;
+            }
+            else if ((cmdPtr->flags & JIM_CMD_ISPROC) == 0) {
+                if (cmdPtr->u.native.help) {
+                    Jim_SetResultString(interp, cmdPtr->u.native.help, -1);
+                    return JIM_OK;
+                }
+            }
+            /* This isn't an error */
+            Jim_SetResultFormatted(interp, "No help available for command \"%#s\"", argv[2]);
+            return JIM_OK;
+        }
+
         case INFO_BODY:
         case INFO_STATICS:
         case INFO_ARGS:{
@@ -16004,7 +15914,7 @@ static int Jim_InfoCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
                 if ((cmdPtr = Jim_GetCommand(interp, argv[2], JIM_ERRMSG)) == NULL) {
                     return JIM_ERR;
                 }
-                if (!cmdPtr->isproc) {
+                if ((cmdPtr->flags & JIM_CMD_ISPROC) == 0) {
                     Jim_SetResultFormatted(interp, "command \"%#s\" is not a procedure", argv[2]);
                     return JIM_ERR;
                 }
@@ -16106,11 +16016,11 @@ static int Jim_ExistsCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
     int result = 0;
 
     static const char * const options[] = {
-        "-command", "-proc", "-alias", "-var", NULL
+        "-command", "-proc", "-alias", "-channel", "-var", NULL
     };
     enum
     {
-        OPT_COMMAND, OPT_PROC, OPT_ALIAS, OPT_VAR
+        OPT_COMMAND, OPT_PROC, OPT_ALIAS, OPT_CHANNEL, OPT_VAR
     };
     int option;
 
@@ -16125,8 +16035,7 @@ static int Jim_ExistsCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
         objPtr = argv[2];
     }
     else {
-        Jim_WrongNumArgs(interp, 1, argv, "?option? name");
-        return JIM_ERR;
+        return JIM_USAGE;
     }
 
     if (option == OPT_VAR) {
@@ -16143,11 +16052,15 @@ static int Jim_ExistsCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
                 break;
 
             case OPT_ALIAS:
-                result = cmd->isproc == 0 && cmd->u.native.cmdProc == JimAliasCmd;
+                result = (cmd->flags & JIM_CMD_ISALIAS) != 0;
                 break;
 
             case OPT_PROC:
-                result = cmd->isproc;
+                result = (cmd->flags & JIM_CMD_ISPROC) != 0;
+                break;
+
+            case OPT_CHANNEL:
+                result = (cmd->flags & JIM_CMD_ISCHANNEL) != 0;
                 break;
             }
         }
@@ -16164,11 +16077,6 @@ static int Jim_SplitCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
     Jim_Obj *resObjPtr;
     int c;
     int len;
-
-    if (argc != 2 && argc != 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "string ?splitChars?");
-        return JIM_ERR;
-    }
 
     str = Jim_GetString(argv[1], &len);
     if (len == 0) {
@@ -16251,10 +16159,6 @@ static int Jim_JoinCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     const char *joinStr;
     int joinStrLen;
 
-    if (argc != 2 && argc != 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "list ?joinString?");
-        return JIM_ERR;
-    }
     /* Init */
     if (argc == 2) {
         joinStr = " ";
@@ -16272,10 +16176,6 @@ static int Jim_FormatCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
 {
     Jim_Obj *objPtr;
 
-    if (argc < 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "formatString ?arg arg ...?");
-        return JIM_ERR;
-    }
     objPtr = Jim_FormatString(interp, argv[1], argc - 2, argv + 2);
     if (objPtr == NULL)
         return JIM_ERR;
@@ -16289,10 +16189,6 @@ static int Jim_ScanCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     Jim_Obj *listPtr, **outVec;
     int outc, i;
 
-    if (argc < 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "string format ?varName varName ...?");
-        return JIM_ERR;
-    }
     if (argv[2]->typePtr != &scanFmtStringObjType)
         SetScanFmtFromAny(interp, argv[2]);
     if (FormatGetError(argv[2]) != 0) {
@@ -16362,10 +16258,6 @@ static int Jim_ScanCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
 /* [error] */
 static int Jim_ErrorCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    if (argc != 2 && argc != 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "message ?stacktrace?");
-        return JIM_ERR;
-    }
     Jim_SetResult(interp, argv[1]);
     if (argc == 3) {
         JimSetStackTrace(interp, argv[2]);
@@ -16379,10 +16271,6 @@ static int Jim_LrangeCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *a
 {
     Jim_Obj *objPtr;
 
-    if (argc != 4) {
-        Jim_WrongNumArgs(interp, 1, argv, "list first last");
-        return JIM_ERR;
-    }
     if ((objPtr = Jim_ListRange(interp, argv[1], argv[2], argv[3])) == NULL)
         return JIM_ERR;
     Jim_SetResult(interp, objPtr);
@@ -16396,8 +16284,7 @@ static int Jim_LrepeatCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *
     jim_wide count;
 
     if (argc < 2 || Jim_GetWideExpr(interp, argv[1], &count) != JIM_OK || count < 0) {
-        Jim_WrongNumArgs(interp, 1, argv, "count ?value ...?");
-        return JIM_ERR;
+        return JIM_USAGE;
     }
     if (count == 0 || argc == 2) {
         Jim_SetEmptyResult(interp);
@@ -16472,10 +16359,6 @@ static int Jim_EnvCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv
         return JIM_OK;
     }
 
-    if (argc > 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "varName ?default?");
-        return JIM_ERR;
-    }
     key = Jim_String(argv[1]);
     val = getenv(key);
     if (val == NULL) {
@@ -16492,18 +16375,7 @@ static int Jim_EnvCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv
 /* [source] */
 static int Jim_SourceCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
-    int retval;
-
-    if (Jim_CheckTaint(interp, JIM_TAINT_ANY)) {
-        Jim_SetTaintError(interp, 1, argv);
-        return JIM_ERR;
-    }
-
-    if (argc != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "fileName");
-        return JIM_ERR;
-    }
-    retval = Jim_EvalFile(interp, Jim_String(argv[1]));
+    int retval = Jim_EvalFile(interp, Jim_String(argv[1]));
 
     return retval == JIM_RETURN ? JIM_OK : retval;
 }
@@ -16514,10 +16386,6 @@ static int Jim_LreverseCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const 
     Jim_Obj *revObjPtr, **ele;
     int len;
 
-    if (argc != 2) {
-        Jim_WrongNumArgs(interp, 1, argv, "list");
-        return JIM_ERR;
-    }
     JimListGetElements(interp, argv[1], &len, &ele);
     revObjPtr = Jim_NewListObj(interp, NULL, 0);
     ListEnsureLength(revObjPtr, len);
@@ -16561,10 +16429,6 @@ static int Jim_RangeCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
     int len, i;
     Jim_Obj *objPtr;
 
-    if (argc < 2 || argc > 4) {
-        Jim_WrongNumArgs(interp, 1, argv, "?start? end ?step?");
-        return JIM_ERR;
-    }
     if (argc == 2) {
         if (Jim_GetWideExpr(interp, argv[1], &end) != JIM_OK)
             return JIM_ERR;
@@ -16593,10 +16457,6 @@ static int Jim_RandCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
 {
     jim_wide min = 0, max = 0, len, maxMul;
 
-    if (argc < 1 || argc > 3) {
-        Jim_WrongNumArgs(interp, 1, argv, "?min? max");
-        return JIM_ERR;
-    }
     if (argc == 1) {
         max = JIM_WIDE_MAX;
     } else if (argc == 2) {
@@ -16624,101 +16484,109 @@ static int Jim_RandCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     }
 }
 
-static const struct {
+static const struct jim_core_cmd_def_t {
     const char *name;
     Jim_CmdProc *cmdProc;
+    short minargs;
+    short maxargs;
+    const char *usage;
+    int flags;
 } Jim_CoreCommandsTable[] = {
-    {"alias", Jim_AliasCoreCommand},
-    {"set", Jim_SetCoreCommand},
-    {"unset", Jim_UnsetCoreCommand},
-    {"puts", Jim_PutsCoreCommand},
-    {"+", Jim_AddCoreCommand},
-    {"*", Jim_MulCoreCommand},
-    {"-", Jim_SubCoreCommand},
-    {"/", Jim_DivCoreCommand},
-    {"incr", Jim_IncrCoreCommand},
-    {"while", Jim_WhileCoreCommand},
-    {"loop", Jim_LoopCoreCommand},
-    {"for", Jim_ForCoreCommand},
-    {"foreach", Jim_ForeachCoreCommand},
-    {"lmap", Jim_LmapCoreCommand},
-    {"lassign", Jim_LassignCoreCommand},
-    {"if", Jim_IfCoreCommand},
-    {"switch", Jim_SwitchCoreCommand},
-    {"list", Jim_ListCoreCommand},
-    {"lindex", Jim_LindexCoreCommand},
-    {"lset", Jim_LsetCoreCommand},
-    {"lsearch", Jim_LsearchCoreCommand},
-    {"llength", Jim_LlengthCoreCommand},
-    {"lappend", Jim_LappendCoreCommand},
-    {"linsert", Jim_LinsertCoreCommand},
-    {"lreplace", Jim_LreplaceCoreCommand},
-    {"lsort", Jim_LsortCoreCommand},
-    {"append", Jim_AppendCoreCommand},
+    {"*", Jim_MulCoreCommand, 0, -1, "?number ...?"  },
+    {"+", Jim_AddCoreCommand, 0, -1, "?number ...?"  },
+    {"-", Jim_SubCoreCommand, 1, -1, "number ?number ...?" },
+    {"/", Jim_DivCoreCommand, 1, -1, "number ?number ...?" },
+    {"alias", Jim_AliasCoreCommand, 2, -1, "newname command ?args ...?" },
+    {"append", Jim_AppendCoreCommand, 1, -1, "varName ?value ...?" },
+    {"apply", Jim_ApplyCoreCommand, 1, -1, "lambdaExpr ?arg ...?" },
+    {"break", Jim_BreakCoreCommand, 0, 1, "?level?" },
+    {"catch", Jim_CatchCoreCommand, 1, -1, "?-?no?code ... --? script ?resultVarName? ?optionVarName?" },
+    {"concat", Jim_ConcatCoreCommand, 0, -1, "?arg ...?" },
+    {"continue", Jim_ContinueCoreCommand, 0, 1, "?level?" },
 #if defined(JIM_DEBUG_COMMAND) && !defined(JIM_BOOTSTRAP)
-    {"debug", Jim_DebugCoreCommand},
+    {"debug", Jim_DebugCoreCommand, 1, -1, "subcommand ?arg ...?" },
 #endif /* JIM_DEBUG_COMMAND && !JIM_BOOTSTRAP */
-    {"eval", Jim_EvalCoreCommand},
-    {"uplevel", Jim_UplevelCoreCommand},
-    {"expr", Jim_ExprCoreCommand},
-    {"break", Jim_BreakCoreCommand},
-    {"continue", Jim_ContinueCoreCommand},
-    {"proc", Jim_ProcCoreCommand},
-    {"xtrace", Jim_XtraceCoreCommand},
-    {"concat", Jim_ConcatCoreCommand},
-    {"return", Jim_ReturnCoreCommand},
-    {"upvar", Jim_UpvarCoreCommand},
-    {"global", Jim_GlobalCoreCommand},
-    {"string", Jim_StringCoreCommand},
-    {"time", Jim_TimeCoreCommand},
-    {"timerate", Jim_TimeRateCoreCommand},
-    {"exit", Jim_ExitCoreCommand},
-    {"catch", Jim_CatchCoreCommand},
-    {"try", Jim_TryCoreCommand},
-#ifdef JIM_REFERENCES
-    {"ref", Jim_RefCoreCommand},
-    {"getref", Jim_GetrefCoreCommand},
-    {"setref", Jim_SetrefCoreCommand},
-    {"finalize", Jim_FinalizeCoreCommand},
-    {"collect", Jim_CollectCoreCommand},
+    {"dict", Jim_DictCoreCommand, 1, -1, "subcommand ?arg ...?"},
+    {"env", Jim_EnvCoreCommand, 0, 2, "?varName? ?default?" },
+    {"error", Jim_ErrorCoreCommand, 1, 2, "message ?stacktrace?" },
+    {"eval", Jim_EvalCoreCommand, 1, -1, "arg ?arg ...?" },
+    {"exists", Jim_ExistsCoreCommand, 1, 2, "?-command|-proc|-alias|-channel|-var? name" },
+    {"exit", Jim_ExitCoreCommand, 0, 1, "?exitCode?" },
+#ifndef JIM_COMPAT
+    {"expr", Jim_ExprCoreCommand, 1, -1, "expression ?...?" },
+#else
+    {"expr", Jim_ExprCoreCommand, 1, 1, "expression" },
 #endif
-    {"rename", Jim_RenameCoreCommand},
-    {"dict", Jim_DictCoreCommand},
-    {"subst", Jim_SubstCoreCommand},
-    {"info", Jim_InfoCoreCommand},
-    {"exists", Jim_ExistsCoreCommand},
-    {"split", Jim_SplitCoreCommand},
-    {"join", Jim_JoinCoreCommand},
-    {"format", Jim_FormatCoreCommand},
-    {"scan", Jim_ScanCoreCommand},
-    {"error", Jim_ErrorCoreCommand},
-    {"lrange", Jim_LrangeCoreCommand},
-    {"lrepeat", Jim_LrepeatCoreCommand},
-    {"env", Jim_EnvCoreCommand},
-    {"source", Jim_SourceCoreCommand},
-    {"lreverse", Jim_LreverseCoreCommand},
-    {"range", Jim_RangeCoreCommand},
-    {"rand", Jim_RandCoreCommand},
-    {"tailcall", Jim_TailcallCoreCommand},
-    {"local", Jim_LocalCoreCommand},
-    {"upcall", Jim_UpcallCoreCommand},
-    {"apply", Jim_ApplyCoreCommand},
-    {"stacktrace", Jim_StacktraceCoreCommand},
+    {"for", Jim_ForCoreCommand, 4, 4, "start test next body" },
+    {"foreach", Jim_ForeachCoreCommand, 3, -1, "varList list ?varList list ...? script" },
+    {"format", Jim_FormatCoreCommand, 1, -1, "formatString ?arg arg ...?" },
+    {"global", Jim_GlobalCoreCommand, 1, -1, "varName ?varName ...?" },
+    {"if", Jim_IfCoreCommand, 2, -1, "condition ?then? trueBody ?elseif ...? ?else? ?falseBody?" },
+    {"incr", Jim_IncrCoreCommand, 1, 2, "varName ?increment?" },
+    {"info", Jim_InfoCoreCommand, 1, -1, "subcommand ?arg ...?"},
+    {"join", Jim_JoinCoreCommand, 1, 2, "list ?joinString?" },
+    {"lappend", Jim_LappendCoreCommand, 1, -1, "varName ?value value ...?" },
+    {"lassign", Jim_LassignCoreCommand, 2, -1, "varList list ?varName ...?" },
+    {"lindex", Jim_LindexCoreCommand, 1, -1, "list ?index ...?" },
+    {"linsert", Jim_LinsertCoreCommand, 2, -1, "list index ?element ...?" },
+    {"list", Jim_ListCoreCommand, 0, -1, "?arg ...?" },
+    {"llength", Jim_LlengthCoreCommand, 1, 1, "list" },
+    {"lmap", Jim_LmapCoreCommand, 3, -1, "varList list ?varList list ...? script" },
+    {"local", Jim_LocalCoreCommand, 1, -1, "cmd ?args ...?" },
+    {"loop", Jim_LoopCoreCommand, 3, 5, "var ?first? limit ?incr? body" },
+    {"lrange", Jim_LrangeCoreCommand, 3, 3, "list first last" },
+    {"lrepeat", Jim_LrepeatCoreCommand, 1, -1, "count ?value ...?" },
+    {"lreplace", Jim_LreplaceCoreCommand, 3, -1, "list first last ?element ...?" },
+    {"lreverse", Jim_LreverseCoreCommand, 1, 1, "list" },
+    {"lsearch", Jim_LsearchCoreCommand, 2, -1, "?-exact|-glob|-regexp|-command 'command'? ?-bool|-inline? ?-not? ?-nocase? ?-all? ?-stride len? ?-index val? list value" },
+    {"lset", Jim_LsetCoreCommand, 2, -1, "listVar ?index ...? value" },
+    {"lsort", Jim_LsortCoreCommand, 1, -1, "?options? list" },
+    {"proc", Jim_ProcCoreCommand, 3, 4, "name arglist ?statics? body" },
+    {"puts", Jim_PutsCoreCommand, 1, 2, "?-nonewline? string" },
+    {"rand", Jim_RandCoreCommand, 0, 2, "?min? ?max?" },
+    {"range", Jim_RangeCoreCommand, 1, 3, "?start? end ?step?" },
+    {"rename", Jim_RenameCoreCommand, 2, 2, "oldName newName" },
+    {"return", Jim_ReturnCoreCommand, 0, -1, "?-code code? ?-errorinfo stacktrace? ?-level level? ?result?" },
+    {"scan", Jim_ScanCoreCommand, 2, -1, "string format ?varName varName ...?" },
+    {"set", Jim_SetCoreCommand, 1, 2, "varName ?newValue?" },
+    {"source", Jim_SourceCoreCommand, 1, 1, "fileName", JIM_CMD_NOTAINT },
+    {"split", Jim_SplitCoreCommand, 1, 2, "string ?splitChars?" },
+    {"stacktrace", Jim_StacktraceCoreCommand, 0, 2, "?firstlevel? ?lastlevel?" },
+    {"string", Jim_StringCoreCommand, 1, -1, "subcommand ?arg ...?" },
+    {"subst", Jim_SubstCoreCommand, 1, 4, "?options? string" },
+    {"switch", Jim_SwitchCoreCommand, 2, -1, "?options? string pattern body ... ?default body? or pattern body ?pattern body ...?" },
+    {"tailcall", Jim_TailcallCoreCommand, 0, -1, "?cmd arg ...?" },
+    {"time", Jim_TimeCoreCommand, 1, 2, "script ?count?" },
+    {"timerate", Jim_TimerateCoreCommand, 1, 2, "script ?milliseconds?" },
+    {"try", Jim_TryCoreCommand, 1, -1, "?-?no?code ... --? script ?on|trap codes vars script? ... ?finally script?" },
+    {"unset", Jim_UnsetCoreCommand, 0, -1, "?-nocomplain? ?--? ?varName ...?"},
+    {"upcall", Jim_UpcallCoreCommand, 1, -1, "cmd ?args ...?" },
+    {"uplevel", Jim_UplevelCoreCommand, 1, -1, "?level? command ?arg ...?" },
+    {"upvar", Jim_UpvarCoreCommand, 2, -1, "?level? otherVar myVar ?otherVar myVar ...?"},
+    {"while", Jim_WhileCoreCommand, 2, 2, "condition body" },
+    {"xtrace", Jim_XtraceCoreCommand, 1, 1, "callback" },
+#ifdef JIM_REFERENCES
+    {"collect", Jim_CollectCoreCommand, 0, 0, "" },
+    {"finalize", Jim_FinalizeCoreCommand, 1, 2, "reference ?finalizerProc?" },
+    {"getref", Jim_GetrefCoreCommand, 1, 1, "reference" },
+    {"ref", Jim_RefCoreCommand, 2, 3, "string tag ?finalizer?" },
+    {"setref", Jim_SetrefCoreCommand, 2, 2, "reference newValue" },
+#endif
 #ifdef JIM_TAINT
-    {"taint", Jim_TaintCoreCommand},
-    {"untaint", Jim_UntaintCoreCommand},
+    {"taint", Jim_TaintCoreCommand, 1, 1, "varname"},
+    {"untaint", Jim_UntaintCoreCommand, 1, 1, "varname"},
 #endif
     {NULL, NULL},
 };
 
 void Jim_RegisterCoreCommands(Jim_Interp *interp)
 {
-    int i = 0;
+    const struct jim_core_cmd_def_t *c;
 
-    while (Jim_CoreCommandsTable[i].name != NULL) {
-        Jim_CreateCommand(interp,
-            Jim_CoreCommandsTable[i].name, Jim_CoreCommandsTable[i].cmdProc, NULL, NULL);
-        i++;
+    for (c = Jim_CoreCommandsTable; c->name; c++) {
+        /* All core commands must have usage */
+        assert(c->usage);
+        Jim_RegisterCmd(interp, c->name, c->usage, c->minargs, c->maxargs, c->cmdProc, NULL, NULL, c->flags);
     }
 }
 

--- a/jim.h
+++ b/jim.h
@@ -838,6 +838,7 @@ JIM_EXPORT int Jim_RenameCommand (Jim_Interp *interp,
         Jim_Obj *oldNameObj, Jim_Obj *newNameObj);
 JIM_EXPORT Jim_Cmd * Jim_GetCommand (Jim_Interp *interp,
         Jim_Obj *objPtr, int flags);
+/* Note that if Jim_SetVariable() fails, and valObjPtr has a zero reference count, it will be freed */
 JIM_EXPORT int Jim_SetVariable (Jim_Interp *interp,
         Jim_Obj *nameObjPtr, Jim_Obj *valObjPtr);
 JIM_EXPORT int Jim_SetVariableStr (Jim_Interp *interp,

--- a/jim.h
+++ b/jim.h
@@ -125,7 +125,7 @@ extern "C" {
  * ---------------------------------------------------------------------------*/
 
 /* Increment this every time the public ABI changes */
-#define JIM_ABI_VERSION 101
+#define JIM_ABI_VERSION 102
 
 #define JIM_OK 0
 #define JIM_ERR 1
@@ -439,8 +439,6 @@ typedef struct Jim_CallFrame {
     Jim_Obj *procBodyObjPtr; /* body object of the running procedure */
     struct Jim_CallFrame *next; /* Callframes are in a linked list */
     Jim_Obj *nsObj;             /* Namespace for this proc call frame */
-    Jim_Obj *unused_fileNameObj;
-    int unused_line;
     Jim_Stack *localCommands; /* commands to be destroyed when the call frame is destroyed */
     struct Jim_Obj *tailcallObj;  /* Pending tailcall invocation */
     struct Jim_Cmd *tailcallCmd;  /* Resolved command for pending tailcall invocation */
@@ -540,7 +538,6 @@ typedef struct Jim_PrngState {
  * ---------------------------------------------------------------------------*/
 typedef struct Jim_Interp {
     Jim_Obj *result; /* object returned by the last command called. */
-    int unused_errorLine; /* Error line where an error occurred. */
     Jim_Obj *currentFilenameObj; /* filename of current Jim_EvalFile() */
     int break_level;       /* break/continue level */
     int maxCallFrameDepth; /* Used for infinite loop detection. */
@@ -568,11 +565,9 @@ typedef struct Jim_Interp {
     int safeexpr; /* Set when evaluating a "safe" expression, no var subst or command eval */
     Jim_Obj *liveList; /* Linked list of all the live objects. */
     Jim_Obj *freeList; /* Linked list of all the unused objects. */
-    Jim_Obj *unused_currentScriptObj; /* Script currently in execution. */
     Jim_EvalFrame topEvalFrame;  /* dummy top evaluation frame */
     Jim_EvalFrame *evalFrame;  /* evaluation stack */
     int procLevel;
-    Jim_Obj * const *unused_argv;
     Jim_Obj *nullScriptObj; /* script representation of an empty string */
     Jim_Obj *emptyObj; /* Shared empty string object. */
     Jim_Obj *trueObj; /* Shared true int object. */
@@ -591,7 +586,7 @@ typedef struct Jim_Interp {
     Jim_Obj *defer; /* "jim::defer" */
     Jim_Obj *traceCmdObj; /* If non-null, execution trace command to invoke */
     int unknown_called; /* The unknown command has been invoked */
-    int errorFlag; /* Set if an error occurred during execution. */
+    int hasErrorStackTrace; /* If a stack trace has been set due to an error during execution. */
     void *cmdPrivData; /* Used to pass the private data pointer to
                   a command. It is set to what the user specified
                   via Jim_CreateCommand(). */

--- a/jim.h
+++ b/jim.h
@@ -183,6 +183,7 @@ typedef struct Jim_Stack {
     int len;
     int maxlen;
     void **vector;
+    void (*freefunc) (void *ptr);
 } Jim_Stack;
 
 /* -----------------------------------------------------------------------------
@@ -703,13 +704,10 @@ JIM_EXPORT void Jim_SetSourceInfo(Jim_Interp *interp, Jim_Obj *objPtr,
 
 
 /* stack */
-JIM_EXPORT void Jim_InitStack(Jim_Stack *stack);
-JIM_EXPORT void Jim_FreeStack(Jim_Stack *stack);
-JIM_EXPORT int Jim_StackLen(Jim_Stack *stack);
+JIM_EXPORT void Jim_StackInit(Jim_Stack *stack, void (*freefunc) (void *ptr));
+JIM_EXPORT void Jim_StackFree(Jim_Stack *stack);
 JIM_EXPORT void Jim_StackPush(Jim_Stack *stack, void *element);
-JIM_EXPORT void * Jim_StackPop(Jim_Stack *stack);
-JIM_EXPORT void * Jim_StackPeek(Jim_Stack *stack);
-JIM_EXPORT void Jim_FreeStackElements(Jim_Stack *stack, void (*freeFunc)(void *ptr));
+JIM_EXPORT void *Jim_StackPop(Jim_Stack *stack);
 
 /* hash table */
 JIM_EXPORT int Jim_InitHashTable (Jim_HashTable *ht,

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -57,6 +57,11 @@ Changes since 0.83
 #. `aio` - support for configurable read and write buffering
 #. Add support for `package forget`
 #. Add `aio translation` support (and fconfigure -translation)
+#. `exec` TIP 424 - support safer +'exec |'+ syntax (also +'open "|| pipeline..."'+)
+#. New `lsubst` command to create lists using subst-style substitution
+#. Add support for `regexp -expanded` and `regsub -expanded`
+#. `vwait` now accepts a script argument
+#. Add support for `os.umask`
 
 Changes between 0.82 and 0.83
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2320,6 +2325,8 @@ exec
 ~~~~
 +*exec* 'arg ?arg\...?'+
 
++*exec* | '{cmdlist \...} ?redirection \...?'+
+
 This command treats its arguments as the specification
 of one or more UNIX commands to execute as subprocesses.
 The commands take the form of a standard shell pipeline;
@@ -2353,7 +2360,8 @@ is a newline then that character is deleted from the result
 or error message for consistency with normal
 Tcl return values.
 
-An +'arg'+ may have one of the following special forms:
+An +'arg'+ (or +'redirection'+ in the second form) may have one of the
+following special forms:
 
 +>filename+::
     The standard output of the last command in the pipeline
@@ -2370,23 +2378,23 @@ An +'arg'+ may have one of the following special forms:
     will normally return an empty string.
 
 +2>filename+::
-    The standard error of the last command in the pipeline
+    The standard error of all commands in the pipeline
     is redirected to the file.
 
 +2>>filename+::
     As above, but append to the file.
 
 +2>@fileId+::
-    The standard error of the last command in the pipeline is
+    The standard error of all commands in the pipeline is
     redirected to the given (writable) file descriptor.
 
 +2>@1+::
-    The standard error of the last command in the pipeline is
-    redirected to the same file descriptor as the standard output.
+    The standard error of all commands in the pipeline is
+    redirected command output.
 
 +>&filename+::
-    Both the standard output and standard error of the last command
-    in the pipeline is redirected to the file.
+    Both standard output from the last command and standard error from all commands
+    in the pipeline are redirected to the file.
 
 +>>&filename+::
     As above, but append to the file.
@@ -2403,23 +2411,28 @@ An +'arg'+ may have one of the following special forms:
     The standard input of the first command in the pipeline
     is taken from the given (readable) file descriptor.
 
+Note that any of the forms that take an argument (filename, fileId or string)
+their argument may be a separate word. e.g. +'<< $str'+.
+
 If there is no redirection of standard input, standard error
 or standard output, these are connected to the corresponding
 input or output of the application.
 
-If the last +'arg'+ is +&+ then the command will be
-executed in background.
-In this case the standard output from the last command
-in the pipeline will
-go to the application's standard output unless
-redirected in the command, and error output from all
-the commands in the pipeline will go to the application's
-standard error file. The return value of exec in this case
-is a list of process ids (pids) in the pipeline.
+If the last +'arg'+ or +'redirection'+ is +&+ then the command will be
+executed in background.  In this case the standard output from the last
+command in the pipeline will go to the application's standard output
+unless redirected in the command, and error output from all the commands
+in the pipeline will go to the application's standard error file. The
+return value of exec in this case is a list of process ids (pids) in
+the pipeline.
 
 Each +'arg'+ becomes one word for a command, except for
 +|+, +<+, +<<+, +>+, and +&+ arguments, and the
 arguments that follow +<+, +<<+, and +>+.
+
+In the second form, +'cmdlist'+ is the command list, so there
+is no ambiguity about whether an argument or a redirection.
+Note that this second form is not currently supported by Tcl.
 
 The first word in each command is taken as the command name;
 the directories in the PATH environment variable are searched for
@@ -3654,6 +3667,8 @@ pipeline is directed to the current standard output unless overridden
 by the command. If read-only access is used (e.g. +'access'+ is r),
 standard input for the pipeline is taken from the current standard
 input unless overridden by the command.
+
+Note that this incudes new style exec syntax, e.g. +'open |[list | ls -l] r'+.
 
 The `pid` command may be used to return the process ids of the commands
 forming the command pipeline.

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -5465,14 +5465,16 @@ Time-based execution is also available via the eventloop API.
     the type of the event. An error occurs if +'id'+ does not
     match an event.
 
-+*vwait ?-signal?* 'variable'+::
++*vwait ?-signal?* 'variable' ?script?+::
     A call to `vwait` enters the eventloop. `vwait` processes
     events until the named (global) variable changes or all
     event handlers are removed. The variable need not exist
     beforehand.  If there are no event handlers defined, `vwait`
-    returns immediately. If +'-signal'+ is specified, `vwait` will
+    returns immediately. If +*-signal*+ is specified, `vwait` will
     also quit if a handled signal occurs. In this case, `signal check -clear`
-    can be used to check for the signal that occurred.
+    can be used to check for the signal that occurred. If +'script'+ is given
+    it is evaluated after each event. If it returns break, `vwait` returns.
+    `vwait` also returns with an error if the script returns an error.
 
 +*update ?idletasks?*+::
     A call to `update` enters the eventloop to process expired events, but

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -5047,8 +5047,8 @@ what options were selected when Jim Tcl was built.
 
 
 [[cmd_1]]
-posix: os.fork, os.gethostname, os.getids, os.uptime
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+posix: os.fork, os.gethostname, os.getids, os.uptime, os.umask
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +*os.fork*+::
     Invokes 'fork(2)' and returns the result.
 
@@ -5062,6 +5062,9 @@ posix: os.fork, os.gethostname, os.getids, os.uptime
     . os.getids
     uid 1000 euid 1000 gid 100 egid 100
 ----
+
++*os.umask* ?newmask?+::
+    Set or return the current process 'umask(2)'. Returns the previous umask.
 
 +*os.uptime*+::
     Returns the number of seconds since system boot. See description of 'uptime' in 'sysinfo(2)'.

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -3901,7 +3901,7 @@ See `aio read`
 
 regexp
 ~~~~~~
-+*regexp ?-nocase? ?-line? ?-indices? ?-start* 'offset'? *?-all? ?-inline? ?--?* 'exp string ?matchVar? ?subMatchVar subMatchVar \...?'+
++*regexp ?-nocase? ?-line? ?-indices? ?-start* 'offset'? *?-all? ?-inline? ?-expanded? ?--?* 'exp string ?matchVar? ?subMatchVar subMatchVar \...?'+
 
 Determines whether the regular expression +'exp'+ matches part or
 all of +'string'+ and returns 1 if it does, 0 if it doesn't.
@@ -3974,13 +3974,17 @@ The following switches modify the behaviour of +'regexp'+
     data, plus one element for each subexpression in the regular
     expression.
 
++*-expanded*+::
+    Enables use of the expanded regular expression syntax where whitespace
+    and comments are ignored.
+
 +*--*+::
     Marks the end of switches. The argument following this one will be
     treated as +'exp'+ even if it starts with a +-+.
 
 regsub
 ~~~~~~
-+*regsub ?-nocase? ?-all? ?-line? ?-command? ?-start* 'offset'? ?*--*? 'exp string subSpec ?varName?'+
++*regsub ?-nocase? ?-all? ?-line? ?-command? ?-expanded? ?-start* 'offset'? ?*--*? 'exp string subSpec ?varName?'+
 
 This command matches the regular expression +'exp'+ against
 +'string'+ using the rules described in REGULAR EXPRESSIONS
@@ -4061,6 +4065,10 @@ The following switches modify the behaviour of +'regsub'+
     Specifies a character index offset into the string at which to
     start matching the regular expression. +'offset'+ will be
     constrained to the bounds of the input string.
+
++*-expanded*+::
+    Enables use of the expanded regular expression syntax where whitespace
+    and comments are ignored.
 
 +*--*+::
     Marks the end of switches. The argument following this one will be

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -62,6 +62,7 @@ Changes since 0.83
 #. Add support for `regexp -expanded` and `regsub -expanded`
 #. `vwait` now accepts a script argument
 #. Add support for `os.umask`
+#. Add `taint` support for improved data security
 
 Changes between 0.82 and 0.83
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3048,6 +3049,9 @@ The legal +'option'+'s (which may be abbreviated) are:
     procedure. An empty dictionary is returned if the procedure has
     no static variables.
 
++*info tainted* 'str'+::
+    Returns 1 if the value is tainted, or 0 if not.
+
 +*info version*+::
     Returns the version number for this version of Jim in the form +*x.yy*+.
 
@@ -4589,6 +4593,12 @@ The following are identical except the first immediately replaces the current ca
   proc sub_cmd2 ...
 ----
 
+taint
+~~~~~
++*taint* 'varname'+
+
+Set "taint" on the value contained in the given variable.
+
 tell
 ~~~~
 +*tell* 'fileId'+
@@ -4754,6 +4764,12 @@ The `unset` command returns an empty string as result.
 An error occurs if any of the variables doesn't exist, unless '-nocomplain'
 is specified. The '--' argument may be specified to stop option processing
 in case the variable name may be '-nocomplain'.
+
+untaint
+~~~~~~~
++*untaint* 'varname'+
+
+Remove "taint" from the value contained in the given variable.
 
 upcall
 ~~~~~~~
@@ -5167,6 +5183,15 @@ This command returns an empty string.
     If the flush fails (perhaps because the channel is non-blocking), an error
     will be returned instead. Although this is designed for normal files and
     those should be used in blocking mode.
+
++$handle *taint source|sink ?0:n?*+::
+    Sets the taint characteristics of the channel. Data read from
+    the channel will have a taint value as set by +'source'+, while
+    a check will be made against data written to the channel against
+    the +'sink'+ value. If the taint of the data and the channel
+    match, the operation will fail. By default, channels created
+    by `open` are not tainted while channels created by `socket`
+    have both set to 1.
 
 +$handle *tell*+::
     Returns the current seek position or -1 if the channel is not seekable.

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -329,7 +329,7 @@ has three fields:  the first, `set`, is the name of a Tcl command, and
 the last two, 'a' and '22', will be passed as arguments to
 the `set` command.  The command name may refer either to a built-in
 Tcl command, an application-specific command bound in with the library
-procedure 'Jim_CreateCommand', or a command procedure defined with the
+procedure 'Jim_RegisterCommand', or a command procedure defined with the
 `proc` built-in command.
 
 Arguments are passed literally as text strings.  Individual commands may
@@ -1208,6 +1208,10 @@ defined in jim.h, and are:
 +JIM_EXIT(6)+::
     Indicates that the command called the `exit` command.
     The string contains the exit code.
+
++JIM_USAGE(-1)+::
+    This is a special return code that is automatically translated into JIM_ERR with the command usage
+    (from Jim_RegisterCommand()) as the message.
 
 Tcl programmers do not normally need to think about return codes,
 since +JIM_OK+ is almost always returned.  If anything else is returned
@@ -2476,12 +2480,12 @@ this variable is unset, in which case the original environment is used).
 
 exists
 ~~~~~~
-+*exists ?-var|-proc|-command|-alias?* 'name'+
++*exists ?-var|-proc|-command|-alias|-channel?* 'name'+
 
-Checks the existence of the given variable, procedure, command
-or alias respectively and returns 1 if it exists or 0 if not.  This command
+Checks the existence of the given variable, procedure, command,
+alias or channel respectively and returns 1 if it exists or 0 if not.  This command
 provides a more simplified/convenient version of `info exists`,
-`info procs` and `info commands`.
+`info procs`, `info commands`, `info aliases` and `info channels`.
 
 If the type is omitted, a type of '-var' is used. The type may be abbreviated.
 
@@ -2929,12 +2933,14 @@ The legal +'option'+'s (which may be abbreviated) are:
 +*info channels*+::
     Returns a list of all open file handles from `open` or `socket`
 
-+*info commands* ?'pattern'?+::
++*info commands ?-all?* ?'pattern'?+::
     If +'pattern'+ isn't specified, returns a list of names of all the
     Tcl commands, including both the built-in commands written in C and
     the command procedures defined using the `proc` command.
     If +'pattern'+ is specified, only those names matching +'pattern'+
     (using <<_string_matching,STRING MATCHING>> rules) are returned.
+    Normally commands containing a space character are not returned.
+    If +*-all*+ is given, the result does include these commands.
 
 +*info complete* 'command' ?'missing'?+::
     Returns 1 if +'command'+ is a complete Tcl command in the sense of
@@ -3010,11 +3016,13 @@ The legal +'option'+'s (which may be abbreviated) are:
     was invoked. A full path will be returned, unless the path
     can't be determined, in which case the empty string will be returned.
 
-+*info procs* ?'pattern'?+::
++*info procs ?-all?* ?'pattern'?+::
     If +'pattern'+ isn't specified, returns a list of all the
     names of Tcl command procedures.
     If +'pattern'+ is specified, only those names matching +'pattern'+
     (using <<_string_matching,STRING MATCHING>> rules) are returned.
+    Normally commands containing a space character are not returned.
+    If +*-all*+ is given, the result does include these commands.
 
 +*info references*+::
     Returns a list of all references which have not yet been garbage

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -63,6 +63,9 @@ Changes since 0.83
 #. `vwait` now accepts a script argument
 #. Add support for `os.umask`
 #. Add `taint` support for improved data security
+#. Improved API for creating C commands with +'Jim_RegisterCommand'+ for arg checking and usage
+#. New `info usage` to return the usage for a proc or native command
+#. New `info aliases` to list all aliases
 
 Changes between 0.82 and 0.83
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2926,17 +2929,23 @@ The legal +'option'+'s (which may be abbreviated) are:
     +'command'+ must be an alias created with `alias`. In which case the target
     command and arguments, as passed to `alias` are returned. See `exists -alias`
 
++*info aliases ?-all?* ?'pattern'?+::
+    Returns a list of alias commands.
+    See `info commands` for the meaning of +*-all*+ and +'pattern'+.
+
 +*info body* 'procname'+::
     Returns the body of procedure +'procname'+.  +'procname'+ must be
     the name of a Tcl command procedure.
 
-+*info channels*+::
-    Returns a list of all open file handles from `open` or `socket`
++*info channels ?-all?* ?'pattern'?+::
+    Returns a list of open file handles from `open` or `socket`.
+    See `info commands` for the meaning of +*-all*+ and +'pattern'+.
 
 +*info commands ?-all?* ?'pattern'?+::
     If +'pattern'+ isn't specified, returns a list of names of all the
     Tcl commands, including both the built-in commands written in C and
-    the command procedures defined using the `proc` command.
+    the command procedures defined using the `proc` command (including aliases
+    and channels).
     If +'pattern'+ is specified, only those names matching +'pattern'+
     (using <<_string_matching,STRING MATCHING>> rules) are returned.
     Normally commands containing a space character are not returned.
@@ -3017,12 +3026,8 @@ The legal +'option'+'s (which may be abbreviated) are:
     can't be determined, in which case the empty string will be returned.
 
 +*info procs ?-all?* ?'pattern'?+::
-    If +'pattern'+ isn't specified, returns a list of all the
-    names of Tcl command procedures.
-    If +'pattern'+ is specified, only those names matching +'pattern'+
-    (using <<_string_matching,STRING MATCHING>> rules) are returned.
-    Normally commands containing a space character are not returned.
-    If +*-all*+ is given, the result does include these commands.
+    Returns a list containing the names of Tcl command procedures.
+    See `info commands` for the meaning of +*-all*+ and +'pattern'+.
 
 +*info references*+::
     Returns a list of all references which have not yet been garbage
@@ -3059,6 +3064,11 @@ The legal +'option'+'s (which may be abbreviated) are:
 
 +*info tainted* 'str'+::
     Returns 1 if the value is tainted, or 0 if not.
+
++*info usage* 'command'+::
+    Returns the usage for the given command. For Tcl command procedures, this is based
+    on the arguments defined for the procedure. For a C command, this is the command usage
+    that was specificied when the command was registered.
 
 +*info version*+::
     Returns the version number for this version of Jim in the form +*x.yy*+.

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -3164,6 +3164,63 @@ than variables, a list of unassigned elements is returned.
     a=1,b=2
 ----
 
+lsubst
+~~~~
++*lsubst ?-line?* 'string'+
+
+This command is similar to `list` in that it creates a list, but uses
+the same rules as scripts when constructing the elements of the list.
+It is somewhat similar to `subst` except it produces a list instead of a string.
+
+This means that variables are substituted, commands are evaluated, backslashes are
+interpreted, the expansion operator is applied and comments are skipped.
+
+Consider the following example.
+
+---
+    set x 1
+    set y {2 3}
+    set z 3
+    lsubst {
+        # This is a list with interpolation
+        $x; # The x variable
+        {*}$y; # The y variable expanded
+        [string cat a b c]; # A command
+        {*}[list 4 5]; # A list expanded into multiple elements
+        "$z$z"; # A string with interpolation
+    }
+---
+
+The result of `lsubst` is the following list with 7 elements.
+
+---
+    1 2 3 abc 4 5 33
+---
+
+This is particularly useful when constructing a list (or dict)
+as a data structure as it easily allows for comments and variable and command
+substitution.
+
+Sometimes it is useful to return each "command" as a separate list rather than
+simply running all the words together. This can be accomplished with `lsubst -line`.
+
+Consider the following example.
+
+---
+    lsubst -line {
+        # two "lines" because of the semicolon
+        one a; two b
+        # one line with three elements
+        {*}{a b c}
+    }
+---
+
+The result of `lsubst -line` is the following list with 3 elements, one for each "command".
+
+---
+{one a} {two b} {a b c}
+---
+
 local
 ~~~~~
 +*local* 'cmd ?arg\...?'+

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -66,6 +66,7 @@ Changes since 0.83
 #. Improved API for creating C commands with +'Jim_RegisterCommand'+ for arg checking and usage
 #. New `info usage` to return the usage for a proc or native command
 #. New `info aliases` to list all aliases
+#. `expr` supports new +'=*'+ and +'=~'+ matching operators (see <<_expressions,EXPRESSIONS>>)
 
 Changes between 0.82 and 0.83
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -881,6 +882,14 @@ of precedence:
 +eq ne+::
     String equal and not equal.  Uses the string value directly without
     attempting to convert to a number first.
+
++=*+::
+   String glob match. The left and side is the string to match and the right
+   and side is the pattern. See <<_string_matching,STRING MATCHING>>.
+
++=~+::
+   String regexp match. The left and side is the string to match and the right
+   and side is the regular expression. See <<_regular_expressions,REGULAR EXPRESSIONS>>.
 
 +in ni+::
     String in list and not in list. For 'in', result is 1 if the left operand (as a string)

--- a/jim_tcl.txt
+++ b/jim_tcl.txt
@@ -3034,6 +3034,10 @@ The legal +'option'+'s (which may be abbreviated) are:
     was invoked. A full path will be returned, unless the path
     can't be determined, in which case the empty string will be returned.
 
++*info patchlevel*+::
+    Returns the build (git) version if available. Otherwise
+    returns the same as `info version`.
+
 +*info procs ?-all?* ?'pattern'?+::
     Returns a list containing the names of Tcl command procedures.
     See `info commands` for the meaning of +*-all*+ and +'pattern'+.

--- a/jimregexp.c
+++ b/jimregexp.c
@@ -1,5 +1,5 @@
 /*
- * vi:se ts=8:
+ * vi:se ts=8 sw=8:
  *
  * regcomp and regexec -- regsub and regerror are elsewhere
  *
@@ -216,6 +216,41 @@ static int str_int_len(const int *seq)
 	return n;
 }
 
+/* skips preg->regparse past white space and comments to end of line if REG_EXPANDED */
+static char *reg_expanded_new_pattern(const char *exp)
+{
+	/* Make a copy and do removal in place as the final will always be no longer than the original */
+	char *newexp = strdup(exp);
+	char *d = newexp;
+	const char *s = exp;
+	int escape = 0;
+
+	while (*s) {
+		if (escape) {
+			escape = 0;
+			continue;
+		}
+		else if (*s == '\\') {
+			escape = 1;
+		}
+		else if (strchr(" \t\r\n\f\v", *s)) {
+			s++;
+			continue;
+		}
+		else if (*s == '#') {
+			/* skip comments to end of line */
+			s++;
+			while (*s && *s != '\n') {
+				s++;
+			}
+			continue;
+		}
+		*d++ = *s++;
+	}
+	*d++ = '\0';
+	return newexp;
+}
+
 /*
  - regcomp - compile a regular expression into internal code
  *
@@ -245,6 +280,11 @@ int jim_regcomp(regex_t *preg, const char *exp, int cflags)
 
 	if (exp == NULL)
 		FAIL(preg, REG_ERR_NULL_ARGUMENT);
+
+	if (cflags & REG_EXPANDED) {
+		preg->exp = reg_expanded_new_pattern(exp);
+		exp = preg->exp;
+	}
 
 	/* First pass: determine size, legality. */
 	preg->cflags = cflags;
@@ -1911,6 +1951,7 @@ size_t jim_regerror(int errcode, const regex_t *preg, char *errbuf,  size_t errb
 
 void jim_regfree(regex_t *preg)
 {
+	free(preg->exp);
 	free(preg->program);
 }
 

--- a/jimregexp.h
+++ b/jimregexp.h
@@ -49,6 +49,7 @@ typedef struct regexp {
 	int regmust;		/* Internal use only. */
 	int regmlen;		/* Internal use only. */
 	int *program;		/* Allocated */
+	char *exp;			/* NULL or allocated version of regcomp expression (for REG_EXPANDED) */
 
 	/* working state - compile */
 	const char *regparse;		/* Input-scan pointer. */
@@ -73,6 +74,7 @@ typedef regexp regex_t;
 #define REG_ICASE 2
 
 #define REG_NOTBOL 16
+#define REG_EXPANDED 32
 
 enum {
 	REG_NOERROR,      /* Success.  */

--- a/oo.tcl
+++ b/oo.tcl
@@ -73,7 +73,7 @@ proc class {classname {baseclasses {}} classvars} {
 	proc "$classname classvars" {} classvars { return $classvars }
 	proc "$classname classname" {} classname { return $classname }
 	proc "$classname methods" {} classname {
-		lsort [lmap p [info commands "$classname *"] {
+		lsort [lmap p [info commands -all "$classname *"] {
 			lindex [split $p " "] 1
 		}]
 	}

--- a/tests/clock.test
+++ b/tests/clock.test
@@ -5,7 +5,7 @@ constraint cmd {clock scan}
 
 test clock-1.1 {clock usage} -body {
     clock
-} -returnCodes error -match glob -result {wrong # args: should be "clock command ..."*}
+} -returnCodes error -match glob -result {wrong # args: should be "clock subcommand ?arg ...?"}
 
 test clock-1.2 {clock usage} -body {
     clock blah

--- a/tests/coverage.test
+++ b/tests/coverage.test
@@ -175,7 +175,7 @@ test cmd-1 {standard -commands} jim {
 
 test rand-1 {rand} -constraints rand -body {
 	rand 1 2 3
-} -returnCodes error -result {wrong # args: should be "rand ?min? max"}
+} -returnCodes error -result {wrong # args: should be "rand ?min? ?max?"}
 
 test rand-2 {rand} -constraints rand -body {
 	rand foo

--- a/tests/debug.test
+++ b/tests/debug.test
@@ -40,7 +40,7 @@ test debug-3.1 {debug objects} -body {
 # does not currently check for too many args
 test debug-3.2 {debug objects too many args} -body {
     debug objects a b c
-} -returnCodes error -result {wrong # args: should be "debug objects"}
+} -returnCodes error -result {wrong # args: should be "debug objects ?-taint?"}
 
 test debug-4.1 {debug invstr too few args} -body {
     debug invstr
@@ -100,7 +100,7 @@ test debug-8.1 {debug show} -body {
 	set x hello
 	lappend x there
     debug show $x
-} -result {refcount: 2, type: list
+} -result {refcount: 2, taint: 0, type: list
 chars (11): <<hello there>>
 bytes (11): 68 65 6c 6c 6f 20 74 68 65 72 65}
 

--- a/tests/debug.test
+++ b/tests/debug.test
@@ -7,7 +7,7 @@ set x 0
 
 test debug-0.1 {debug too few args} -body {
     debug
-} -returnCodes error -match glob -result {wrong # args: should be "debug command ..."*}
+} -returnCodes error -match glob -result {wrong # args: should be "debug subcommand ?arg ...?"}
 
 test debug-0.2 {debug bad option} -body {
     debug badoption

--- a/tests/dict2.test
+++ b/tests/dict2.test
@@ -22,9 +22,9 @@ proc dict-sort {dict} {
     return $result
 }
 
-test dict-1.1 {dict command basic syntax} -returnCodes error -body {
+test dict-1.1 {dict command basic syntax} -body {
     dict
-}  -match glob -result {wrong # args: should be "dict command ..."*}
+} -returnCodes error -match glob -result {wrong # args: should be "dict subcommand ?arg ...?"}
 test dict-1.2 {dict command basic syntax} -returnCodes error -body {
     dict ?
 } -match glob -result *

--- a/tests/event.test
+++ b/tests/event.test
@@ -104,10 +104,8 @@ test event-10.1 {Tcl_Exit procedure} exec {
 
 test event-11.1 {Tcl_VwaitCmd procedure} -body {
     vwait
-} -returnCodes error -match glob -result {wrong # args: should be "vwait* name"}
-test event-11.2 {Tcl_VwaitCmd procedure} -body {
-    vwait a b
-} -returnCodes error -match glob -result {wrong # args: should be "vwait* name"}
+} -returnCodes error -result {wrong # args: should be "vwait ?-signal? name ?script?"}
+
 test event-11.3 {Tcl_VwaitCmd procedure} jim {
     catch {unset x}
     set x 1
@@ -270,5 +268,26 @@ test event-14.2 {IPv6 socket stream.server client address} {jim socket ipv6} {
     list [join [lrange [split $addr6 :] 0 end-1] :]
 } {{[::1]}}
 
+test event-15.1 {vwait with script} {jim} {
+    set x 0
+    set result {}
+
+    local proc waiter {} {&x &result} {
+        lappend result $x
+        after 10 waiter
+    }
+
+    after 10 waiter
+    vwait done_waiter [lambda {} {&x} {
+        # By using a lambda to capture a reference to x, we can
+        # avoid a global variable. (done_waiter is not used)
+        if {[incr x] >= 5} {
+            break
+        }
+    }]
+    # The vwait script iterates 5 times before break, so it will
+    # cancel the event loop before waiter sets done_waiter
+    list $x $result
+} {5 {0 1 2 3 4}}
 
 testreport

--- a/tests/exec-tip424.test
+++ b/tests/exec-tip424.test
@@ -1,0 +1,424 @@
+# The same tests as exec.test, but changed to TIP424 exec syntax
+
+source [file dirname [info script]]/testing.tcl
+
+needs cmd exec
+needs cmd flush
+# Need [pipe] to implement [open |command]
+constraint cmd pipe
+
+constraint expr unix {$tcl_platform(platform) eq {unix}}
+
+# Sleep which supports fractions of a second
+if {[info commands sleep] eq {}} {
+    proc sleep {n} {
+	exec {*}$::sleepx $n
+    }
+}
+
+set f [open sleepx w]
+puts $f {
+    sleep "$@"
+}
+close $f
+#catch {exec chmod +x sleepx}
+set sleepx [list sh sleepx]
+
+# Basic operations.
+
+test exec-1.1 {basic exec operation} {
+    exec | {echo a b c}
+} "a b c"
+test exec-1.2 {pipelining} {
+    exec | {echo a b c d} | cat | cat
+} "a b c d"
+test exec-1.3 {pipelining} {
+    set a [exec | {echo a b c d} | cat | wc]
+    list [scan $a "%d %d %d" b c d] $b $c
+} {3 1 4}
+set arg {12345678901234567890123456789012345678901234567890}
+set arg "$arg$arg$arg$arg$arg$arg"
+test exec-1.4 {long command lines} {
+    exec | [list echo $arg]
+} $arg
+set arg {}
+
+# I/O redirection: input from Tcl command.
+
+test exec-2.1 {redirecting input from immediate source} {
+    exec | cat << "Sample text"
+} {Sample text}
+test exec-2.2 {redirecting input from immediate source} {
+    exec | cat << "Sample text" | cat
+} {Sample text}
+test exec-2.4 {redirecting input from immediate source} {
+    exec | cat | cat << "Sample text"
+} {Sample text}
+test exec-2.5 {redirecting input from immediate source} {
+    exec | cat "<<Joined to arrows"
+} {Joined to arrows}
+test exec-2.6 {redirecting input from immediate source, with UTF} {
+    # If this fails, it may give back:
+    # "\uC3\uA9\uC3\uA0\uC3\uBC\uC3\uB1"
+    # If it does, this means that the UTF -> external conversion did not 
+    # occur before writing out the temp file.
+    exec | cat << "\uE9\uE0\uFC\uF1"
+} "\uE9\uE0\uFC\uF1"
+test exec-2.7 {redirecting input from immediate source with nulls} {
+    exec | cat << "Sample\0text"
+} "Sample\0text"
+
+# I/O redirection: output to file.
+
+file delete gorp.file
+test exec-3.1 {redirecting output to file} {
+    exec | {echo "Some simple words"} > gorp.file
+    exec | {cat gorp.file}
+} "Some simple words"
+test exec-3.2 {redirecting output to file} {
+    exec | {echo "More simple words"} | cat >gorp.file | cat
+    exec | {cat gorp.file}
+} "More simple words"
+test exec-3.3 {redirecting output to file} {
+    exec | {echo "Different simple words"} > gorp.file | cat | cat
+    exec | {cat gorp.file}
+} "Different simple words"
+test exec-3.4 {redirecting output to file} {
+    exec | {echo "Some simple words"} >gorp.file
+    exec | {cat gorp.file}
+} "Some simple words"
+test exec-3.5 {redirecting output to file} {
+    exec | {echo "First line"} >gorp.file
+    exec | {echo "Second line"} >> gorp.file
+    exec | {cat gorp.file}
+} "First line\nSecond line"
+test exec-3.7 {redirecting output to file} {
+    set f [open gorp.file w]
+    puts $f "Line 1"
+    flush $f
+    exec | {echo "More text"} >@ $f
+    exec | {echo "Even more"} >@$f 
+    puts $f "Line 3"
+    close $f
+    exec | {cat gorp.file}
+} "Line 1\nMore text\nEven more\nLine 3"
+
+# I/O redirection: output and stderr to file.
+
+file delete gorp.file
+test exec-4.1 {redirecting output and stderr to file} {
+    exec | {echo "test output"} >& gorp.file
+    exec | {cat gorp.file}
+} "test output"
+test exec-4.2 {redirecting output and stderr to file} {
+    list [exec | {sh -c "echo foo bar 1>&2"} >&gorp.file] \
+	    [exec | {cat gorp.file}]
+} {{} {foo bar}}
+test exec-4.3 {redirecting output and stderr to file} {
+    exec | {echo "first line"} > gorp.file
+    list [exec | {sh -c "echo foo bar 1>&2"} >>&gorp.file] \
+	    [exec | {cat gorp.file}]
+} "{} {first line\nfoo bar}"
+test exec-4.4 {redirecting output and stderr to file} {
+    set f [open gorp.file w]
+    puts $f "Line 1"
+    flush $f
+    exec | {echo "More text"} >&@ $f
+    exec | {echo "Even more"} >&@$f
+    puts $f "Line 3"
+    close $f
+    exec | {cat gorp.file}
+} "Line 1\nMore text\nEven more\nLine 3"
+test exec-4.5 {redirecting output and stderr to file} {
+    set f [open gorp.file w]
+    puts $f "Line 1"
+    flush $f
+    exec | {sh -c "echo foo bar 1>&2"} >&@ $f
+    exec | {sh -c "echo xyzzy 1>&2"} >&@$f
+    puts $f "Line 3"
+    close $f
+    exec | {cat gorp.file}
+} "Line 1\nfoo bar\nxyzzy\nLine 3"
+
+# I/O redirection: input from file.
+
+exec | {echo "Just a few thoughts"} > gorp.file
+
+test exec-5.1 {redirecting input from file} {
+    exec | cat < gorp.file
+} {Just a few thoughts}
+test exec-5.2 {redirecting input from file} {
+    exec | cat | cat < gorp.file
+} {Just a few thoughts}
+test exec-5.3 {redirecting input from file} {
+    exec | cat < gorp.file | cat
+} {Just a few thoughts}
+test exec-5.5 {redirecting input from file} {
+    exec | cat <gorp.file
+} {Just a few thoughts}
+test exec-5.6 {redirecting input from file} {
+    set f [open gorp.file r]
+    set result [exec | cat <@ $f]
+    close $f
+    set result
+} {Just a few thoughts}
+test exec-5.7 {redirecting input from file} {
+    set f [open gorp.file r]
+    set result [exec | cat <@$f]
+    close $f
+    set result
+} {Just a few thoughts}
+
+# I/O redirection: standard error through a pipeline.
+
+test exec-6.1 {redirecting stderr through a pipeline} {
+    exec | {sh -c "echo foo bar"} |& cat
+} "foo bar"
+test exec-6.2 {redirecting stderr through a pipeline} {
+    exec | {sh -c "echo foo bar 1>&2"} |& cat
+} "foo bar"
+test exec-6.3 {redirecting stderr through a pipeline} {
+    exec | {sh -c "echo foo bar 1>&2"} \
+	|& cat |& cat
+} "foo bar"
+
+# I/O redirection: combinations.
+
+file delete gorp.file2
+test exec-7.1 {multiple I/O redirections} {
+    exec | cat << "command input" > gorp.file2 < gorp.file
+    exec | {cat gorp.file2}
+} {Just a few thoughts}
+test exec-7.2 {multiple I/O redirections} {
+    exec cat < gorp.file << "command input"
+} {command input}
+
+# Long input to command and output from command.
+
+set a [string repeat a 1000000]
+test exec-8.1 {long input and output} {
+    string length [exec | cat << $a]
+} 1000000
+
+# More than 20 arguments to exec.
+
+test exec-8.1 {long input and output} {
+    exec | {echo 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23}
+} {1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23}
+
+# Commands that return errors.
+
+test exec-9.1 {commands returning errors} {
+    catch {exec | gorp456}
+} {1}
+test exec-9.2 {commands returning errors} {
+    catch {exec | {echo foo} | foo123} msg
+} {1}
+test exec-9.3 {commands returning errors} {
+    list [catch {exec | [list {*}$sleepx 0.1] | false | [list {*}$sleepx 0.1]} msg]
+} {1}
+test exec-9.4 {commands returning errors} jim {
+    list [catch {exec | false | {echo "foo bar"}} msg] $msg
+} {1 {foo bar}}
+test exec-9.5 {commands returning errors} {
+    list [catch {exec | gorp456 | {echo a b c}} msg]
+} {1}
+test exec-9.6 {commands returning errors} jim {
+    list [catch {exec | {sh -c "echo error msg 1>&2"}} msg] $msg
+} {0 {error msg}}
+test exec-9.7 {commands returning errors} jim {
+    # Note: Use sleep here to ensure the order
+    list [catch {exec | {sh -c "echo error msg 1 1>&2"} \
+		     | {sh -c "sleep 0.1; echo error msg 2 1>&2"}} msg] $msg
+} {0 {error msg 1
+error msg 2}}
+
+# Errors in executing the Tcl command, as opposed to errors in the
+# processes that are invoked.
+
+test exec-10.1 {errors in exec invocation} {
+    list [catch {exec |} msg]
+} {1}
+test exec-10.3 {errors in exec invocation} {
+    list [catch {exec | cat |} msg] $msg
+} {1 {cmdlist required after |}}
+test exec-10.4 {errors in exec invocation} {
+    list [catch {exec | cat | | cat} msg] $msg
+} {1 {invalid redirection cat}}
+test exec-10.5 {errors in exec invocation} {
+    list [catch {exec | cat | |& cat} msg] $msg
+} {1 {invalid redirection cat}}
+test exec-10.6 {errors in exec invocation} {
+    list [catch {exec | cat |&} msg] $msg
+} {1 {cmdlist required after |&}}
+test exec-10.7 {errors in exec invocation} {
+    list [catch {exec | cat <} msg] $msg
+} {1 {can't specify "<" as last word in command}}
+test exec-10.8 {errors in exec invocation} {
+    list [catch {exec | cat >} msg] $msg
+} {1 {can't specify ">" as last word in command}}
+test exec-10.9 {errors in exec invocation} {
+    list [catch {exec | cat <<} msg] $msg
+} {1 {can't specify "<<" as last word in command}}
+test exec-10.10 {errors in exec invocation} {
+    list [catch {exec | cat >>} msg] $msg
+} {1 {can't specify ">>" as last word in command}}
+test exec-10.11 {errors in exec invocation} {
+    list [catch {exec | cat >&} msg] $msg
+} {1 {can't specify ">&" as last word in command}}
+test exec-10.12 {errors in exec invocation} {
+    list [catch {exec | cat >>&} msg] $msg
+} {1 {can't specify ">>&" as last word in command}}
+test exec-10.13 {errors in exec invocation} {
+    list [catch {exec | cat >@} msg] $msg
+} {1 {can't specify ">@" as last word in command}}
+test exec-10.14 {errors in exec invocation} {
+    list [catch {exec | cat <@} msg] $msg
+} {1 {can't specify "<@" as last word in command}}
+test exec-10.15 {errors in exec invocation} {
+    list [catch {exec | cat < a/b/c} msg] [string tolower $msg]
+} {1 {couldn't read file "a/b/c": no such file or directory}}
+test exec-10.16 {errors in exec invocation} {
+    list [catch {exec | cat << foo > a/b/c} msg] [string tolower $msg]
+} {1 {couldn't write file "a/b/c": no such file or directory}}
+test exec-10.17 {errors in exec invocation} {
+    list [catch {exec | cat << foo > a/b/c} msg] [string tolower $msg]
+} {1 {couldn't write file "a/b/c": no such file or directory}}
+set f [open gorp.file w]
+test exec-10.18 {errors in exec invocation} {
+    list [catch {exec | cat <<test <@ $f} msg]
+} 1
+close $f
+set f [open gorp.file r]
+test exec-10.19 {errors in exec invocation} {
+    list [catch {exec | cat <<test >@ $f} msg]
+} 1
+close $f
+
+# Commands in background.
+
+test exec-11.1 {commands in background} {
+    set x [lindex [time {exec | [list {*}$sleepx 0.2] &}] 0]
+    expr $x<1000000
+} 1
+test exec-11.2 {commands in background} {
+    list [catch {exec | {echo a &b}} msg] $msg
+} {0 {a &b}}
+test exec-11.3 {commands in background} {
+    llength [exec | [list {*}$sleepx 0.1] &]
+} 1
+test exec-11.4 {commands in background} {
+    llength [exec | [list {*}$sleepx 0.1] | [list {*}$sleepx 0.1] | [list {*}$sleepx 0.1] &]
+} 3
+
+# Make sure that background commands are properly reaped when
+# they eventually die.
+
+exec | [list {*}$sleepx 0.3]
+
+test exec-12.1 {reaping background processes} -constraints unix -body {
+    for {set i 0} {$i < 20} {incr i} {
+        exec | {echo foo} > exec.tmp1 &
+    }
+    exec | [list {*}$sleepx 0.1]
+    catch {exec | ps | {fgrep "echo foo"} | {fgrep -v grep} | wc} msg
+    lindex $msg 0
+} -cleanup {
+    file delete exec.tmp1
+} -result 0
+
+# Redirecting standard error separately from standard output
+
+test exec-15.1 {standard error redirection} {
+    exec | {echo "First line"} > gorp.file
+    list [exec | {sh -c "echo foo bar 1>&2"} 2> gorp.file] \
+	    [exec | {cat gorp.file}]
+} {{} {foo bar}}
+test exec-15.2 {standard error redirection} {
+    list [exec | {sh -c "echo foo bar 1>&2"} \
+		| {echo biz baz} >gorp.file 2> gorp.file2] \
+	    [exec | {cat gorp.file}] \
+	    [exec | {cat gorp.file2}]
+} {{} {biz baz} {foo bar}}
+test exec-15.3 {standard error redirection} {
+    list [exec | {sh -c "echo foo bar 1>&2"} \
+	        | {echo biz baz} 2>gorp.file > gorp.file2] \
+	    [exec | {cat gorp.file}] \
+	    [exec | {cat gorp.file2}]
+} {{} {foo bar} {biz baz}}
+test exec-15.4 {standard error redirection} {
+    set f [open gorp.file w]
+    puts $f "Line 1"
+    flush $f
+    exec | {sh -c "echo foo bar 1>&2"} 2>@ $f
+    puts $f "Line 3"
+    close $f
+    exec | {cat gorp.file}
+} {Line 1
+foo bar
+Line 3}
+test exec-15.5 {standard error redirection} {
+    exec | {echo "First line"} > gorp.file
+    exec | {sh -c "echo foo bar 1>&2"} 2>> gorp.file
+    exec | {cat gorp.file}
+} {First line
+foo bar}
+test exec-15.6 {standard error redirection} {
+    exec | {sh -c "echo foo bar 1>&2"} > gorp.file2 2> gorp.file \
+	    >& gorp.file 2> gorp.file2 | {echo biz baz}
+    list [exec | {cat gorp.file}] [exec | {cat gorp.file2}]
+} {{biz baz} {foo bar}}
+test exec-15.7 {combine standard output/standard error} -body {
+    exec | {sh -c "echo foo bar 1>&2"} > gorp.file 2>@1
+    exec | {cat gorp.file}
+} -cleanup {
+    file delete gorp.file gorp.file2
+} -result {foo bar}
+
+test exec-16.1 {flush output before exec} -body {
+    set f [open gorp.file w]
+    puts $f "First line"
+    exec | {echo "Second line"} >@ $f
+    puts $f "Third line"
+    close $f
+    exec | {cat gorp.file}
+} -cleanup {
+    file delete gorp.file
+} -result {First line
+Second line
+Third line}
+
+test exec-17.1 {redirecting from command pipeline} -setup {
+    makeFile "abc\nghi\njkl" gorp.file
+} -constraints pipe -body {
+    set f [open "|| {cat gorp.file} | {wc -l}" r]
+    set result [lindex [exec | cat <@$f] 0]
+    close $f
+    set result
+} -cleanup {
+    file delete gorp.file
+} -result {3}
+
+test exec-17.2 {redirecting to command pipeline} -setup {
+    makeFile "abc\nghi\njkl" gorp.file
+} -constraints pipe -body {
+    set f [open "|| {wc -l} >gorp2.file" w]
+    exec | {cat gorp.file} >@$f
+    flush $f
+    close $f
+    lindex [exec | {cat gorp2.file}] 0
+} -cleanup {
+    file delete gorp.file gorp2.file
+} -result {3}
+
+test exec-17.3 {redirecting stderr to stdout} -body {
+    exec | {sh -c "echo foo bar 1>&2"} 2>@1
+} -result {foo bar}
+
+file delete sleepx
+
+# Now we probably have a lot of unreaped zombies at this point
+# so reap them to avoid confusing further tests
+wait
+
+testreport

--- a/tests/exec.test
+++ b/tests/exec.test
@@ -443,6 +443,10 @@ test exec-17.2 {redirecting to command pipeline} -setup {
     file delete gorp.file gorp2.file
 } -result {3}
 
+test exec-17.3 {redirecting stderr to stdout} -body {
+    exec sh -c "echo foo bar 1>&2" 2>@1
+} -result {foo bar}
+
 file delete sleepx
 
 # Now we probably have a lot of unreaped zombies at this point

--- a/tests/exec.test
+++ b/tests/exec.test
@@ -268,7 +268,8 @@ error msg 2}}
 test exec-10.1 {errors in exec invocation} {
     list [catch {exec} msg]
 } {1}
-test exec-10.2 {errors in exec invocation} {
+# Note that with TIP424 exec, this is no longer an error in Jim
+test exec-10.2 {errors in exec invocation} tcl {
     list [catch {exec | cat} msg] $msg
 } {1 {illegal use of | or |& in command}}
 test exec-10.3 {errors in exec invocation} {

--- a/tests/exists.test
+++ b/tests/exists.test
@@ -76,12 +76,28 @@ test exists-1.16 "Exists local lambda" lambda {
 	a
 } 1
 
-test exists-1.17 {exists usage} -body {
-	exists -dummy blah
-} -returnCodes error -result {bad option "-dummy": must be -alias, -command, -proc, or -var}
+test exists-1.17 "Exists -channel" {
+	exists -channel bogus
+} 0
 
-test exists-1.18 {exists usage} -body {
+test exists-1.18 "Exists -channel" {
+	exists -channel stdout
+} 1
+
+test exists-1.19 "Exists -channel" {
+	exists -channel info
+} 0
+
+test exists-1.20 "Exists -channel" {
+	exists -channel a
+} 0
+
+test exists-2.1 {exists usage} -body {
+	exists -dummy blah
+} -returnCodes error -result {bad option "-dummy": must be -alias, -channel, -command, -proc, or -var}
+
+test exists-2.2 {exists usage} -body {
 	exists abc def ghi
-} -returnCodes error -result {wrong # args: should be "exists ?option? name"}
+} -returnCodes error -result {wrong # args: should be "exists ?-command|-proc|-alias|-channel|-var? name"}
 
 testreport

--- a/tests/history.test
+++ b/tests/history.test
@@ -4,9 +4,8 @@ needs cmd {history save}
 needs expr "jim::lineedit" {$jim::lineedit}
 
 test history-1.1 {history usage} -body {
-	history
-} -returnCodes error -result {wrong # args: should be "history command ..."
-Use "history -help ?command?" for help}
+    history
+} -returnCodes error -result {wrong # args: should be "history subcommand ?arg ...?"}
 
 test history-1.2 {history -help} -body {
 	history -help

--- a/tests/jim.test
+++ b/tests/jim.test
@@ -3557,7 +3557,7 @@ catch {unset sum; unset err; unset i}
 ################################################################################
 test env-1.1 {env} -body {
     env abc def ghi
-} -returnCodes error -result {wrong # args: should be "env varName ?default?"}
+} -returnCodes error -result {wrong # args: should be "env ?varName? ?default?"}
 
 test env-1.2 {env} -body {
     env DOES_NOT_EXIST abc

--- a/tests/jim.test
+++ b/tests/jim.test
@@ -3152,9 +3152,9 @@ test info-2.4 {info commands option} {
 } {_test1_ _test2_}
 catch {rename _test1_ {}}
 catch {rename _test2_ {}}
-test info-2.5 {info commands option} {
+test info-2.5 {info commands option} -body {
     list [catch {info commands a b} msg] $msg
-} {1 {wrong # args: should be "info commands ?pattern?"}}
+    } -result {1 {wrong # args: should be "info commands ?-all? ?pattern?"}}
 test info-3.1 {info exists option} {
     set value foo
     info exists value

--- a/tests/loadtest.c
+++ b/tests/loadtest.c
@@ -17,19 +17,11 @@ static const jim_subcmd_type loadtest_command_table[] = {
     { NULL }
 };
 
-static int loadtest_cmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
-{
-    return Jim_CallSubCmd(interp, Jim_ParseSubCmd(interp, loadtest_command_table, argc, argv), argc, argv);
-}
-
 #ifndef NO_ENTRYPOINT
 int Jim_loadtestInit(Jim_Interp *interp)
 {
-    if (Jim_PackageProvide(interp, "loadtest", "1.0", JIM_ERRMSG)) {
-        return JIM_ERR;
-    }
-
-    Jim_CreateCommand(interp, "loadtest", loadtest_cmd, 0, 0);
+    Jim_PackageProvideCheck(interp, "loadtest");
+    Jim_RegisterSubCmd(interp, "loadtest", loadtest_command_table, NULL);
 
     return JIM_OK;
 }

--- a/tests/loop.test
+++ b/tests/loop.test
@@ -152,6 +152,15 @@ test loop-2.8 {modify loop var} {
     set a
 } {1 2 3 4 5}
 
+# Previously this would leak memory (configure --maintainer)
+test loop-2.9 {fail to set loop var} -body {
+    set i 1
+    loop i(x) 1 6 {
+        incr y
+    }
+    set y
+} -returnCodes error -result {can't set "i(x)": variable isn't array}
+
 testreport
 break
 

--- a/tests/lsubst.test
+++ b/tests/lsubst.test
@@ -1,0 +1,139 @@
+source [file dirname [info script]]/testing.tcl
+
+needs cmd lsubst
+
+test lsubst-1.1 {no args} -body {
+    lsubst
+} -returnCodes error -result {wrong # args: should be "lsubst ?-line? string"}
+
+test lsubst-1.2 {too many args} -body {
+    lsubst a b c
+} -returnCodes error -result {wrong # args: should be "lsubst ?-line? string"}
+
+test lsubst-1.3 {basic, no subst} -body {
+    lsubst {a b c}
+} -result {a b c}
+
+test lsubst-1.4 {basics, vars} -body {
+    set a 1
+    set b "2 3"
+    set c "4 5 6"
+    set d ".1"
+    lsubst {$a $b $c$d}
+} -result {1 {2 3} {4 5 6.1}}
+
+test lsubst-1.5 {comments} -body {
+    # It is helpful to be able to include comments in a list definition
+    # just like in a script
+    lsubst {
+        # comment line
+        1
+        2 3
+        # comment line with continuation \
+        this is also a comments
+        4 ;# comment at end of line
+        5
+    }
+} -result {1 2 3 4 5}
+
+test lsubst-1.6 {commands} -body {
+    set a 0
+    lsubst {
+        [incr a]
+        [incr a]
+        [list d e]
+        [string cat f g][string cat h i]
+    }
+} -result {1 2 {d e} fghi}
+
+test lsubst-1.7 {expand} -body {
+    set a {1 2}
+    set space " "
+    set b {3 4 5}
+    lsubst {
+        {*}$a
+        {*}$a$space$b$space[list 6 7]
+    }
+} -result {1 2 1 2 3 4 5 6 7}
+
+test lsubst-1.8 {empty case} -body {
+    lsubst {
+        # Nothing
+    }
+} -result {}
+
+test lsubst-1.9 {backslash escapes} -body {
+    lsubst {
+        # char escapes
+        \r\n\t
+        # unicode escapes
+        \u00b5
+        # hex escapes
+        \x41\x42
+    }
+} -result [list \r\n\t \u00b5 AB]
+
+test lsubst-1.10 {simple -line} -body {
+    set a {1 2}
+    set b {3 4 5}
+    lsubst -line {
+        # This line won't produce a list, but the next will produce a list with two elements
+        {*}$a
+        # And this one will have three elements
+        one two $b
+    }
+} -result {{1 2} {one two {3 4 5}}}
+
+test lsubst-2.1 {error, missing [} -body {
+    lsubst {
+        # Missing bracket
+        [string cat
+    }
+} -returnCodes error -result {unmatched "["}
+
+test lsubst-2.2 {error, invalid command} -body {
+    lsubst {
+        a
+        [dummy]
+        b
+    }
+} -returnCodes error -result {invalid command name "dummy"}
+
+test lsubst-2.3 {error, unset variable} -body {
+    lsubst {
+        a
+        $doesnotexist
+        b
+    }
+} -returnCodes error -result {can't read "doesnotexist": no such variable}
+
+test lsubst-2.4 {break} -body {
+    lsubst {
+        a
+        [break]
+        b
+    }
+} -returnCodes error -result {invoked "break" outside of a loop}
+
+test lsubst-2.5 {continue} -body {
+    lsubst {
+        a
+        [continue]
+        b
+    }
+} -returnCodes error -result {invoked "continue" outside of a loop}
+
+test lsubst-3.1 {preservation of line numbers} -body {
+    set x abc
+    set src1 [info source $x]
+    set list [lsubst {
+        a
+        $x
+        b
+    }]
+    if {[info source [lindex $list 1]] ne [info source $x]} {
+        error "source does not match
+    }
+} -result {}
+
+testreport

--- a/tests/regexp.test
+++ b/tests/regexp.test
@@ -583,6 +583,11 @@ test regexp-18.12 {regexp -all -inline -indices} {
     regexp -all -inline -indices a(b(c)d|e(f)g)h abcdhaefgh
 } {{0 4} {1 3} {2 2} {-1 -1} {5 9} {6 8} {-1 -1} {7 7}}
 
+test regexp-18.13 {regexp -all with match vars} -body {
+    regexp -all a(b(c)d|e(f)g)h abcdhaefgh a b c d e
+    list $a $b $c $d $e
+} -result {aefgh efg {} f {}}
+
 test regexp-19.1 {regsub null replacement} {
     regsub -all {@} {@hel@lo@} "\0a\0" result
     list $result [string length $result]

--- a/tests/regexp.test
+++ b/tests/regexp.test
@@ -199,9 +199,9 @@ test regexp-6.1 {regexp errors} {
 test regexp-6.2 {regexp errors} {
     list [catch {regexp -nocase a} msg] $msg
 } {1 {wrong # args: should be "regexp ?-switch ...? exp string ?matchVar? ?subMatchVar ...?"}}
-test regexp-6.3 {regexp errors} jim {
+test regexp-6.3 {regexp errors} -constraints jim -body {
     list [catch {regexp -gorp a} msg] $msg
-} {1 {bad switch "-gorp": must be --, -all, -indices, -inline, -line, -nocase, or -start}}
+} -result {1 {bad switch "-gorp": must be --, -all, -expanded, -indices, -inline, -line, -nocase, or -start}}
 test regexp-6.4 {regexp errors} {
     catch {regexp a( b} msg
 } 1
@@ -367,7 +367,7 @@ test regexp-11.4 {regsub errors} {
 } {1 {wrong # args: should be "regsub ?-switch ...? exp string subSpec ?varName?"}}
 test regexp-11.5 {regsub errors} -constraints jim -body {
     list [catch {regsub -gorp a b c} msg] $msg
-} -result {1 {bad switch "-gorp": must be --, -all, -command, -line, -nocase, or -start}}
+} -result {1 {bad switch "-gorp": must be --, -all, -command, -expanded, -line, -nocase, or -start}}
 test regexp-11.6 {regsub errors} {
     catch {regsub -nocase a( b c d} msg
 } 1

--- a/tests/regexp2.test
+++ b/tests/regexp2.test
@@ -943,19 +943,31 @@ test regexp-25.3 {End of word} {
     regexp {\mcd\M} cdef
 } 0
 
-test regexp-26.1 {regexp operator =~} {
+test regexp-25.4 {Braces not a repeat count} {
+    regexp "{abc}" "test{abc}def"
+} 1
+
+test regexp-25.5 {Repeat follows nothing} -body {
+    regexp "{3}" "test{3}def"
+} -returnCodes error -match glob -result {couldn't compile regular expression pattern: *}
+
+test regexp-25.6 {Meta char after nothing is error} -body {
+    regexp "?" "te?st"
+} -returnCodes error -match glob -result {couldn't compile regular expression pattern: *}
+
+test regexp-26.1 {regexp operator =~} jim {
     expr {"abc" =~ "^a"}
 } 1
 
-test regexp-26.2 {regexp operator =~} {
+test regexp-26.2 {regexp operator =~} jim {
     expr {"abc" =~ "^b"}
 } 0
 
-test regexp-26.2 {regexp operator =~} {
+test regexp-26.2 {regexp operator =~} jim {
     expr {"abc" =~ ".b."}
 } 1
 
-test regexp-26.3 {regexp operator =~ invalid regexp} -body {
+test regexp-26.3 {regexp operator =~ invalid regexp} -constraints jim -body {
     expr {"abc" =~ {[}}
 } -returnCodes error -result {couldn't compile regular expression pattern: brackets [] not balanced}
 

--- a/tests/regexp2.test
+++ b/tests/regexp2.test
@@ -943,4 +943,20 @@ test regexp-25.3 {End of word} {
     regexp {\mcd\M} cdef
 } 0
 
+test regexp-26.1 {regexp operator =~} {
+    expr {"abc" =~ "^a"}
+} 1
+
+test regexp-26.2 {regexp operator =~} {
+    expr {"abc" =~ "^b"}
+} 0
+
+test regexp-26.2 {regexp operator =~} {
+    expr {"abc" =~ ".b."}
+} 1
+
+test regexp-26.3 {regexp operator =~ invalid regexp} -body {
+    expr {"abc" =~ {[}}
+} -returnCodes error -result {couldn't compile regular expression pattern: brackets [] not balanced}
+
 testreport

--- a/tests/regexp2.test
+++ b/tests/regexp2.test
@@ -463,12 +463,12 @@ test regexpComp-9.6 {-all option to regsub} {
     }
 } {1 123xxx}
 
-#test regexpComp-10.1 {expanded syntax in regsub} {
-#    evalInProc {
-#	set foo xxx
-#	list [regsub -expanded ". \#comment\n  . \#comment2" abc def foo] $foo
-#    }
-#} {1 defc}
+test regexpComp-10.1 {expanded syntax in regsub} {
+    evalInProc {
+	set foo xxx
+	list [regsub -expanded ". \#comment\n  . \#comment2" abc def foo] $foo
+    }
+} {1 defc}
 test regexpComp-10.2 {newline sensitivity in regsub} {
     evalInProc {
 	set foo xxx
@@ -523,11 +523,11 @@ test regexpComp-11.4 {regsub errors} {
 	list [catch {regsub a b c d e f} msg] $msg
     }
 } {1 {wrong # args: should be "regsub ?-switch ...? exp string subSpec ?varName?"}}
-#test regexpComp-11.5 {regsub errors} {
-#    evalInProc {
-#	list [catch {regsub -gorp a b c} msg] $msg
-#    }
-#} {1 {bad switch "-gorp": must be -all, -nocase, -expanded, -line, -linestop, -lineanchor, -start, or --}}
+test regexpComp-11.5 {regsub errors} {
+    evalInProc {
+	list [catch {regsub -gorp a b c} msg] $msg
+    }
+} {1 {bad switch "-gorp": must be --, -all, -command, -expanded, -line, -nocase, or -start}}
 test regexpComp-11.6 {regsub errors} {
     evalInProc {
 	list [catch {regsub -nocase a( b c d} msg] $msg
@@ -958,5 +958,9 @@ test regexp-26.2 {regexp operator =~} {
 test regexp-26.3 {regexp operator =~ invalid regexp} -body {
     expr {"abc" =~ {[}}
 } -returnCodes error -result {couldn't compile regular expression pattern: brackets [] not balanced}
+
+test regexp-27.1 {regexp expanded} -body {
+    regexp -expanded -all -inline { a ( b b ) + } {abbbbbbcde}
+} -returnCodes ok -result {abbbbbb bb}
 
 testreport

--- a/tests/socket.test
+++ b/tests/socket.test
@@ -120,6 +120,11 @@ test socket-1.7 {socketpair} -body {
 	lassign [socket pair] s1 s2
 	$s1 buffering line
 	$s2 buffering line
+	# We trust the data received on these sockets
+	if {[exists -command taint]} {
+		$s1 taint source 0
+		$s2 taint source 0
+	}
 	stdout flush
 	if {[os.fork] == 0} {
 		$s1 close
@@ -345,6 +350,10 @@ if {[os.fork] == 0} {
 		# read everything available (non-blocking read)
 		set buf [$c read]
 		if {[string length $buf]} {
+			# It is safe to send this back to where it came from
+			if {[exists -command untaint]} {
+				untaint buf
+			}
 			$c puts -nonewline $buf
 			$c flush
 		}

--- a/tests/ssl.test
+++ b/tests/ssl.test
@@ -22,6 +22,10 @@ if {[os.fork] == 0} {
 	$c readable {
 		# read everything available and echo it back
 		set buf [$c read]
+		# We don't mind sending tainted data back to it's source
+		if {[exists -command taint]} {
+			untaint buf
+		}
 		$c puts -nonewline $buf
 		$c flush
 		if {[$c eof]} {

--- a/tests/stringmatch.test
+++ b/tests/stringmatch.test
@@ -230,4 +230,16 @@ test stringmatch-7.4 {null in pattern} {
     string match *b\[\0a\]r* foobar
 } 1
 
+test regexp-8.1 {string match operator =*} {
+    expr {"abc" =* "a*"}
+} 1
+
+test regexp-26.2 {regexp operator =~} {
+    expr {"abc" =* "b*"}
+} 0
+
+test regexp-26.2 {regexp operator =~} {
+    expr {"abc" =* {*[bB]c}}
+} 1
+
 testreport

--- a/tests/taint.test
+++ b/tests/taint.test
@@ -170,6 +170,14 @@ test taint-2.6 {file delete with tainted data} -body {
 	file delete $t
 } -returnCodes error -result {file delete: tainted data}
 
+test taint-2.7 {check errorcode on tainted data} -body {
+	try {
+		eval {exec $t}
+	} on error {msg opts} {
+		dict get $opts -errorcode
+	}
+} -result {TAINTED}
+
 test taint-3.1 {filehandle not taint source by default} {
 	set f [open [info script]]
 	gets $f buf

--- a/tests/taint.test
+++ b/tests/taint.test
@@ -1,0 +1,204 @@
+source [file dirname [info script]]/testing.tcl
+
+needs cmd taint
+
+# create a tainted var
+set t tainted
+taint t
+
+test taint-1.1 {taint simple var} {
+	info tainted $t
+} 1
+
+test taint-1.2 {set taint, simple var} {
+	set x $t
+	info tainted $x
+} 1
+
+test taint-1.3 {untaint ref counting simple var} {
+	untaint x
+	list [info tainted $x] [info tainted $t]
+} {0 1}
+
+# Tainting an array element taints the array/dict, but
+# not each element
+test taint-1.4 {taint array var} {
+	set a {1 one 2 two}
+	taint a(2)
+	list [info tainted $a(1)] [info tainted $a(2)] [info tainted $a]
+} {0 1 1}
+
+# Adding a tainted value to an array taints the array/dict, but
+# not each element
+test taint-1.5 {tainted value taints dict} {
+	unset -nocomplain a
+	array set a {1 one 2 two}
+	set a(3) $t
+	list [info tainted $a(1)] [info tainted $a(3)] [info tainted $a]
+} {0 1 1}
+
+# lappend taints the list, but not each element
+test taint-1.6 {lappend with taint} {
+	set a {1 2}
+	lappend a $t
+	list [info tainted $a] [lmap p $a {info tainted $p}]
+} {1 {0 0 1}}
+
+# lset taints the list, but not each element
+test taint-1.7 {lset with taint} {
+	set a [list a b c d]
+	lset a 1 $t
+	list [info tainted $a] [lmap p $a {info tainted $p}]
+} {1 {0 1 0 0}}
+
+# append taints the string
+test taint-1.8 {append with taint} {
+	set a abc
+	append a $t
+	info tainted $a
+} 1
+
+test taint-1.9 {taint entire list} {
+	set a [list 1 2 3]
+	taint a
+	list [info tainted $a] [lmap p $a {info tainted $p}]
+} {1 {1 1 1}}
+
+test taint-1.10 {taint entire dict} {
+	set a [dict create a 1 b 2 c 3]
+	taint a
+	list [info tainted $a] [info tainted [dict get $a b]]
+} {1 1}
+
+
+test taint-1.11 {interpolation with taint} {
+	set x "x$t"
+	info tainted $x
+} 1
+
+test taint-1.12 {lrange with taint} {
+	set a [list 1 2 3 $t 5 6]
+	info tainted [lrange $a 0 1]
+} 0
+
+test taint-1.13 {lrange with taint} {
+	set a [list 1 2 3 $t 5 6]
+	info tainted [lrange $a 2 4]
+} 1
+
+test taint-1.14 {lindex with taint} {
+	set a [list 1 2 3 $t 5 6]
+	info tainted [lindex $a 1]
+} 0
+
+test taint-1.15 {lassign with taint} {
+	set a [list 1 $t 3]
+	lassign $a x y z
+	list [info tainted $x] [info tainted $y] [info tainted $z]
+} {0 1 0}
+
+test taint-1.16 {lreverse with taint} {
+	set a [lreverse [list 1 2 $t]]
+	list [info tainted $a] [lmap p $a {info tainted $p}]
+} {1 {1 0 0}}
+
+test taint-1.17 {lsort with taint} {
+	set a [lsort [list zzz aaa $t bbb ppp]]
+	list [info tainted $a] [lmap p $a {info tainted $p}]
+} {1 {0 0 0 1 0}}
+
+test taint-1.18 {lreplace with taint} {
+	set a {a b c}
+	set b [lreplace $a 1 1 $t]
+	list [info tainted $b] [lmap p $b {info tainted $p}]
+} {1 {0 1 0}}
+
+test taint-1.19 {dict with taint} {
+	set a [dict create a 1 b 2 c $t d 4]
+	info tainted $a
+} 1
+
+test taint-1.20 {dict with taint} {
+	set a [dict create a 1 b 2 c $t d 4]
+	info tainted [dict get $a b]
+} 0
+
+test taint-1.21 {dict with taint} {
+	set a [dict create a 1 b 2 c $t d 4]
+	info tainted [dict get $a c]
+} 1
+
+test taint-1.22 {dict with taint} {
+	dict set a $t e
+	set result {}
+	foreach i [lsort [dict keys $a]] {
+		set v [dict get $a $i]
+		lappend result [list $i $v [info tainted $i] [info tainted $v]]
+	}
+	set result
+} {{a 1 0 0} {b 2 0 0} {c tainted 0 1} {d 4 0 0} {tainted e 1 0}}
+
+test taint-1.23 {nested dict with taint} {
+	set a [dict create]
+	dict set a 1 A 1-A
+	dict set a 2 A 2-A
+	dict set a 1 T $t
+	info tainted $a
+} 1
+
+test taint-2.1 {exec with tainted data} -body {
+	exec $t
+} -returnCodes error -result {exec: tainted data}
+
+test taint-2.2 {eval with tainted data - allowed} {
+	eval "set a $t"
+} tainted
+
+test taint-2.3 {eval with braced tainted data - allowed} {
+	eval {set a $t}
+} tainted
+
+test taint-2.4 {eval exec with tainted data} -body {
+	eval {exec $t}
+} -returnCodes error -result {exec: tainted data}
+
+test taint-2.5 {open with tainted data} -body {
+	open "|$t"
+} -returnCodes error -result {open: tainted data}
+
+test taint-2.6 {file delete with tainted data} -body {
+	file delete $t
+} -returnCodes error -result {file delete: tainted data}
+
+test taint-3.1 {filehandle not taint source by default} {
+	set f [open [info script]]
+	gets $f buf
+	info tainted $buf
+} 0
+
+test taint-3.2 {set taint source on filehandle} {
+	$f taint source 1
+	gets $f buf
+	info tainted $buf
+} 1
+
+test taint-3.3 {filehandle not taint sink by default} -body {
+	set g [open out.tmp w]
+	puts $g $t
+} -result {}
+
+test taint-3.4 {set taint sink on filehandle} -body {
+	$g taint sink 1
+	puts $g $t
+} -returnCodes error -result "puts: tainted data"
+
+test taint-3.5 {copyto taint source to sink} -body {
+	$f copyto $g
+} -returnCodes error -result {copying tainted source}
+
+$f close
+$g close
+
+file delete out.tmp
+
+testreport


### PR DESCRIPTION
I plan to merge master-next soon with the following changes:

- exec TIP 424 - support safer exec | syntax (also open "|| pipeline...")
- New lsubst command to create lists using subst-style substitution
- Add support for regexp -expanded and regsub -expanded
- vwait now accepts a script argument
- Add support for os.umask
- Add taint support for improved data security
- Improved API for creating C commands with Jim_RegisterCommand for arg checking and usage
- New info usage to return the usage for a proc or native command
- New info aliases to list all aliases
- expr supports new =* and =~ matching operators

Any testing/feedback before merge is welcome