### PR TITLE
Add more build generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,11 @@ jim-oo.c
 jimsh
 *.exe
 libjim.a
+*.so
 *.so.*
 *.dll
 *.o
+*.dylib
 configure.gnu
 jimsh0
 build-jim-ext


### PR DESCRIPTION
Ignore *.so and *.dylib files in Git.
See #349 
