### PR TITLE
pack: reject bitoffset that overflows int in JimSetBitsInt*

### DIFF
--- a/jim-pack.c
+++ b/jim-pack.c
@@ -395,7 +395,7 @@ static int Jim_PackCmd(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
         if (Jim_GetWideExpr(interp, argv[5], &pos) != JIM_OK) {
             return JIM_ERR;
         }
-        if (pos < 0 || (option == OPT_STR && pos % 8)) {
+        if (pos < 0 || pos > INT_MAX - width || (option == OPT_STR && pos % 8)) {
             Jim_SetResultFormatted(interp, "bad bitoffset: %#s", argv[5]);
             return JIM_ERR;
         }


### PR DESCRIPTION
## Problem

\`Jim_PackCmd()\` validates \`pos\`/\`width\` as \`jim_wide\` (64-bit), checking only \`pos < 0\` (no upper bound), before passing them to \`JimSetBitsIntBigEndian()\`/\`JimSetBitsIntLittleEndian()\`, whose signatures declare \`pos\`/\`width\` as 32-bit \`int\`.

A large enough \`pos\` silently truncates when narrowed to \`int\`. For example \`2147483648\` (2^31) narrows to \`INT_MIN\`. When \`pos % 8 == 0\` and \`width == 8\`, the fast path computes \`bitvec[pos/8] = value\`, i.e. \`bitvec[-268435456]\` — an out-of-bounds write far before the buffer, causing a segfault.

Repro (built from source, real crash, not simulated):

\`\`\`tcl
set x "hello"
pack x 255 -intbe 8 2147483648
\`\`\`

This reliably segfaults (exit 139) after the preceding string-growth loop in \`Jim_PackCmd\` grows the string to ~256MB.

A differential control test with \`pos=2147483640\` (still requires growing the string to the same order of magnitude, but does not cross the 2^31 boundary) completes cleanly, which isolates the crash to the int truncation rather than the string-growth loop itself.

\`unpack\` was checked too: \`Jim_UnpackCmd()\` gates via \`if (pos < len*8)\` using the un-truncated 64-bit \`pos\` before calling the bit-manipulation helpers, and \`len\` is bounded by an actually-existing string object's size, so it isn't reachable through this same easy path and is out of scope for this fix.

## Fix

Extend the existing bitoffset validation in \`Jim_PackCmd\` to also reject any \`pos\` that would not survive narrowing to the \`int pos\`/\`int width\` parameters used downstream, reusing the same error path/format already used for the \`pos < 0\` case:

\`\`\`c
if (pos < 0 || pos > INT_MAX - width || (option == OPT_STR && pos % 8)) {
    Jim_SetResultFormatted(interp, "bad bitoffset: %#s", argv[5]);
    return JIM_ERR;
}
\`\`\`

## Testing

- Rebuilt cleanly, no warnings.
- Repro above now returns a clean scripted error (\`bad bitoffset: 2147483648\`) instead of crashing.
- Control case (\`2147483640\`) is now also correctly and symmetrically rejected, confirming the new boundary is exact.
- \`tests/pack.test\`: 25/25 pass.
- Full \`make test\`: no new failures (jim.test 640/640, binary.test 491/491; only pre-existing, unrelated Windows \`exec2\` failures remain, confirmed present on unpatched master too via \`git stash\`).