### PR TITLE
A couple of small segfault fixes

### DIFF
--- a/jim-format.c
+++ b/jim-format.c
@@ -221,7 +221,7 @@ Jim_Obj *Jim_FormatString(Jim_Interp *interp, Jim_Obj *fmtObjPtr, int objc, Jim_
             step = utf8_tounicode(format, &ch);
         }
         if (isdigit(ch)) {
-            precision = strtoul(format, &end, 10);
+            precision = strtol(format, &end, 10);
             format = end;
             step = utf8_tounicode(format, &ch);
         } else if (ch == '*') {

--- a/jim.c
+++ b/jim.c
@@ -413,7 +413,7 @@ static int JimStringFirst(const char *s1, int l1, const char *s2, int l2, int id
     int i;
     int l1bytelen;
 
-    if (!l1 || !l2 || l1 > l2) {
+    if (!l1 || !l2 || l1 > l2 || idx > l2) {
         return -1;
     }
     if (idx < 0)

--- a/jim.c
+++ b/jim.c
@@ -4220,6 +4220,11 @@ static int JimCreateProcedureStatics(Jim_Interp *interp, Jim_Cmd *cmdPtr, Jim_Ob
                     }
                     else {
                         initObjPtr = Jim_GetVariable(interp, nameObjPtr, JIM_NONE);
+                        if (!initObjPtr) {
+                            Jim_SetResultFormatted(interp, "Could not resolve upvar \"%#s\"'s value", nameObjPtr);
+                            Jim_DecrRefCount(interp, nameObjPtr);
+                            return JIM_ERR;
+                        }
                     }
                     break;
 

--- a/jim.c
+++ b/jim.c
@@ -8213,6 +8213,9 @@ static int SetIndexFromAny(Jim_Interp *interp, Jim_Obj *objPtr)
     else if (idx < 0) {
         idx = -INT_MAX;
     }
+    else if (idx > INT_MAX) {
+        goto badindex;
+    }
 
     /* Free the old internal repr and set the new one. */
     Jim_FreeIntRep(interp, objPtr);

--- a/tests/upvar.test
+++ b/tests/upvar.test
@@ -323,7 +323,14 @@ test upvar-9.4 {upvar links to static} jim {
     proc p2 {} {{a 3}} { list [p1] $a }
     p2
 } {4 4}
-test upvar-9.5 {upvar via global namespace} {
+test upvar-9.5 {upvar when uninitialized caught in static} jim {
+    proc p1 {} {
+        upvar doesNotExist x
+        proc p2 {} {x} {}
+    }
+    list [catch p1 msg] $msg
+} {1 {Could not resolve upvar "x"'s value}}
+test upvar-9.6 {upvar via global namespace} {
     set x 2
     unset -nocomplain y
     # Links ::y to ::x
@@ -332,7 +339,7 @@ test upvar-9.5 {upvar via global namespace} {
     list $x $y
 } {1 1}
 
-test upvar-9.6 {upvar via global namespace} {
+test upvar-9.7 {upvar via global namespace} {
     set x 2
     unset -nocomplain x
     # Links ::x to ::x
@@ -340,7 +347,7 @@ test upvar-9.6 {upvar via global namespace} {
     list [catch p1 msg] $msg
 } {1 {can't upvar from variable to itself}}
 
-test upvar-9.7 {upvar to higher level} {
+test upvar-9.8 {upvar to higher level} {
     proc p1 {} { upvar 0 x ::globx }
     list [catch p1 msg] $msg
 } {1 {bad variable name "::globx": upvar won't create namespace variable that refers to procedure variable}}


### PR DESCRIPTION
Hi!

I ran into a few crashes when fuzzing again, and these changes should fix the following:

- Out of bounds read in [string first]: reproduce with `string first abc abc 1000000`.
- Unchecked truncation in `SetIndexFromAny`: reproduce with `lreplace {} 3000000001 3000000000`.
- Integer overflow in format: reproduce with `format %.40000000000000000000s 0`
- Procedure static binding of an uninitialized upvar: reproduce with
```tcl
upvar 0 x y
proc foo {} {y} {}
```

I wasn't sure what error message would be best for the procedure case, so feel free to modify that. I also added a test case for the procedure case.
