### PR TITLE
jimiocompat: Avoid unused variable compiler warnings

### DIFF
--- a/jimiocompat.c
+++ b/jimiocompat.c
@@ -194,7 +194,9 @@ int Jim_OpenForRead(const char *filename)
 int Jim_MakeTempFile(Jim_Interp *interp, const char *filename_template, int unlink_file)
 {
     int fd;
+#ifdef HAVE_UMASK
     mode_t mask;
+#endif
     Jim_Obj *filenameObj;
 
     if (filename_template == NULL) {


### PR DESCRIPTION
In the *NIX implementation of Jim_MakeTempFile(), the variable "mask" becomes unused if HAVE_UMASK is not present, causing -Wunused-variable compiler warnings (if enabled).

Make a trivial fix to address this.