### PR TITLE
Check signals in loops that dispatch no commands

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -12803,6 +12803,12 @@ static int Jim_WhileCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
         if (!boolean)
             break;
 
+        /* Allow an async signal to break a loop whose body dispatches no
+         * command (e.g. {} or the incr fast-path), which otherwise reaches
+         * no per-command signal check. */
+        if (Jim_CheckSignal(interp))
+            return JIM_SIGNAL;
+
         if ((retval = Jim_EvalObj(interp, argv[2])) != JIM_OK) {
             if (JimCheckLoopRetcode(interp, retval)) {
                 return retval;
@@ -12926,6 +12932,11 @@ static int Jim_ForCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv
 
         /* --- OPTIMIZED FOR --- */
         while (retval == JIM_OK) {
+            /* Break on an async signal even if the body dispatches no command. */
+            if (Jim_CheckSignal(interp)) {
+                retval = JIM_SIGNAL;
+                goto out;
+            }
             /* === Check condition === */
             /* Note that currentVal is already set here */
 
@@ -12976,6 +12987,11 @@ static int Jim_ForCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *argv
 #endif
 
     while (boolean && (retval == JIM_OK || retval == JIM_CONTINUE)) {
+        /* Break on an async signal even if the body dispatches no command. */
+        if (Jim_CheckSignal(interp)) {
+            retval = JIM_SIGNAL;
+            break;
+        }
         /* Body */
         retval = Jim_EvalObj(interp, argv[4]);
         if (JimCheckLoopRetcode(interp, retval)) {
@@ -13039,6 +13055,11 @@ static int Jim_LoopCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     retval = Jim_SetVariable(interp, argv[1], Jim_NewIntObj(interp, i));
 
     while (((i < limit && incr > 0) || (i > limit && incr < 0)) && retval == JIM_OK) {
+        /* Break on an async signal even if the body dispatches no command. */
+        if (Jim_CheckSignal(interp)) {
+            retval = JIM_SIGNAL;
+            break;
+        }
         retval = Jim_EvalObj(interp, bodyObjPtr);
         if (JimCheckLoopRetcode(interp, retval)) {
             return retval;
@@ -13161,6 +13182,11 @@ static int JimForeachMapHelper(Jim_Interp *interp, int argc, Jim_Obj *const *arg
     Jim_IncrRefCount(resultObj);
 
     while (1) {
+        /* Break on an async signal even if the body dispatches no command. */
+        if (Jim_CheckSignal(interp)) {
+            result = JIM_SIGNAL;
+            goto err;
+        }
         /* Have we expired all lists? */
         for (i = 0; i < numargs; i += 2) {
             if (!JimListIterDone(interp, &iters[i + 1])) {


### PR DESCRIPTION
### The problem

A pending signal only aborts a running script at the per-command check (`Jim_CheckSignal`, right after `JimInvokeCommand` in `Jim_EvalObj`) and at `catch`/`try` entry.

But a loop whose body and condition dispatch no command reaches neither, so `catch -signal { ... }` with an incoming signal like `SIGINT` or `ALRM` can't break out of loops such as:

```tcl
while 1 {}
while {$i < $n} {incr i}     ;# the incr fast-path dispatches nothing
for {} {1} {} {}
```

The empty-body and `incr` fast-paths in `Jim_EvalObj` return before the command loop, and the C-level loop constructs (`while`, `for`, `loop`, `foreach`/`lmap`) don't check signals themselves, so these spin until the process is killed (with an untrappable signal).

Degenerate cases, maybe.  But they can arise in novice code, generated code, etc.

A signal already breaks any loop that dispatches a command each iteration in the body *or* the condition. `while {[ready]} {...}`, or even `while {[expr {1+1}]} {}`, are already interruptible because of the command substitution in the condition.

The issue is loops where *neither* the condition nor the body dispatches a command, like a pure-expression condition with an empty or fast-path body such as the ones I list in the block above.

### Reproduction

```sh
$ jimsh -e 'set i 0; signal handle ALRM; alarm 0.3; puts [catch -signal { while {$i < 4000000000} {incr i} } msg]/$msg'
5/SIGALRM
```

With the proposed change it prints `5/SIGALRM`.

On master that same line produces no output: the loop never checks the signal and runs for tens of seconds, completing the loop instead of breaking out at the `ALRM`.

### The patch

I propose adding a `Jim_CheckSignal` test at the iteration boundary of `while`, `for` (both the general and optimized paths), `loop`, and `foreach`/`lmap`. A pending signal breaks the loop with `JIM_SIGNAL`, propagated by the existing loop return-code handling. `Jim_CheckSignal` is the existing macro:

```c
#define Jim_CheckSignal(i) ((i)->signal_level && (i)->sigmask)
```

### Testing

`make test`, full suite, identical on master and with the patch:

```text
Totals: Total 5908  Passed 5736  Skipped 172  Failed 0
```

### Performance

The concern is the fast loop paths, so we don't make them un-fast. The added check is one `signal_level` indirect load and a not-taken branch per iteration.

Across 5 runs interleaving master and patched and totalling 15 minutes:

```tcl
for {set i 0}  {$i < 3000000000} {incr i} {}
# master 9.28 ns/iter, patch +0.31 (+3.3%)
# runs +0.333 +0.244 +0.313 +0.355 +0.286 - jitter ~0.04 (0.43%)

set i 0; while {$i < 1500000000} {incr i}
# master ~19.9 ns/iter, patch +0.16 (+0.8%)
# runs +0.099 +0.339 +0.148 +0.303 -0.069 - jitter ~0.15 (0.75%)

set i 0; while {$i <  500000000} {set x 1; incr i}
# master 60.7 ns/iter, patch +0.50 (+0.8%)
# runs +0.857 +0.790 +0.424 +0.649 -0.221 - jitter ~0.39 (0.64%)
```

The last two come in under 1%, but some of the patched runs came in *faster* due to measurement jitter, and you can see that at any rate we are pulling numbers out of noise.  I don't claim this to be a rigorous *quantitative* analysis.

For useful loops, I expect the cost is genuinely negligible.

### Context

I'm experimenting with embedding Jim Tcl into a microcontroller project (Teensy 4.1 platform, bare metal) as a configuration shell and for user script callbacks in the application.

Here, I'm overriding `Jim_CheckSignal` so it also calls a hook where I can pump my background services loop tightly.  These empty loop cases could lead to starvation on my setup and eventually a watchdog reboot.

I also noticed they cause signal deafness on the OS-hosted case, so I wanted to propose this patch back upstream.
